### PR TITLE
Fix instantiation of Z3Sorts

### DIFF
--- a/MachineArithmetic/Z3Sort.class.st
+++ b/MachineArithmetic/Z3Sort.class.st
@@ -47,14 +47,15 @@ Z3Sort class >> classForSortKind: sortKind [
 
 { #category : #'instance creation' }
 Z3Sort class >> fromExternalAddress: anExternalAddress inContext: aZ3Context [
-	| class |
+	| class dummySort |
 
 	self assert: self == Z3Sort 
 		 description: 'Attempting to instantiate sort subclass directly'.
 	self assert: (Z3 get_ast_kind: aZ3Context _: anExternalAddress) == SORT_AST
 		 description: 'Attempting to instantiate sort for something that is not a sort'.
 
-	class := self classForSortKind: (Z3 get_sort_kind: aZ3Context _: anExternalAddress).
+	dummySort := Z3Sort basicNew initializeWithAddress: anExternalAddress context: aZ3Context.
+	class := self classForSortKind: (Z3 get_sort_kind: aZ3Context _: dummySort).
 	^ aZ3Context internAST: class address: anExternalAddress.
 
 ]


### PR DESCRIPTION
Before this commit, LibZ3>>_get_sort_kind:c_:t would crash, for example
when Z3_mk_datatypes() tries to instantiate the 'out' array of Z3Sorts,
because t is expected to be a Z3Sort, not an ExternalAddress, but on
entry to Z3Sort>>fromExternalAddress:inContext: all we have is an
ExternalAddress (the whole point of calling get_sort_kind() being to
figure out which concrete subclass of Z3Sort to instantiate).
We can't really change _get_sort_kind:_:'s expectations, because it's
autogenerated by apigen.py; therefore, we create a temporary dummy sort
object, pass that to _get_sort_kind:_:, and then instantiate the correct
subclass.