### PR TITLE
Cleanup - part II

### DIFF
--- a/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
+++ b/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #BaselineOfMachineArithmetic,
+	#superclass : #BaselineOf,
+	#category : #BaselineOfMachineArithmetic
+}
+
+{ #category : #baselines }
+BaselineOfMachineArithmetic >> baseline: spec [
+	<baseline>
+	spec
+		for: #pharo
+		do: [ 
+			spec
+				package: #'MachineArithmetic-FFI-Pharo';
+				package: #'MachineArithmetic';
+				package: #'MachineArithmetic-Tests'.
+			]
+]

--- a/BaselineOfMachineArithmetic/package.st
+++ b/BaselineOfMachineArithmetic/package.st
@@ -1,0 +1,1 @@
+Package { #name : #BaselineOfMachineArithmetic }

--- a/MachineArithmetic-FFI-Pharo/LibZ3.class.st
+++ b/MachineArithmetic-FFI-Pharo/LibZ3.class.st
@@ -297,12 +297,6 @@ LibZ3 >> mkAnd: ctx numArgs: n args: args [
 ]
 
 { #category : #'constants and applications' }
-LibZ3 >> mkApp00: ctx funcDecl: d [
-	"Call Z3_mk_app with 0 args."
-	^ self ffiCall: #( AST Z3_mk_app (Z3Context ctx, FuncDecl d) )
-]
-
-{ #category : #'constants and applications' }
 LibZ3 >> mkApp: ctx func: decl arity: numArgs args: ffiArray [
 	"Call Z3_mk_app with 0 args."
 	^ self ffiCall: #( void*  Z3_mk_app (Z3Context ctx, FuncDecl decl, uint numArgs, FFIExternalArray ffiArray) )

--- a/MachineArithmetic-FFI-Pharo/Z3IdentityObject.class.st
+++ b/MachineArithmetic-FFI-Pharo/Z3IdentityObject.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #Z3IdentityObject,
 	#superclass : #FFIExternalObject,
+	#classVars : [
+		'EmptyExternalArray'
+	],
 	#classInstVars : [
 		'instances'
 	],
@@ -12,6 +15,15 @@ Z3IdentityObject class >> asExternalTypeOn: generator [
 	^ Z3IdentityObjectType objectClass: self
 ]
 
+{ #category : #initialization }
+Z3IdentityObject class >> initialize [
+	EmptyExternalArray := FFIExternalArray externalNewType: 'void*' size: 0.
+	
+	"
+	Z3IdentityObject initialize
+	"
+]
+
 { #category : #'as yet unclassified' }
 Z3IdentityObject class >> instances [
 	instances isNil ifTrue: [ instances := WeakValueDictionary new ].
@@ -21,6 +33,8 @@ Z3IdentityObject class >> instances [
 { #category : #utilities }
 Z3IdentityObject class >> mkExternalArray: anArray [
 	| extArray |
+	
+	anArray isEmpty ifTrue:[ ^ EmptyExternalArray ].
 	
 	extArray := FFIExternalArray externalNewType: 'void*' size: anArray size.
 	anArray withIndexDo:[:o :i |

--- a/MachineArithmetic-FFI-Pharo/Z3IdentityObject.class.st
+++ b/MachineArithmetic-FFI-Pharo/Z3IdentityObject.class.st
@@ -40,7 +40,7 @@ Z3IdentityObject class >> new: anExternalData [
 
 { #category : #'as yet unclassified' }
 Z3IdentityObject class >> unwrapAround: anObject [
-	self instance removeKey: anObject handle asInteger.	
+	self instances removeKey: anObject handle asInteger.	
 	
 ]
 

--- a/MachineArithmetic/FuncDecl.class.st
+++ b/MachineArithmetic/FuncDecl.class.st
@@ -9,7 +9,10 @@ Class {
 
 { #category : #accessing }
 FuncDecl >> app [
-	^(LibZ3 uniqueInstance mkApp00: ctx funcDecl: self) ctx: self ctx
+	| args |
+	
+	args := self mkExternalArray: #().
+	^AST wrap: (LibZ3 uniqueInstance mkApp: ctx func: self arity: 0 args: args) in: self ctx
 ]
 
 { #category : #accessing }

--- a/README.md
+++ b/README.md
@@ -7,3 +7,22 @@ While as Smalltalkers we are rightly proud of the elaborate model of ℤ
 implemented in the hierarchy of _Integer_, the entities that the CPU computes
 are *not* integers, therefore this approximation results in confusion
 and ultimately in subtle bugs.
+
+## How to load
+
+### ...into Pharo
+
+````
+Metacello new
+  baseline: 'MachineArithmetic';
+  repository: 'github://shingarov/MachineArithmetic/src';
+  load.
+````
+
+To create fresh image (say `machinearithmetic.image`) from currently checked-out revision, do:
+
+````
+pharo Pharo.image save machinearithmetic
+pharo machinearithmetic.image metacello install tonel://. BaselineOfMachineArithmetic
+````
+

--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ To create fresh image (say `machinearithmetic.image`) from currently checked-out
 ````
 pharo Pharo.image save machinearithmetic
 pharo machinearithmetic.image metacello install tonel://. BaselineOfMachineArithmetic
+pharo machinearithmetic.image eval --save "(IceRepositoryCreator new location: '.' asFileReference; createRepository) register"
 ````
 


### PR DESCRIPTION
This PR contains few smaller fixes cleanups and improvements. 

It also introduces Metacello's `BaselineOf` to ease loading of MachineArithmetic to Pharo and for dependency management of other projects, such as Powerlang or OSVM.  `README.md` has been updated accordingly. 