### PR TITLE
Fix Tonel not to remove all files unconditionally

### DIFF
--- a/PreSmalltalks-Pharo/TonelWriter.extension.st
+++ b/PreSmalltalks-Pharo/TonelWriter.extension.st
@@ -1,0 +1,35 @@
+Extension { #name : #TonelWriter }
+
+{ #category : #'*PreSmalltalks-Pharo' }
+TonelWriter >> writePackage: aDefinition [
+
+	packageDir := self obtainPackageDir: aDefinition.
+	"this is lame... removing and rewriting full package needs to be rethink :)"
+	(self fileUtils directoryExists: self packageDir) ifTrue: [
+		"No, it is not only lame, it is dangerous and utterly stupid.
+		 Repeat after me: I'll not mess up with files I do not know!.
+		 Hundred times!"
+		| dir |
+		
+		dir := self packageDir.
+		dir allChildren do:[:file |
+			file isRegular" file" ifTrue:[
+				((file pathString endsWith: '.class.st') 
+				or:[file pathString endsWith:'.extension.st']) ifTrue:[
+					"Okay, this file looks like Smalltalk source, remove it.
+					 (it will be recreated later)"
+					file delete.
+				].
+			]
+		].	
+	].
+	self fileUtils ensureDirectoryExists: self packageDir.
+	self fileUtils 
+		writeStreamFor: 'package.st' 
+		in: self packageDir 
+		do: [ :s | 
+			s 
+				<< 'Package ' 
+				<< (self toSTON: { #name ->  packageDir asSymbol } asDictionary) 
+				<< self newLine ] 
+]


### PR DESCRIPTION
...when writing package. Tonel should not silently remove any files
(including those it has no idea of) without even saying anything. 

This commit changes the code so that it only removes files that 
look like (Tonel-managed) source files. I say "look like" because there's
no easy way to tell. 

Method `TonelWriter >> writePackage:` is the same across all vanilla
Pharo versions from 8 (including) so this override seem to be "safe",
should we ever move away from Pharo 8.