### PR TITLE
Flush current (global) context when it is `#del`eted

### DIFF
--- a/MachineArithmetic/Z3Context.class.st
+++ b/MachineArithmetic/Z3Context.class.st
@@ -18,14 +18,6 @@ Z3Context class >> current [
 	^self global
 ]
 
-{ #category : #'global context' }
-Z3Context class >> delCurrent [
-	| current |
-	current := self current.
-	current del.
-	current == Global ifTrue: [ Global := nil ]
-]
-
 { #category : #'instance creation' }
 Z3Context class >> from: aZ3Config [
 	^LibZ3 uniqueInstance mkContext: aZ3Config 
@@ -59,9 +51,17 @@ Z3Context class >> z3versionString [
 
 { #category : #'as yet unclassified' }
 Z3Context >> del [
+	"In case #del is sent to current global context, we have to flush it first 
+	 before we `z3_del_context()` to make sure no subsequent code will use it. 
+
+	 This is not fool-proof as there still may be instances that uses it, but still 
+	 this helps to stabilize tests. We need ref-counting..."
+
+	Global == self ifTrue:[Global := nil].
 	self class unwrapAround: self.
 	LibZ3 uniqueInstance delContext: self.
 	self poison
+
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
This is to make sure that subsequent calls won't pick up deleted
context which would lead to a crash.

This is not fool-proof as there still may be instances that uses it, but still
this helps to stabilize tests and prevent (some) weird crashes.