### PR TITLE
Return Z3 ASTs (Int, Bool, ...) in model

### DIFF
--- a/MachineArithmetic-Tests/SimpleZ3Test.class.st
+++ b/MachineArithmetic-Tests/SimpleZ3Test.class.st
@@ -370,7 +370,7 @@ SimpleZ3Test >> testProveNotValid [
 	p := Bool var: 'p'.
 	thm := p.
 	counterexample := solver proveNotValid: thm.
-	self assert: (counterexample constants at: 'p') equals: 'false'.
+	self assert: (counterexample constants at: 'p') equals: Bool false.
 	solver del
 ]
 
@@ -425,12 +425,12 @@ SimpleZ3Test >> testSendMoreMoney [
 	vars := #(s e n d m o r y) collect: [ :x |
 		Int var: x asString ].
 
-	s := vars at: 1.  	e := vars at: 2.
-	n := vars at: 3.  	d := vars at: 4.
-	m := vars at: 5.  	o := vars at: 6.
-	r := vars at: 7.  	y := vars at: 8.
+	s := vars at: 1.    e := vars at: 2.
+	n := vars at: 3.    d := vars at: 4.
+	m := vars at: 5.    o := vars at: 6.
+	r := vars at: 7.    y := vars at: 8.
 	
-	vars do: [ :x | 	solver assert: (x >= 0); assert: (x <= 9) ].
+	vars do: [ :x |     solver assert: (x >= 0); assert: (x <= 9) ].
 	solver assert: (m eq: 0) not.
 	solver assert: (solver ctx mkDistinct: vars).
 	solver assert: (
@@ -441,8 +441,8 @@ SimpleZ3Test >> testSendMoreMoney [
 		).
 	self assert: solver check.
 	model := solver getModel constants.
-	self assert: (model at: 'y')	 equals: '2'.	
-	self assert: (model at: 'd')	 equals: '7'.
+	self assert: (model at: 'y')         equals: 2.   
+	self assert: (model at: 'd')         equals: 7.
 	solver del
 ]
 
@@ -521,7 +521,7 @@ SimpleZ3Test >> testShapesN [
 	assert: ( t + c + s + q eq: a).
 	self assert: solver check.
 	model := solver getModel constants.
-	self assert: (model at: '?')	 equals: '20'.	
+	self assert: (model at: '?')         equals: 20.  
 	solver del
 ]
 

--- a/MachineArithmetic-Tests/YurichevBookTest.class.st
+++ b/MachineArithmetic-Tests/YurichevBookTest.class.st
@@ -21,9 +21,9 @@ YurichevBookTest >> test2_2_1_int [
 	self assert: s check.
 	model := s getModel constants.
 	self flag: #todo. "but constantsASTs fail to compare with 1"
-	self assert: (model at: 'x') equals: '1'.
-	self assert: (model at: 'y') equals: '(- 2)'.
-	self assert: (model at: 'y') equals: '(- 2)'.
+	self assert: (model at: 'x') equals: 1.
+	self assert: (model at: 'y') equals: -2.
+	self assert: (model at: 'y') equals: -2.
 ]
 
 { #category : #tests }
@@ -74,9 +74,9 @@ YurichevBookTest >> test2_2_2 [
 	s assert: (circle*square - (triangle*circle) eq: circle).
 	self assert: s check.
 	model := s getModel constants.
-	self assert: (model at: 'triangle') equals: '1'.
-	self assert: (model at: 'square') equals: '2'.
-	self assert: (model at: 'circle') equals: '5'.
+	self assert: (model at: 'triangle') equals: 1.
+	self assert: (model at: 'square') equals: 2.
+	self assert: (model at: 'circle') equals: 5.
 ]
 
 { #category : #tests }
@@ -97,15 +97,14 @@ YurichevBookTest >> testDogCatMouse [
 	self assert: s check.
 	m := s getModel constants.
 	
-	self assert: (m at: 'dogs') equals: '3'.
-	self assert: (m at: 'cats') equals: '41'.
-	self assert: (m at: 'mice') equals: '56'.
+	self assert: (m at: 'dogs') equals: 3.
+	self assert: (m at: 'cats') equals: 41.
+	self assert: (m at: 'mice') equals: 56.
 		
 	"TODO: Use readable selectors (~=?) after merging 'equality'"
 	s assert: (dogs eq: 3) not | (cats eq: 41) not | (mice eq: 56) not.
 	self deny: s check.
 	s del
-
 ]
 
 { #category : #tests }

--- a/MachineArithmetic/Int.class.st
+++ b/MachineArithmetic/Int.class.st
@@ -16,6 +16,12 @@ Int class >> sort [
 	^Z3Sort int
 ]
 
+{ #category : #converting }
+Int >> asInteger [
+	"Convert Z3 int to Smalltalk integer."
+	^ self value
+]
+
 { #category : #adapting }
 Int >> beLikeMe: value [
 	^value toInt

--- a/MachineArithmetic/Z3Model.class.st
+++ b/MachineArithmetic/Z3Model.class.st
@@ -50,9 +50,9 @@ Z3Model >> constants [
 		name := cnst name getString.
 		a := cnst value.
 		v := self eval: a completion: true.
-		resultDictionary at: name put: v astToString
+		resultDictionary at: name put: v
 	 ].
-	^resultDictionary 
+	^resultDictionary
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
This commit changes `Z3Model >> constants` to return dictionary mapping
constant names to values as Z3 ASTs, *not* a print string of that AST.

This is much more useful when using Z3 to find solutions for you.