### PR TITLE
[FFI] Add and use `Z3Object >> ensureValidZ3Object` to detect invalid…

### DIFF
--- a/MachineArithmetic-FFI-Pharo/ExternalAddress.extension.st
+++ b/MachineArithmetic-FFI-Pharo/ExternalAddress.extension.st
@@ -5,6 +5,7 @@ ExternalAddress class >> newPoison [
 	"Return an ExternalAddress representing a 'poison address', i.e.,
 	 address that is invalid. Used to debug use-after-free errors."
 	
+	"Keep the poison value sync with Z3Object >> #isPoisoned!"
 	^self fromAddress: 16rBAD00BAD
 	
 ]

--- a/MachineArithmetic-FFI-Pharo/Z3Object.class.st
+++ b/MachineArithmetic-FFI-Pharo/Z3Object.class.st
@@ -66,6 +66,17 @@ Z3Object class >> fromExternalAddress: address [
 ]
 
 { #category : #utilities }
+Z3Object >> ensureValidZ3Object [
+    "This method is no-op if the object appears to be valid 
+     (based on the pointer value). Othwewise, thrown and
+     error."
+
+    self isNull ifTrue: [ self error:'Invalid Z3 object (null)!' ].
+    self isPoisoned ifTrue: [ self error:'Invalid Z3 object (poisoned)!' ].
+
+]
+
+{ #category : #utilities }
 Z3Object >> externalArray: anFFIExternalArray  pointerAt: anInteger [
 	^ anFFIExternalArray at: anInteger 
 		
@@ -80,6 +91,23 @@ Z3Object >> externalArrayFrom: anArray [
 { #category : #initialization }
 Z3Object >> initializeWithAddress: address [
 	self setHandle: address
+]
+
+{ #category : #testing }
+Z3Object >> isPoisoned [
+	"Return true, if this value has been 'poisoned', false otherwise.
+	 See #poison."
+	
+	"Note, that below value is hard-coded for performance, see
+	 ExternalAddress class >> #newPoison. Keep in sync!"
+	
+	^ self getHandle asInteger == 16rBAD00BAD.
+	
+	"
+	Z3Object new poison; isPoisoned.
+  Z3Object new isPoisoned.
+	"
+
 ]
 
 { #category : #utilities }

--- a/MachineArithmetic-FFI-SmalltalkX/ExternalAddress.extension.st
+++ b/MachineArithmetic-FFI-SmalltalkX/ExternalAddress.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #ExternalAddress }
 ExternalAddress class >> newPoison [
 	"Return an ExternalAddress representing a 'poison address', i.e.,
 	 address that is invalid. Used to debug use-after-free errors."
-	
+
+	"Keep the poison value sync with Z3Object >> #isPoisoned!"
 	^self fromAddress: 16rBAD00BAD
-	
 ]

--- a/MachineArithmetic-FFI-SmalltalkX/Z3Object.class.st
+++ b/MachineArithmetic-FFI-SmalltalkX/Z3Object.class.st
@@ -88,6 +88,16 @@ Z3Object class >> initialize [
 
 ]
 
+{ #category : #utilities }
+Z3Object >> ensureValidZ3Object [
+	"This method is no-op if the object appears to be valid 
+	 (based on the pointer value). Othwewise, thrown and
+	 error."
+
+	self isNull ifTrue: [ self error:'Invalid Z3 object (null)!' ].
+	self isPoisoned ifTrue: [ self error:'Invalid Z3 object (poisoned)!' ].
+]
+
 { #category : #initialization }
 Z3Object >> initialize [
 	self error: 'Should not be sent nor overriden. Use / override `#initializeWithAddress:` instead'
@@ -98,6 +108,21 @@ Z3Object >> initialize [
 Z3Object >> initializeWithAddress: anExternalAddress [
 	self setAddress: anExternalAddress
 
+]
+
+{ #category : #testing }
+Z3Object >> isPoisoned [
+	"Return true, if this value has been 'poisoned', false otherwise.
+	 See #poison."
+	
+	"Note, that below value is hard-coded for performance, see
+	 ExternalAddress class >> #newPoison. Keep in sync!"    
+	^ self address == 16rBAD00BAD.
+	
+	"
+	Z3Object new poison; isPoisoned.
+	Z3Object new isPoisoned.
+	"
 ]
 
 { #category : #utilities }

--- a/MachineArithmetic/Z3.class.st
+++ b/MachineArithmetic/Z3.class.st
@@ -19,6 +19,10 @@ Z3 class >> add_const_interp: c _: m _: f _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
+	f ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _add_const_interp: c _: m _: f _: a.
 	c errorCheck.
 	^ retval
@@ -70,6 +74,9 @@ Z3 class >> add_rec_def: c _: f _: n _: args _: body [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
+	body ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _add_rec_def: c _: f _: n _: argsExt _: body.
 	argsExt notNil ifTrue:[argsExt free].
@@ -95,6 +102,9 @@ Z3 class >> algebraic_add: c _: a _: b [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	b ensureValidZ3Object.
 	retval := lib _algebraic_add: c _: a _: b.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -120,6 +130,9 @@ Z3 class >> algebraic_div: c _: a _: b [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	b ensureValidZ3Object.
 	retval := lib _algebraic_div: c _: a _: b.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -143,6 +156,9 @@ Z3 class >> algebraic_eq: c _: a _: b [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	b ensureValidZ3Object.
 	retval := lib _algebraic_eq: c _: a _: b.
 	c errorCheck.
 	^ retval
@@ -166,6 +182,8 @@ Z3 class >> algebraic_eval: c _: p _: n _: a [
 	"
 	| retval aExt |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
 	aExt := self externalArrayFrom: a.
 	retval := lib _algebraic_eval: c _: p _: n _: aExt.
 	aExt notNil ifTrue:[aExt free].
@@ -190,6 +208,9 @@ Z3 class >> algebraic_ge: c _: a _: b [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	b ensureValidZ3Object.
 	retval := lib _algebraic_ge: c _: a _: b.
 	c errorCheck.
 	^ retval
@@ -211,6 +232,8 @@ Z3 class >> algebraic_get_i: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _algebraic_get_i: c _: a.
 	c errorCheck.
 	^ retval
@@ -232,6 +255,8 @@ Z3 class >> algebraic_get_poly: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _algebraic_get_poly: c _: a.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -255,6 +280,9 @@ Z3 class >> algebraic_gt: c _: a _: b [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	b ensureValidZ3Object.
 	retval := lib _algebraic_gt: c _: a _: b.
 	c errorCheck.
 	^ retval
@@ -276,6 +304,8 @@ Z3 class >> algebraic_is_neg: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _algebraic_is_neg: c _: a.
 	c errorCheck.
 	^ retval
@@ -297,6 +327,8 @@ Z3 class >> algebraic_is_pos: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _algebraic_is_pos: c _: a.
 	c errorCheck.
 	^ retval
@@ -317,6 +349,8 @@ Z3 class >> algebraic_is_value: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _algebraic_is_value: c _: a.
 	c errorCheck.
 	^ retval
@@ -338,6 +372,8 @@ Z3 class >> algebraic_is_zero: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _algebraic_is_zero: c _: a.
 	c errorCheck.
 	^ retval
@@ -360,6 +396,9 @@ Z3 class >> algebraic_le: c _: a _: b [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	b ensureValidZ3Object.
 	retval := lib _algebraic_le: c _: a _: b.
 	c errorCheck.
 	^ retval
@@ -382,6 +421,9 @@ Z3 class >> algebraic_lt: c _: a _: b [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	b ensureValidZ3Object.
 	retval := lib _algebraic_lt: c _: a _: b.
 	c errorCheck.
 	^ retval
@@ -405,6 +447,9 @@ Z3 class >> algebraic_mul: c _: a _: b [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	b ensureValidZ3Object.
 	retval := lib _algebraic_mul: c _: a _: b.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -428,6 +473,9 @@ Z3 class >> algebraic_neq: c _: a _: b [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	b ensureValidZ3Object.
 	retval := lib _algebraic_neq: c _: a _: b.
 	c errorCheck.
 	^ retval
@@ -450,6 +498,8 @@ Z3 class >> algebraic_power: c _: a _: k [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _algebraic_power: c _: a _: k.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -474,6 +524,8 @@ Z3 class >> algebraic_root: c _: a _: k [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _algebraic_root: c _: a _: k.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -499,6 +551,8 @@ Z3 class >> algebraic_roots: c _: p _: n _: a [
 	"
 	| retval aExt |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
 	aExt := self externalArrayFrom: a.
 	retval := lib _algebraic_roots: c _: p _: n _: aExt.
 	aExt notNil ifTrue:[aExt free].
@@ -523,6 +577,8 @@ Z3 class >> algebraic_sign: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _algebraic_sign: c _: a.
 	c errorCheck.
 	^ retval
@@ -546,6 +602,9 @@ Z3 class >> algebraic_sub: c _: a _: b [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	b ensureValidZ3Object.
 	retval := lib _algebraic_sub: c _: a _: b.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -566,6 +625,8 @@ Z3 class >> app_to_ast: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _app_to_ast: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -822,6 +883,8 @@ Z3 class >> ast_to_string: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _ast_to_string: c _: a.
 	c errorCheck.
 	^ retval
@@ -841,6 +904,8 @@ Z3 class >> ast_vector_dec_ref: c _: v [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	v ensureValidZ3Object.
 	retval := lib _ast_vector_dec_ref: c _: v.
 	c errorCheck.
 	^ retval
@@ -862,6 +927,8 @@ Z3 class >> ast_vector_get: c _: v _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	v ensureValidZ3Object.
 	retval := lib _ast_vector_get: c _: v _: i.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -882,6 +949,8 @@ Z3 class >> ast_vector_inc_ref: c _: v [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	v ensureValidZ3Object.
 	retval := lib _ast_vector_inc_ref: c _: v.
 	c errorCheck.
 	^ retval
@@ -901,6 +970,9 @@ Z3 class >> ast_vector_push: c _: v _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	v ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _ast_vector_push: c _: v _: a.
 	c errorCheck.
 	^ retval
@@ -920,6 +992,8 @@ Z3 class >> ast_vector_resize: c _: v _: n [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	v ensureValidZ3Object.
 	retval := lib _ast_vector_resize: c _: v _: n.
 	c errorCheck.
 	^ retval
@@ -941,6 +1015,9 @@ Z3 class >> ast_vector_set: c _: v _: i _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	v ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _ast_vector_set: c _: v _: i _: a.
 	c errorCheck.
 	^ retval
@@ -960,6 +1037,8 @@ Z3 class >> ast_vector_size: c _: v [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	v ensureValidZ3Object.
 	retval := lib _ast_vector_size: c _: v.
 	c errorCheck.
 	^ retval
@@ -979,6 +1058,8 @@ Z3 class >> ast_vector_to_string: c _: v [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	v ensureValidZ3Object.
 	retval := lib _ast_vector_to_string: c _: v.
 	c errorCheck.
 	^ retval
@@ -998,6 +1079,9 @@ Z3 class >> ast_vector_translate: s _: v _: t [
 	"
 	| retval |
 
+	s ensureValidZ3Object.
+	v ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _ast_vector_translate: s _: v _: t.
 	s errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: s.
@@ -1031,6 +1115,8 @@ Z3 class >> benchmark_to_smtlib_string: c _: name _: logic _: status _: attribut
 	"
 	| retval assumptionsExt |
 
+	c ensureValidZ3Object.
+	formula ensureValidZ3Object.
 	assumptionsExt := self externalArrayFrom: assumptions.
 	retval := lib _benchmark_to_smtlib_string: c _: name _: logic _: status _: attributes _: num_assumptions _: assumptionsExt _: formula.
 	assumptionsExt notNil ifTrue:[assumptionsExt free].
@@ -1066,6 +1152,10 @@ Z3 class >> datatype_update_field: c _: field_access _: t _: value [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	field_access ensureValidZ3Object.
+	t ensureValidZ3Object.
+	value ensureValidZ3Object.
 	retval := lib _datatype_update_field: c _: field_access _: t _: value.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -1088,6 +1178,8 @@ Z3 class >> dec_ref: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _dec_ref: c _: a.
 	c errorCheck.
 	^ retval
@@ -1109,6 +1201,7 @@ Z3 class >> del_config: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _del_config: c.
 	^ retval
 
@@ -1132,6 +1225,8 @@ Z3 class >> del_constructor: c _: constr [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	constr ensureValidZ3Object.
 	retval := lib _del_constructor: c _: constr.
 	c errorCheck.
 	^ retval
@@ -1158,6 +1253,8 @@ Z3 class >> del_constructor_list: c _: clist [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	clist ensureValidZ3Object.
 	retval := lib _del_constructor_list: c _: clist.
 	c errorCheck.
 	^ retval
@@ -1179,6 +1276,7 @@ Z3 class >> del_context: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _del_context: c.
 	^ retval
 
@@ -1242,6 +1340,7 @@ Z3 class >> eval_smtlib2_string: arg0 _: str [
 	"
 	| retval |
 
+	arg0 ensureValidZ3Object.
 	retval := lib _eval_smtlib2_string: arg0 _: str.
 	arg0 errorCheck.
 	^ retval
@@ -1295,6 +1394,10 @@ Z3 class >> fixedpoint_add_cover: c _: d _: level _: pred _: property [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	pred ensureValidZ3Object.
+	property ensureValidZ3Object.
 	retval := lib _fixedpoint_add_cover: c _: d _: level _: pred _: property.
 	c errorCheck.
 	^ retval
@@ -1326,6 +1429,9 @@ Z3 class >> fixedpoint_add_fact: c _: d _: r _: num_args _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	r ensureValidZ3Object.
 	argsExt := Z3Object externalU32ArrayFrom: args.
 	retval := lib _fixedpoint_add_fact: c _: d _: r _: num_args _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -1350,6 +1456,10 @@ Z3 class >> fixedpoint_add_invariant: c _: d _: pred _: property [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	pred ensureValidZ3Object.
+	property ensureValidZ3Object.
 	retval := lib _fixedpoint_add_invariant: c _: d _: pred _: property.
 	c errorCheck.
 	^ retval
@@ -1376,6 +1486,10 @@ Z3 class >> fixedpoint_add_rule: c _: d _: rule _: name [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	rule ensureValidZ3Object.
+	name ensureValidZ3Object.
 	retval := lib _fixedpoint_add_rule: c _: d _: rule _: name.
 	c errorCheck.
 	^ retval
@@ -1398,6 +1512,9 @@ Z3 class >> fixedpoint_assert: c _: d _: axiom [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	axiom ensureValidZ3Object.
 	retval := lib _fixedpoint_assert: c _: d _: axiom.
 	c errorCheck.
 	^ retval
@@ -1417,6 +1534,8 @@ Z3 class >> fixedpoint_dec_ref: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _fixedpoint_dec_ref: c _: d.
 	c errorCheck.
 	^ retval
@@ -1445,6 +1564,8 @@ Z3 class >> fixedpoint_from_file: c _: f _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
 	retval := lib _fixedpoint_from_file: c _: f _: s.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -1474,6 +1595,8 @@ Z3 class >> fixedpoint_from_string: c _: f _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
 	retval := lib _fixedpoint_from_string: c _: f _: s.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -1502,6 +1625,8 @@ Z3 class >> fixedpoint_get_answer: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _fixedpoint_get_answer: c _: d.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -1522,6 +1647,8 @@ Z3 class >> fixedpoint_get_assertions: c _: f [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
 	retval := lib _fixedpoint_get_assertions: c _: f.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -1547,6 +1674,9 @@ Z3 class >> fixedpoint_get_cover_delta: c _: d _: level _: pred [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	pred ensureValidZ3Object.
 	retval := lib _fixedpoint_get_cover_delta: c _: d _: level _: pred.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -1569,6 +1699,8 @@ Z3 class >> fixedpoint_get_ground_sat_answer: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _fixedpoint_get_ground_sat_answer: c _: d.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -1592,6 +1724,8 @@ Z3 class >> fixedpoint_get_help: c _: f [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
 	retval := lib _fixedpoint_get_help: c _: f.
 	c errorCheck.
 	^ retval
@@ -1615,6 +1749,9 @@ Z3 class >> fixedpoint_get_num_levels: c _: d _: pred [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	pred ensureValidZ3Object.
 	retval := lib _fixedpoint_get_num_levels: c _: d _: pred.
 	c errorCheck.
 	^ retval
@@ -1653,6 +1790,9 @@ Z3 class >> fixedpoint_get_reachable: c _: d _: pred [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	pred ensureValidZ3Object.
 	retval := lib _fixedpoint_get_reachable: c _: d _: pred.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -1675,6 +1815,8 @@ Z3 class >> fixedpoint_get_reason_unknown: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _fixedpoint_get_reason_unknown: c _: d.
 	c errorCheck.
 	^ retval
@@ -1694,6 +1836,8 @@ Z3 class >> fixedpoint_get_rule_names_along_trace: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _fixedpoint_get_rule_names_along_trace: c _: d.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -1714,6 +1858,8 @@ Z3 class >> fixedpoint_get_rules: c _: f [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
 	retval := lib _fixedpoint_get_rules: c _: f.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -1734,6 +1880,8 @@ Z3 class >> fixedpoint_get_rules_along_trace: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _fixedpoint_get_rules_along_trace: c _: d.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -1769,6 +1917,8 @@ Z3 class >> fixedpoint_inc_ref: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _fixedpoint_inc_ref: c _: d.
 	c errorCheck.
 	^ retval
@@ -1798,6 +1948,9 @@ Z3 class >> fixedpoint_query: c _: d _: query [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	query ensureValidZ3Object.
 	retval := lib _fixedpoint_query: c _: d _: query.
 	c errorCheck.
 	^ retval
@@ -1827,6 +1980,9 @@ Z3 class >> fixedpoint_query_from_lvl: c _: d _: query _: lvl [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	query ensureValidZ3Object.
 	retval := lib _fixedpoint_query_from_lvl: c _: d _: query _: lvl.
 	c errorCheck.
 	^ retval
@@ -1853,6 +2009,8 @@ Z3 class >> fixedpoint_query_relations: c _: d _: num_relations _: relations [
 	"
 	| retval relationsExt |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	relationsExt := self externalArrayFrom: relations.
 	retval := lib _fixedpoint_query_relations: c _: d _: num_relations _: relationsExt.
 	relationsExt notNil ifTrue:[relationsExt free].
@@ -1877,6 +2035,9 @@ Z3 class >> fixedpoint_register_relation: c _: d _: f [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	f ensureValidZ3Object.
 	retval := lib _fixedpoint_register_relation: c _: d _: f.
 	c errorCheck.
 	^ retval
@@ -1899,6 +2060,9 @@ Z3 class >> fixedpoint_set_params: c _: f _: p [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
+	p ensureValidZ3Object.
 	retval := lib _fixedpoint_set_params: c _: f _: p.
 	c errorCheck.
 	^ retval
@@ -1922,6 +2086,9 @@ Z3 class >> fixedpoint_set_predicate_representation: c _: d _: f _: num_relation
 	"
 	| retval relation_kindsExt |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	f ensureValidZ3Object.
 	relation_kindsExt := self externalArrayFrom: relation_kinds.
 	retval := lib _fixedpoint_set_predicate_representation: c _: d _: f _: num_relations _: relation_kindsExt.
 	relation_kindsExt notNil ifTrue:[relation_kindsExt free].
@@ -1950,6 +2117,8 @@ Z3 class >> fixedpoint_to_string: c _: f _: num_queries _: queries [
 	"
 	| retval queriesExt |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
 	queriesExt := self externalArrayFrom: queries.
 	retval := lib _fixedpoint_to_string: c _: f _: num_queries _: queriesExt.
 	queriesExt notNil ifTrue:[queriesExt free].
@@ -1972,6 +2141,10 @@ Z3 class >> fixedpoint_update_rule: c _: d _: a _: name [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
+	a ensureValidZ3Object.
+	name ensureValidZ3Object.
 	retval := lib _fixedpoint_update_rule: c _: d _: a _: name.
 	c errorCheck.
 	^ retval
@@ -1994,6 +2167,8 @@ Z3 class >> fpa_get_ebits: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _fpa_get_ebits: c _: s.
 	c errorCheck.
 	^ retval
@@ -2020,6 +2195,8 @@ Z3 class >> fpa_get_numeral_exponent_bv: c _: t _: biased [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _fpa_get_numeral_exponent_bv: c _: t _: biased.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2072,6 +2249,8 @@ Z3 class >> fpa_get_numeral_exponent_string: c _: t _: biased [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _fpa_get_numeral_exponent_string: c _: t _: biased.
 	c errorCheck.
 	^ retval
@@ -2119,6 +2298,8 @@ Z3 class >> fpa_get_numeral_sign_bv: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _fpa_get_numeral_sign_bv: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2144,6 +2325,8 @@ Z3 class >> fpa_get_numeral_significand_bv: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _fpa_get_numeral_significand_bv: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2171,6 +2354,8 @@ Z3 class >> fpa_get_numeral_significand_string: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _fpa_get_numeral_significand_string: c _: t.
 	c errorCheck.
 	^ retval
@@ -2216,6 +2401,8 @@ Z3 class >> fpa_get_sbits: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _fpa_get_sbits: c _: s.
 	c errorCheck.
 	^ retval
@@ -2238,6 +2425,8 @@ Z3 class >> fpa_is_numeral_inf: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _fpa_is_numeral_inf: c _: t.
 	c errorCheck.
 	^ retval
@@ -2260,6 +2449,8 @@ Z3 class >> fpa_is_numeral_nan: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _fpa_is_numeral_nan: c _: t.
 	c errorCheck.
 	^ retval
@@ -2282,6 +2473,8 @@ Z3 class >> fpa_is_numeral_negative: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _fpa_is_numeral_negative: c _: t.
 	c errorCheck.
 	^ retval
@@ -2304,6 +2497,8 @@ Z3 class >> fpa_is_numeral_normal: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _fpa_is_numeral_normal: c _: t.
 	c errorCheck.
 	^ retval
@@ -2326,6 +2521,8 @@ Z3 class >> fpa_is_numeral_positive: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _fpa_is_numeral_positive: c _: t.
 	c errorCheck.
 	^ retval
@@ -2348,6 +2545,8 @@ Z3 class >> fpa_is_numeral_subnormal: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _fpa_is_numeral_subnormal: c _: t.
 	c errorCheck.
 	^ retval
@@ -2370,6 +2569,8 @@ Z3 class >> fpa_is_numeral_zero: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _fpa_is_numeral_zero: c _: t.
 	c errorCheck.
 	^ retval
@@ -2389,6 +2590,8 @@ Z3 class >> func_decl_to_ast: c _: f [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
 	retval := lib _func_decl_to_ast: c _: f.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2407,6 +2610,8 @@ Z3 class >> func_decl_to_string: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _func_decl_to_string: c _: d.
 	c errorCheck.
 	^ retval
@@ -2676,6 +2881,8 @@ Z3 class >> get_algebraic_number_lower: c _: a _: precision [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_algebraic_number_lower: c _: a _: precision.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2700,6 +2907,8 @@ Z3 class >> get_algebraic_number_upper: c _: a _: precision [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_algebraic_number_upper: c _: a _: precision.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2722,6 +2931,8 @@ Z3 class >> get_app_arg: c _: a _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_app_arg: c _: a _: i.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2742,6 +2953,8 @@ Z3 class >> get_app_decl: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_app_decl: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2763,6 +2976,8 @@ Z3 class >> get_app_num_args: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_app_num_args: c _: a.
 	c errorCheck.
 	^ retval
@@ -2784,6 +2999,8 @@ Z3 class >> get_arity: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_arity: c _: d.
 	c errorCheck.
 	^ retval
@@ -2810,6 +3027,8 @@ Z3 class >> get_array_sort_domain: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _get_array_sort_domain: c _: t.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -2837,6 +3056,8 @@ Z3 class >> get_array_sort_domain_n: c _: t _: idx [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _get_array_sort_domain_n: c _: t _: idx.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -2862,6 +3083,8 @@ Z3 class >> get_array_sort_range: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _get_array_sort_range: c _: t.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -2884,6 +3107,8 @@ Z3 class >> get_as_array_func_decl: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_as_array_func_decl: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2907,6 +3132,8 @@ Z3 class >> get_ast_hash: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_ast_hash: c _: a.
 	c errorCheck.
 	^ retval
@@ -2932,6 +3159,8 @@ Z3 class >> get_ast_id: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _get_ast_id: c _: t.
 	c errorCheck.
 	^ retval
@@ -2951,6 +3180,7 @@ Z3 class >> get_ast_kind: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _get_ast_kind: c _: a.
 	c errorCheck.
 	^ retval
@@ -2970,6 +3200,8 @@ Z3 class >> get_bool_value: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_bool_value: c _: a.
 	c errorCheck.
 	^ retval
@@ -2994,6 +3226,8 @@ Z3 class >> get_bv_sort_size: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _get_bv_sort_size: c _: t.
 	c errorCheck.
 	^ retval
@@ -3020,6 +3254,8 @@ Z3 class >> get_datatype_sort_constructor: c _: t _: idx [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _get_datatype_sort_constructor: c _: t _: idx.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3048,6 +3284,8 @@ Z3 class >> get_datatype_sort_constructor_accessor: c _: t _: idx_c _: idx_a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _get_datatype_sort_constructor_accessor: c _: t _: idx_c _: idx_a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3074,6 +3312,8 @@ Z3 class >> get_datatype_sort_num_constructors: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _get_datatype_sort_num_constructors: c _: t.
 	c errorCheck.
 	^ retval
@@ -3100,6 +3340,8 @@ Z3 class >> get_datatype_sort_recognizer: c _: t _: idx [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _get_datatype_sort_recognizer: c _: t _: idx.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3122,6 +3364,8 @@ Z3 class >> get_decl_ast_parameter: c _: d _: idx [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_decl_ast_parameter: c _: d _: idx.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3144,6 +3388,8 @@ Z3 class >> get_decl_double_parameter: c _: d _: idx [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_decl_double_parameter: c _: d _: idx.
 	c errorCheck.
 	^ retval
@@ -3165,6 +3411,8 @@ Z3 class >> get_decl_func_decl_parameter: c _: d _: idx [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_decl_func_decl_parameter: c _: d _: idx.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3187,6 +3435,8 @@ Z3 class >> get_decl_int_parameter: c _: d _: idx [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_decl_int_parameter: c _: d _: idx.
 	c errorCheck.
 	^ retval
@@ -3206,6 +3456,8 @@ Z3 class >> get_decl_kind: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_decl_kind: c _: d.
 	c errorCheck.
 	^ retval
@@ -3225,6 +3477,8 @@ Z3 class >> get_decl_name: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_decl_name: c _: d.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -3245,6 +3499,8 @@ Z3 class >> get_decl_num_parameters: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_decl_num_parameters: c _: d.
 	c errorCheck.
 	^ retval
@@ -3268,6 +3524,8 @@ Z3 class >> get_decl_parameter_kind: c _: d _: idx [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_decl_parameter_kind: c _: d _: idx.
 	c errorCheck.
 	^ retval
@@ -3289,6 +3547,8 @@ Z3 class >> get_decl_rational_parameter: c _: d _: idx [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_decl_rational_parameter: c _: d _: idx.
 	c errorCheck.
 	^ retval
@@ -3310,6 +3570,8 @@ Z3 class >> get_decl_sort_parameter: c _: d _: idx [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_decl_sort_parameter: c _: d _: idx.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -3332,6 +3594,8 @@ Z3 class >> get_decl_symbol_parameter: c _: d _: idx [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_decl_symbol_parameter: c _: d _: idx.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -3354,6 +3618,8 @@ Z3 class >> get_denominator: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_denominator: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3378,6 +3644,8 @@ Z3 class >> get_domain: c _: d _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_domain: c _: d _: i.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -3400,6 +3668,8 @@ Z3 class >> get_domain_size: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_domain_size: c _: d.
 	c errorCheck.
 	^ retval
@@ -3424,6 +3694,7 @@ Z3 class >> get_error_code: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _get_error_code: c.
 	^ retval
 
@@ -3442,6 +3713,7 @@ Z3 class >> get_error_msg: c _: err [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _get_error_msg: c _: err.
 	^ retval
 
@@ -3514,6 +3786,8 @@ Z3 class >> get_func_decl_id: c _: f [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
 	retval := lib _get_func_decl_id: c _: f.
 	c errorCheck.
 	^ retval
@@ -3546,6 +3820,8 @@ Z3 class >> get_implied_equalities: c _: s _: num_terms _: terms _: class_ids [
 	"
 	| retval termsExt class_idsExt |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	termsExt := self externalArrayFrom: terms.
 	class_idsExt := Z3Object externalU32ArrayFrom: class_ids.
 	retval := lib _get_implied_equalities: c _: s _: num_terms _: termsExt _: class_idsExt.
@@ -3577,6 +3853,8 @@ Z3 class >> get_index_value: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_index_value: c _: a.
 	c errorCheck.
 	^ retval
@@ -3600,6 +3878,8 @@ Z3 class >> get_lstring: c _: s _: length [
 	"
 	| retval lengthExt |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	lengthExt := Z3Object externalU32ArrayFrom: length.
 	retval := lib _get_lstring: c _: s _: lengthExt.
 	1 to: length size do: [ :i |
@@ -3627,6 +3907,7 @@ Z3 class >> get_num_probes: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _get_num_probes: c.
 	c errorCheck.
 	^ retval
@@ -3646,6 +3927,7 @@ Z3 class >> get_num_tactics: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _get_num_tactics: c.
 	c errorCheck.
 	^ retval
@@ -3668,6 +3950,8 @@ Z3 class >> get_numeral_binary_string: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_numeral_binary_string: c _: a.
 	c errorCheck.
 	^ retval
@@ -3690,6 +3974,8 @@ Z3 class >> get_numeral_decimal_string: c _: a _: precision [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_numeral_decimal_string: c _: a _: precision.
 	c errorCheck.
 	^ retval
@@ -3711,6 +3997,8 @@ Z3 class >> get_numeral_double: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_numeral_double: c _: a.
 	c errorCheck.
 	^ retval
@@ -3816,6 +4104,8 @@ Z3 class >> get_numeral_string: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_numeral_string: c _: a.
 	c errorCheck.
 	^ retval
@@ -3860,6 +4150,8 @@ Z3 class >> get_numeral_uint: c _: v _: u [
 	"
 	| retval uExt |
 
+	c ensureValidZ3Object.
+	v ensureValidZ3Object.
 	uExt := Z3Object externalU32ArrayFrom: u.
 	retval := lib _get_numeral_uint: c _: v _: uExt.
 	1 to: u size do: [ :i |
@@ -3889,6 +4181,8 @@ Z3 class >> get_numerator: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_numerator: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3909,6 +4203,8 @@ Z3 class >> get_pattern: c _: p _: idx [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
 	retval := lib _get_pattern: c _: p _: idx.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3929,6 +4225,8 @@ Z3 class >> get_pattern_num_terms: c _: p [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
 	retval := lib _get_pattern_num_terms: c _: p.
 	c errorCheck.
 	^ retval
@@ -3950,6 +4248,7 @@ Z3 class >> get_probe_name: c _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _get_probe_name: c _: i.
 	c errorCheck.
 	^ retval
@@ -3971,6 +4270,8 @@ Z3 class >> get_quantifier_body: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_quantifier_body: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3993,6 +4294,8 @@ Z3 class >> get_quantifier_bound_name: c _: a _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_quantifier_bound_name: c _: a _: i.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -4015,6 +4318,8 @@ Z3 class >> get_quantifier_bound_sort: c _: a _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_quantifier_bound_sort: c _: a _: i.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -4037,6 +4342,8 @@ Z3 class >> get_quantifier_no_pattern_ast: c _: a _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_quantifier_no_pattern_ast: c _: a _: i.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -4059,6 +4366,8 @@ Z3 class >> get_quantifier_num_bound: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_quantifier_num_bound: c _: a.
 	c errorCheck.
 	^ retval
@@ -4080,6 +4389,8 @@ Z3 class >> get_quantifier_num_no_patterns: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_quantifier_num_no_patterns: c _: a.
 	c errorCheck.
 	^ retval
@@ -4101,6 +4412,8 @@ Z3 class >> get_quantifier_num_patterns: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_quantifier_num_patterns: c _: a.
 	c errorCheck.
 	^ retval
@@ -4122,6 +4435,8 @@ Z3 class >> get_quantifier_pattern_ast: c _: a _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_quantifier_pattern_ast: c _: a _: i.
 	c errorCheck.
 	^ Z3Pattern fromExternalAddress: retval inContext: c.
@@ -4144,6 +4459,8 @@ Z3 class >> get_quantifier_weight: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _get_quantifier_weight: c _: a.
 	c errorCheck.
 	^ retval
@@ -4166,6 +4483,8 @@ Z3 class >> get_range: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_range: c _: d.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -4186,6 +4505,8 @@ Z3 class >> get_re_sort_basis: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _get_re_sort_basis: c _: s.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -4210,6 +4531,8 @@ Z3 class >> get_relation_arity: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _get_relation_arity: c _: s.
 	c errorCheck.
 	^ retval
@@ -4234,6 +4557,8 @@ Z3 class >> get_relation_column: c _: s _: col [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _get_relation_column: c _: s _: col.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -4254,6 +4579,8 @@ Z3 class >> get_seq_sort_basis: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _get_seq_sort_basis: c _: s.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -4276,6 +4603,7 @@ Z3 class >> get_sort: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _get_sort: c _: a.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -4296,6 +4624,8 @@ Z3 class >> get_sort_id: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _get_sort_id: c _: s.
 	c errorCheck.
 	^ retval
@@ -4317,6 +4647,7 @@ Z3 class >> get_sort_kind: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _get_sort_kind: c _: t.
 	c errorCheck.
 	^ retval
@@ -4336,6 +4667,8 @@ Z3 class >> get_sort_name: c _: d [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	retval := lib _get_sort_name: c _: d.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -4359,6 +4692,8 @@ Z3 class >> get_string: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _get_string: c _: s.
 	c errorCheck.
 	^ retval
@@ -4382,6 +4717,8 @@ Z3 class >> get_string_contents: c _: s _: length _: contents [
 	"
 	| retval contentsExt |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	contentsExt := Z3Object externalU32ArrayFrom: contents.
 	retval := lib _get_string_contents: c _: s _: length _: contentsExt.
 	1 to: contents size do: [ :i |
@@ -4411,6 +4748,8 @@ Z3 class >> get_string_length: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _get_string_length: c _: s.
 	c errorCheck.
 	^ retval
@@ -4434,6 +4773,8 @@ Z3 class >> get_symbol_int: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _get_symbol_int: c _: s.
 	c errorCheck.
 	^ retval
@@ -4455,6 +4796,8 @@ Z3 class >> get_symbol_kind: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _get_symbol_kind: c _: s.
 	c errorCheck.
 	^ retval
@@ -4482,6 +4825,8 @@ Z3 class >> get_symbol_string: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _get_symbol_string: c _: s.
 	c errorCheck.
 	^ retval
@@ -4503,6 +4848,7 @@ Z3 class >> get_tactic_name: c _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _get_tactic_name: c _: i.
 	c errorCheck.
 	^ retval
@@ -4529,6 +4875,8 @@ Z3 class >> get_tuple_sort_field_decl: c _: t _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _get_tuple_sort_field_decl: c _: t _: i.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -4555,6 +4903,8 @@ Z3 class >> get_tuple_sort_mk_decl: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _get_tuple_sort_mk_decl: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -4580,6 +4930,8 @@ Z3 class >> get_tuple_sort_num_fields: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _get_tuple_sort_num_fields: c _: t.
 	c errorCheck.
 	^ retval
@@ -4993,6 +5345,8 @@ Z3 class >> inc_ref: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _inc_ref: c _: a.
 	c errorCheck.
 	^ retval
@@ -5019,6 +5373,7 @@ Z3 class >> interrupt: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _interrupt: c.
 	c errorCheck.
 	^ retval
@@ -5053,6 +5408,8 @@ Z3 class >> is_algebraic_number: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _is_algebraic_number: c _: a.
 	c errorCheck.
 	^ retval
@@ -5070,6 +5427,8 @@ Z3 class >> is_app: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _is_app: c _: a.
 	c errorCheck.
 	^ retval
@@ -5095,6 +5454,8 @@ Z3 class >> is_as_array: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _is_as_array: c _: a.
 	c errorCheck.
 	^ retval
@@ -5114,6 +5475,8 @@ Z3 class >> is_char_sort: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _is_char_sort: c _: s.
 	c errorCheck.
 	^ retval
@@ -5133,6 +5496,9 @@ Z3 class >> is_eq_ast: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _is_eq_ast: c _: t1 _: t2.
 	c errorCheck.
 	^ retval
@@ -5152,6 +5518,9 @@ Z3 class >> is_eq_func_decl: c _: f1 _: f2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	f1 ensureValidZ3Object.
+	f2 ensureValidZ3Object.
 	retval := lib _is_eq_func_decl: c _: f1 _: f2.
 	c errorCheck.
 	^ retval
@@ -5171,6 +5540,9 @@ Z3 class >> is_eq_sort: c _: s1 _: s2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s1 ensureValidZ3Object.
+	s2 ensureValidZ3Object.
 	retval := lib _is_eq_sort: c _: s1 _: s2.
 	c errorCheck.
 	^ retval
@@ -5192,6 +5564,8 @@ Z3 class >> is_lambda: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _is_lambda: c _: a.
 	c errorCheck.
 	^ retval
@@ -5209,6 +5583,8 @@ Z3 class >> is_numeral_ast: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _is_numeral_ast: c _: a.
 	c errorCheck.
 	^ retval
@@ -5229,6 +5605,8 @@ Z3 class >> is_quantifier_exists: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _is_quantifier_exists: c _: a.
 	c errorCheck.
 	^ retval
@@ -5248,6 +5626,8 @@ Z3 class >> is_quantifier_forall: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _is_quantifier_forall: c _: a.
 	c errorCheck.
 	^ retval
@@ -5267,6 +5647,8 @@ Z3 class >> is_re_sort: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _is_re_sort: c _: s.
 	c errorCheck.
 	^ retval
@@ -5286,6 +5668,8 @@ Z3 class >> is_seq_sort: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _is_seq_sort: c _: s.
 	c errorCheck.
 	^ retval
@@ -5305,6 +5689,8 @@ Z3 class >> is_string: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _is_string: c _: s.
 	c errorCheck.
 	^ retval
@@ -5324,6 +5710,8 @@ Z3 class >> is_string_sort: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _is_string_sort: c _: s.
 	c errorCheck.
 	^ retval
@@ -5343,6 +5731,8 @@ Z3 class >> is_well_sorted: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _is_well_sorted: c _: t.
 	c errorCheck.
 	^ retval
@@ -5367,6 +5757,7 @@ Z3 class >> mk_add: c _: num_args _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_add: c _: num_args _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -5394,6 +5785,7 @@ Z3 class >> mk_and: c _: num_args _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_and: c _: num_args _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -5420,6 +5812,8 @@ Z3 class >> mk_app: c _: d _: num_args _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
+	d ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_app: c _: d _: num_args _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -5447,6 +5841,8 @@ Z3 class >> mk_array_default: c _: array [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	array ensureValidZ3Object.
 	retval := lib _mk_array_default: c _: array.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5469,6 +5865,9 @@ Z3 class >> mk_array_ext: c _: arg1 _: arg2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	arg1 ensureValidZ3Object.
+	arg2 ensureValidZ3Object.
 	retval := lib _mk_array_ext: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5495,6 +5894,9 @@ Z3 class >> mk_array_sort: c _: domain _: range [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	domain ensureValidZ3Object.
+	range ensureValidZ3Object.
 	retval := lib _mk_array_sort: c _: domain _: range.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -5518,6 +5920,8 @@ Z3 class >> mk_array_sort_n: c _: n _: domain _: range [
 	"
 	| retval domainExt |
 
+	c ensureValidZ3Object.
+	range ensureValidZ3Object.
 	domainExt := self externalArrayFrom: domain.
 	retval := lib _mk_array_sort_n: c _: n _: domainExt _: range.
 	domainExt notNil ifTrue:[domainExt free].
@@ -5542,6 +5946,8 @@ Z3 class >> mk_as_array: c _: f [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
 	retval := lib _mk_as_array: c _: f.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5583,6 +5989,7 @@ Z3 class >> mk_ast_vector: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_ast_vector: c.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -5605,6 +6012,7 @@ Z3 class >> mk_atleast: c _: num_args _: args _: k [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_atleast: c _: num_args _: argsExt _: k.
 	argsExt notNil ifTrue:[argsExt free].
@@ -5629,6 +6037,7 @@ Z3 class >> mk_atmost: c _: num_args _: args _: k [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_atmost: c _: num_args _: argsExt _: k.
 	argsExt notNil ifTrue:[argsExt free].
@@ -5654,6 +6063,8 @@ Z3 class >> mk_bit2bool: c _: i _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_bit2bool: c _: i _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5676,6 +6087,7 @@ Z3 class >> mk_bool_sort: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_bool_sort: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -5720,6 +6132,8 @@ Z3 class >> mk_bound: c _: index _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_bound: c _: index _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5747,6 +6161,8 @@ Z3 class >> mk_bv2int: c _: t1 _: is_signed [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_bv2int: c _: t1 _: is_signed.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5787,6 +6203,7 @@ Z3 class >> mk_bv_sort: c _: sz [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_bv_sort: c _: sz.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -5809,6 +6226,9 @@ Z3 class >> mk_bvadd: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvadd: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5833,6 +6253,9 @@ Z3 class >> mk_bvadd_no_overflow: c _: t1 _: t2 _: is_signed [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvadd_no_overflow: c _: t1 _: t2 _: is_signed.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5857,6 +6280,9 @@ Z3 class >> mk_bvadd_no_underflow: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvadd_no_underflow: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5879,6 +6305,9 @@ Z3 class >> mk_bvand: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvand: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5909,6 +6338,9 @@ Z3 class >> mk_bvashr: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvashr: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5938,6 +6370,9 @@ Z3 class >> mk_bvlshr: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvlshr: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5960,6 +6395,9 @@ Z3 class >> mk_bvmul: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvmul: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -5984,6 +6422,9 @@ Z3 class >> mk_bvmul_no_overflow: c _: t1 _: t2 _: is_signed [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvmul_no_overflow: c _: t1 _: t2 _: is_signed.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6008,6 +6449,9 @@ Z3 class >> mk_bvmul_no_underflow: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvmul_no_underflow: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6030,6 +6474,9 @@ Z3 class >> mk_bvnand: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvnand: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6052,6 +6499,8 @@ Z3 class >> mk_bvneg: c _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_bvneg: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6076,6 +6525,8 @@ Z3 class >> mk_bvneg_no_overflow: c _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_bvneg_no_overflow: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6098,6 +6549,9 @@ Z3 class >> mk_bvnor: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvnor: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6120,6 +6574,8 @@ Z3 class >> mk_bvnot: c _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_bvnot: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6142,6 +6598,9 @@ Z3 class >> mk_bvor: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvor: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6164,6 +6623,8 @@ Z3 class >> mk_bvredand: c _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_bvredand: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6186,6 +6647,8 @@ Z3 class >> mk_bvredor: c _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_bvredor: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6216,6 +6679,9 @@ Z3 class >> mk_bvsdiv: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvsdiv: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6240,6 +6706,9 @@ Z3 class >> mk_bvsdiv_no_overflow: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvsdiv_no_overflow: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6262,6 +6731,9 @@ Z3 class >> mk_bvsge: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvsge: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6284,6 +6756,9 @@ Z3 class >> mk_bvsgt: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvsgt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6313,6 +6788,9 @@ Z3 class >> mk_bvshl: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvshl: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6335,6 +6813,9 @@ Z3 class >> mk_bvsle: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvsle: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6365,6 +6846,9 @@ Z3 class >> mk_bvslt: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvslt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6391,6 +6875,9 @@ Z3 class >> mk_bvsmod: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvsmod: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6420,6 +6907,9 @@ Z3 class >> mk_bvsrem: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvsrem: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6442,6 +6932,9 @@ Z3 class >> mk_bvsub: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvsub: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6466,6 +6959,9 @@ Z3 class >> mk_bvsub_no_overflow: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvsub_no_overflow: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6490,6 +6986,9 @@ Z3 class >> mk_bvsub_no_underflow: c _: t1 _: t2 _: is_signed [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvsub_no_underflow: c _: t1 _: t2 _: is_signed.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6516,6 +7015,9 @@ Z3 class >> mk_bvudiv: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvudiv: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6538,6 +7040,9 @@ Z3 class >> mk_bvuge: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvuge: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6560,6 +7065,9 @@ Z3 class >> mk_bvugt: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvugt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6582,6 +7090,9 @@ Z3 class >> mk_bvule: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvule: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6604,6 +7115,9 @@ Z3 class >> mk_bvult: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvult: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6630,6 +7144,9 @@ Z3 class >> mk_bvurem: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvurem: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6652,6 +7169,9 @@ Z3 class >> mk_bvxnor: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvxnor: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6674,6 +7194,9 @@ Z3 class >> mk_bvxor: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_bvxor: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6693,6 +7216,7 @@ Z3 class >> mk_char: c _: ch [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_char: c _: ch.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6713,6 +7237,8 @@ Z3 class >> mk_char_from_bv: c _: bv [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	bv ensureValidZ3Object.
 	retval := lib _mk_char_from_bv: c _: bv.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6733,6 +7259,8 @@ Z3 class >> mk_char_is_digit: c _: ch [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ch ensureValidZ3Object.
 	retval := lib _mk_char_is_digit: c _: ch.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6753,6 +7281,9 @@ Z3 class >> mk_char_le: c _: ch1 _: ch2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ch1 ensureValidZ3Object.
+	ch2 ensureValidZ3Object.
 	retval := lib _mk_char_le: c _: ch1 _: ch2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6777,6 +7308,7 @@ Z3 class >> mk_char_sort: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_char_sort: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -6797,6 +7329,8 @@ Z3 class >> mk_char_to_bv: c _: ch [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ch ensureValidZ3Object.
 	retval := lib _mk_char_to_bv: c _: ch.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6817,6 +7351,8 @@ Z3 class >> mk_char_to_int: c _: ch [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ch ensureValidZ3Object.
 	retval := lib _mk_char_to_int: c _: ch.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6842,6 +7378,9 @@ Z3 class >> mk_concat: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_concat: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6916,6 +7455,9 @@ Z3 class >> mk_const: c _: s _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_const: c _: s _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6943,6 +7485,9 @@ Z3 class >> mk_const_array: c _: domain _: v [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	domain ensureValidZ3Object.
+	v ensureValidZ3Object.
 	retval := lib _mk_const_array: c _: domain _: v.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6977,6 +7522,9 @@ Z3 class >> mk_constructor: c _: name _: recognizer _: num_fields _: field_names
 	"
 	| retval field_namesExt sortsExt sort_refsExt |
 
+	c ensureValidZ3Object.
+	name ensureValidZ3Object.
+	recognizer ensureValidZ3Object.
 	field_namesExt := self externalArrayFrom: field_names.
 	sortsExt := self externalArrayFrom: sorts.
 	sort_refsExt := Z3Object externalU32ArrayFrom: sort_refs.
@@ -7010,6 +7558,7 @@ Z3 class >> mk_constructor_list: c _: num_constructors _: constructors [
 	"
 	| retval constructorsExt |
 
+	c ensureValidZ3Object.
 	constructorsExt := self externalArrayFrom: constructors.
 	retval := lib _mk_constructor_list: c _: num_constructors _: constructorsExt.
 	constructorsExt notNil ifTrue:[constructorsExt free].
@@ -7060,6 +7609,7 @@ Z3 class >> mk_context: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_context: c.
 	^ retval
 
@@ -7095,6 +7645,7 @@ Z3 class >> mk_context_rc: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_context_rc: c.
 	^ retval
 
@@ -7123,6 +7674,8 @@ Z3 class >> mk_datatype: c _: name _: num_constructors _: constructors [
 	"
 	| retval constructorsExt |
 
+	c ensureValidZ3Object.
+	name ensureValidZ3Object.
 	constructorsExt := self externalArrayFrom: constructors.
 	retval := lib _mk_datatype: c _: name _: num_constructors _: constructorsExt.
 	1 to: constructors size do: [ :i |
@@ -7157,6 +7710,8 @@ Z3 class >> mk_datatype_sort: c _: name [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	name ensureValidZ3Object.
 	retval := lib _mk_datatype_sort: c _: name.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -7187,6 +7742,7 @@ Z3 class >> mk_datatypes: c _: num_sorts _: sort_names _: sorts _: constructor_l
 	"
 	| retval sort_namesExt sortsExt constructor_listsExt |
 
+	c ensureValidZ3Object.
 	sort_namesExt := self externalArrayFrom: sort_names.
 	sortsExt := self externalArrayFrom: sorts.
 	constructor_listsExt := self externalArrayFrom: constructor_lists.
@@ -7231,6 +7787,7 @@ Z3 class >> mk_distinct: c _: num_args _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_distinct: c _: num_args _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -7257,6 +7814,9 @@ Z3 class >> mk_div: c _: arg1 _: arg2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	arg1 ensureValidZ3Object.
+	arg2 ensureValidZ3Object.
 	retval := lib _mk_div: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7281,6 +7841,9 @@ Z3 class >> mk_divides: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_divides: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7301,6 +7864,8 @@ Z3 class >> mk_empty_set: c _: domain [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	domain ensureValidZ3Object.
 	retval := lib _mk_empty_set: c _: domain.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7337,6 +7902,8 @@ Z3 class >> mk_enumeration_sort: c _: name _: n _: enum_names _: enum_consts _: 
 	"
 	| retval enum_namesExt enum_constsExt enum_testersExt |
 
+	c ensureValidZ3Object.
+	name ensureValidZ3Object.
 	enum_namesExt := self externalArrayFrom: enum_names.
 	enum_constsExt := self externalArrayFrom: enum_consts.
 	enum_testersExt := self externalArrayFrom: enum_testers.
@@ -7377,6 +7944,9 @@ Z3 class >> mk_eq: c _: l _: r [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	l ensureValidZ3Object.
+	r ensureValidZ3Object.
 	retval := lib _mk_eq: c _: l _: r.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7402,6 +7972,8 @@ Z3 class >> mk_exists: c _: weight _: num_patterns _: patterns _: num_decls _: s
 	"
 	| retval patternsExt sortsExt decl_namesExt |
 
+	c ensureValidZ3Object.
+	body ensureValidZ3Object.
 	patternsExt := self externalArrayFrom: patterns.
 	sortsExt := self externalArrayFrom: sorts.
 	decl_namesExt := self externalArrayFrom: decl_names.
@@ -7443,6 +8015,8 @@ Z3 class >> mk_exists_const: c _: weight _: num_bound _: bound _: num_patterns _
 	"
 	| retval boundExt patternsExt |
 
+	c ensureValidZ3Object.
+	body ensureValidZ3Object.
 	boundExt := self externalArrayFrom: bound.
 	patternsExt := self externalArrayFrom: patterns.
 	retval := lib _mk_exists_const: c _: weight _: num_bound _: boundExt _: num_patterns _: patternsExt _: body.
@@ -7469,6 +8043,9 @@ Z3 class >> mk_ext_rotate_left: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_ext_rotate_left: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7491,6 +8068,9 @@ Z3 class >> mk_ext_rotate_right: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_ext_rotate_right: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7514,6 +8094,8 @@ Z3 class >> mk_extract: c _: high _: low _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_extract: c _: high _: low _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7534,6 +8116,7 @@ Z3 class >> mk_false: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_false: c.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7562,6 +8145,8 @@ Z3 class >> mk_finite_domain_sort: c _: name _: size [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	name ensureValidZ3Object.
 	retval := lib _mk_finite_domain_sort: c _: name _: size.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -7585,6 +8170,7 @@ Z3 class >> mk_fixedpoint: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fixedpoint: c.
 	c errorCheck.
 	^ Z3Fixedpoint fromExternalAddress: retval inContext: c.
@@ -7623,6 +8209,8 @@ Z3 class >> mk_forall: c _: weight _: num_patterns _: patterns _: num_decls _: s
 	"
 	| retval patternsExt sortsExt decl_namesExt |
 
+	c ensureValidZ3Object.
+	body ensureValidZ3Object.
 	patternsExt := self externalArrayFrom: patterns.
 	sortsExt := self externalArrayFrom: sorts.
 	decl_namesExt := self externalArrayFrom: decl_names.
@@ -7662,6 +8250,8 @@ Z3 class >> mk_forall_const: c _: weight _: num_bound _: bound _: num_patterns _
 	"
 	| retval boundExt patternsExt |
 
+	c ensureValidZ3Object.
+	body ensureValidZ3Object.
 	boundExt := self externalArrayFrom: bound.
 	patternsExt := self externalArrayFrom: patterns.
 	retval := lib _mk_forall_const: c _: weight _: num_bound _: boundExt _: num_patterns _: patternsExt _: body.
@@ -7689,6 +8279,8 @@ Z3 class >> mk_fpa_abs: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_abs: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7716,6 +8308,10 @@ Z3 class >> mk_fpa_add: c _: rm _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_fpa_add: c _: rm _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7743,6 +8339,10 @@ Z3 class >> mk_fpa_div: c _: rm _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_fpa_div: c _: rm _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7771,6 +8371,9 @@ Z3 class >> mk_fpa_eq: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_fpa_eq: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7801,6 +8404,11 @@ Z3 class >> mk_fpa_fma: c _: rm _: t1 _: t2 _: t3 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
+	t3 ensureValidZ3Object.
 	retval := lib _mk_fpa_fma: c _: rm _: t1 _: t2 _: t3.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7839,6 +8447,10 @@ Z3 class >> mk_fpa_fp: c _: sgn _: exp _: sig [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	sgn ensureValidZ3Object.
+	exp ensureValidZ3Object.
+	sig ensureValidZ3Object.
 	retval := lib _mk_fpa_fp: c _: sgn _: exp _: sig.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7865,6 +8477,9 @@ Z3 class >> mk_fpa_geq: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_fpa_geq: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7891,6 +8506,9 @@ Z3 class >> mk_fpa_gt: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_fpa_gt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7920,6 +8538,8 @@ Z3 class >> mk_fpa_inf: c _: s _: negative [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_fpa_inf: c _: s _: negative.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7945,6 +8565,8 @@ Z3 class >> mk_fpa_is_infinite: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_is_infinite: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7970,6 +8592,8 @@ Z3 class >> mk_fpa_is_nan: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_is_nan: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7995,6 +8619,8 @@ Z3 class >> mk_fpa_is_negative: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_is_negative: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8020,6 +8646,8 @@ Z3 class >> mk_fpa_is_normal: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_is_normal: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8045,6 +8673,8 @@ Z3 class >> mk_fpa_is_positive: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_is_positive: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8070,6 +8700,8 @@ Z3 class >> mk_fpa_is_subnormal: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_is_subnormal: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8095,6 +8727,8 @@ Z3 class >> mk_fpa_is_zero: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_is_zero: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8121,6 +8755,9 @@ Z3 class >> mk_fpa_leq: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_fpa_leq: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8147,6 +8784,9 @@ Z3 class >> mk_fpa_lt: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_fpa_lt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8173,6 +8813,9 @@ Z3 class >> mk_fpa_max: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_fpa_max: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8199,6 +8842,9 @@ Z3 class >> mk_fpa_min: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_fpa_min: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8226,6 +8872,10 @@ Z3 class >> mk_fpa_mul: c _: rm _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_fpa_mul: c _: rm _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8252,6 +8902,8 @@ Z3 class >> mk_fpa_nan: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_fpa_nan: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8275,6 +8927,8 @@ Z3 class >> mk_fpa_neg: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_neg: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8311,6 +8965,8 @@ Z3 class >> mk_fpa_numeral_double: c _: v _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_fpa_numeral_double: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8347,6 +9003,8 @@ Z3 class >> mk_fpa_numeral_float: c _: v _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_fpa_numeral_float: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8382,6 +9040,8 @@ Z3 class >> mk_fpa_numeral_int64_uint64: c _: sgn _: exp _: sig _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_fpa_numeral_int64_uint64: c _: sgn _: exp _: sig _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8415,6 +9075,8 @@ Z3 class >> mk_fpa_numeral_int: c _: v _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_fpa_numeral_int: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8450,6 +9112,8 @@ Z3 class >> mk_fpa_numeral_int_uint: c _: sgn _: exp _: sig _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_fpa_numeral_int_uint: c _: sgn _: exp _: sig _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8476,6 +9140,9 @@ Z3 class >> mk_fpa_rem: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_fpa_rem: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8498,6 +9165,7 @@ Z3 class >> mk_fpa_rna: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_rna: c.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8520,6 +9188,7 @@ Z3 class >> mk_fpa_rne: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_rne: c.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8542,6 +9211,7 @@ Z3 class >> mk_fpa_round_nearest_ties_to_away: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_round_nearest_ties_to_away: c.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8564,6 +9234,7 @@ Z3 class >> mk_fpa_round_nearest_ties_to_even: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_round_nearest_ties_to_even: c.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8591,6 +9262,9 @@ Z3 class >> mk_fpa_round_to_integral: c _: rm _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_round_to_integral: c _: rm _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8613,6 +9287,7 @@ Z3 class >> mk_fpa_round_toward_negative: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_round_toward_negative: c.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8635,6 +9310,7 @@ Z3 class >> mk_fpa_round_toward_positive: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_round_toward_positive: c.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8657,6 +9333,7 @@ Z3 class >> mk_fpa_round_toward_zero: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_round_toward_zero: c.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8679,6 +9356,7 @@ Z3 class >> mk_fpa_rounding_mode_sort: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_rounding_mode_sort: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -8701,6 +9379,7 @@ Z3 class >> mk_fpa_rtn: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_rtn: c.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8723,6 +9402,7 @@ Z3 class >> mk_fpa_rtp: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_rtp: c.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8745,6 +9425,7 @@ Z3 class >> mk_fpa_rtz: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_rtz: c.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8771,6 +9452,7 @@ Z3 class >> mk_fpa_sort: c _: ebits _: sbits [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_sort: c _: ebits _: sbits.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -8793,6 +9475,7 @@ Z3 class >> mk_fpa_sort_128: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_sort_128: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -8815,6 +9498,7 @@ Z3 class >> mk_fpa_sort_16: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_sort_16: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -8837,6 +9521,7 @@ Z3 class >> mk_fpa_sort_32: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_sort_32: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -8859,6 +9544,7 @@ Z3 class >> mk_fpa_sort_64: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_sort_64: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -8881,6 +9567,7 @@ Z3 class >> mk_fpa_sort_double: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_sort_double: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -8903,6 +9590,7 @@ Z3 class >> mk_fpa_sort_half: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_sort_half: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -8925,6 +9613,7 @@ Z3 class >> mk_fpa_sort_quadruple: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_sort_quadruple: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -8947,6 +9636,7 @@ Z3 class >> mk_fpa_sort_single: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_fpa_sort_single: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -8973,6 +9663,9 @@ Z3 class >> mk_fpa_sqrt: c _: rm _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_sqrt: c _: rm _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9000,6 +9693,10 @@ Z3 class >> mk_fpa_sub: c _: rm _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_fpa_sub: c _: rm _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9031,6 +9728,9 @@ Z3 class >> mk_fpa_to_fp_bv: c _: bv _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	bv ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_fpa_to_fp_bv: c _: bv _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9062,6 +9762,10 @@ Z3 class >> mk_fpa_to_fp_float: c _: rm _: t _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_fpa_to_fp_float: c _: rm _: t _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9094,6 +9798,11 @@ Z3 class >> mk_fpa_to_fp_int_real: c _: rm _: exp _: sig _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	exp ensureValidZ3Object.
+	sig ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_fpa_to_fp_int_real: c _: rm _: exp _: sig _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9125,6 +9834,10 @@ Z3 class >> mk_fpa_to_fp_real: c _: rm _: t _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_fpa_to_fp_real: c _: rm _: t _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9157,6 +9870,10 @@ Z3 class >> mk_fpa_to_fp_signed: c _: rm _: t _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_fpa_to_fp_signed: c _: rm _: t _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9189,6 +9906,10 @@ Z3 class >> mk_fpa_to_fp_unsigned: c _: rm _: t _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_fpa_to_fp_unsigned: c _: rm _: t _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9219,6 +9940,8 @@ Z3 class >> mk_fpa_to_ieee_bv: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_to_ieee_bv: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9246,6 +9969,8 @@ Z3 class >> mk_fpa_to_real: c _: t [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_to_real: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9275,6 +10000,9 @@ Z3 class >> mk_fpa_to_sbv: c _: rm _: t _: sz [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_to_sbv: c _: rm _: t _: sz.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9304,6 +10032,9 @@ Z3 class >> mk_fpa_to_ubv: c _: rm _: t _: sz [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	rm ensureValidZ3Object.
+	t ensureValidZ3Object.
 	retval := lib _mk_fpa_to_ubv: c _: rm _: t _: sz.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9333,6 +10064,8 @@ Z3 class >> mk_fpa_zero: c _: s _: negative [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_fpa_zero: c _: s _: negative.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9363,6 +10096,8 @@ Z3 class >> mk_fresh_const: c _: prefix _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_fresh_const: c _: prefix _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9390,6 +10125,8 @@ Z3 class >> mk_fresh_func_decl: c _: prefix _: domain_size _: domain _: range [
 	"
 	| retval domainExt |
 
+	c ensureValidZ3Object.
+	range ensureValidZ3Object.
 	domainExt := self externalArrayFrom: domain.
 	retval := lib _mk_fresh_func_decl: c _: prefix _: domain_size _: domainExt _: range.
 	domainExt notNil ifTrue:[domainExt free].
@@ -9412,6 +10149,8 @@ Z3 class >> mk_full_set: c _: domain [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	domain ensureValidZ3Object.
 	retval := lib _mk_full_set: c _: domain.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9446,6 +10185,9 @@ Z3 class >> mk_func_decl: c _: s _: domain_size _: domain _: range [
 	"
 	| retval domainExt |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	range ensureValidZ3Object.
 	domainExt := self externalArrayFrom: domain.
 	retval := lib _mk_func_decl: c _: s _: domain_size _: domainExt _: range.
 	domainExt notNil ifTrue:[domainExt free].
@@ -9470,6 +10212,9 @@ Z3 class >> mk_ge: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_ge: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9519,6 +10264,9 @@ Z3 class >> mk_gt: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_gt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9541,6 +10289,9 @@ Z3 class >> mk_iff: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_iff: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9563,6 +10314,9 @@ Z3 class >> mk_implies: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_implies: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9588,6 +10342,8 @@ Z3 class >> mk_int2bv: c _: n _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_int2bv: c _: n _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9620,6 +10376,8 @@ Z3 class >> mk_int2real: c _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_int2real: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9645,6 +10403,8 @@ Z3 class >> mk_int64: c _: v _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_int64: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9670,6 +10430,8 @@ Z3 class >> mk_int: c _: v _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_int: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9696,6 +10458,7 @@ Z3 class >> mk_int_sort: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_int_sort: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -9724,6 +10487,7 @@ Z3 class >> mk_int_symbol: c _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_int_symbol: c _: i.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -9744,6 +10508,8 @@ Z3 class >> mk_int_to_str: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_int_to_str: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9767,6 +10533,8 @@ Z3 class >> mk_is_int: c _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_is_int: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9790,6 +10558,10 @@ Z3 class >> mk_ite: c _: t1 _: t2 _: t3 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
+	t3 ensureValidZ3Object.
 	retval := lib _mk_ite: c _: t1 _: t2 _: t3.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9828,6 +10600,8 @@ Z3 class >> mk_lambda: c _: num_decls _: sorts _: decl_names _: body [
 	"
 	| retval sortsExt decl_namesExt |
 
+	c ensureValidZ3Object.
+	body ensureValidZ3Object.
 	sortsExt := self externalArrayFrom: sorts.
 	decl_namesExt := self externalArrayFrom: decl_names.
 	retval := lib _mk_lambda: c _: num_decls _: sortsExt _: decl_namesExt _: body.
@@ -9862,6 +10636,8 @@ Z3 class >> mk_lambda_const: c _: num_bound _: bound _: body [
 	"
 	| retval boundExt |
 
+	c ensureValidZ3Object.
+	body ensureValidZ3Object.
 	boundExt := self externalArrayFrom: bound.
 	retval := lib _mk_lambda_const: c _: num_bound _: boundExt _: body.
 	boundExt notNil ifTrue:[boundExt free].
@@ -9886,6 +10662,9 @@ Z3 class >> mk_le: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_le: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9907,6 +10686,8 @@ Z3 class >> mk_linear_order: c _: a _: id [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _mk_linear_order: c _: a _: id.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9940,6 +10721,9 @@ Z3 class >> mk_list_sort: c _: name _: elem_sort _: nil_decl _: is_nil_decl _: c
 	"
 	| retval nil_declExt is_nil_declExt cons_declExt is_cons_declExt head_declExt tail_declExt |
 
+	c ensureValidZ3Object.
+	name ensureValidZ3Object.
+	elem_sort ensureValidZ3Object.
 	nil_declExt := self externalArrayFrom: nil_decl.
 	is_nil_declExt := self externalArrayFrom: is_nil_decl.
 	cons_declExt := self externalArrayFrom: cons_decl.
@@ -10011,6 +10795,7 @@ Z3 class >> mk_lstring: c _: len _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_lstring: c _: len _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10033,6 +10818,9 @@ Z3 class >> mk_lt: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_lt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10061,6 +10849,8 @@ Z3 class >> mk_map: c _: f _: n _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_map: c _: f _: n _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -10085,6 +10875,9 @@ Z3 class >> mk_mod: c _: arg1 _: arg2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	arg1 ensureValidZ3Object.
+	arg2 ensureValidZ3Object.
 	retval := lib _mk_mod: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10105,6 +10898,7 @@ Z3 class >> mk_model: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_model: c.
 	c errorCheck.
 	^ Z3Model fromExternalAddress: retval inContext: c.
@@ -10131,6 +10925,7 @@ Z3 class >> mk_mul: c _: num_args _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_mul: c _: num_args _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -10155,6 +10950,8 @@ Z3 class >> mk_not: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _mk_not: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10183,6 +10980,8 @@ Z3 class >> mk_numeral: c _: numeral _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_numeral: c _: numeral _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10226,6 +11025,7 @@ Z3 class >> mk_or: c _: num_args _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_or: c _: num_args _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -10253,6 +11053,7 @@ Z3 class >> mk_params: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_params: c.
 	c errorCheck.
 	^ Z3ParameterSet fromExternalAddress: retval inContext: c.
@@ -10273,6 +11074,8 @@ Z3 class >> mk_partial_order: c _: a _: id [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _mk_partial_order: c _: a _: id.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10308,6 +11111,7 @@ Z3 class >> mk_pattern: c _: num_patterns _: terms [
 	"
 	| retval termsExt |
 
+	c ensureValidZ3Object.
 	termsExt := self externalArrayFrom: terms.
 	retval := lib _mk_pattern: c _: num_patterns _: termsExt.
 	termsExt notNil ifTrue:[termsExt free].
@@ -10381,6 +11185,8 @@ Z3 class >> mk_piecewise_linear_order: c _: a _: id [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _mk_piecewise_linear_order: c _: a _: id.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10403,6 +11209,9 @@ Z3 class >> mk_power: c _: arg1 _: arg2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	arg1 ensureValidZ3Object.
+	arg2 ensureValidZ3Object.
 	retval := lib _mk_power: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10459,6 +11268,8 @@ Z3 class >> mk_quantifier: c _: is_forall _: weight _: num_patterns _: patterns 
 	"
 	| retval patternsExt sortsExt decl_namesExt |
 
+	c ensureValidZ3Object.
+	body ensureValidZ3Object.
 	patternsExt := self externalArrayFrom: patterns.
 	sortsExt := self externalArrayFrom: sorts.
 	decl_namesExt := self externalArrayFrom: decl_names.
@@ -10486,6 +11297,8 @@ Z3 class >> mk_quantifier_const: c _: is_forall _: weight _: num_bound _: bound 
 	"
 	| retval boundExt patternsExt |
 
+	c ensureValidZ3Object.
+	body ensureValidZ3Object.
 	boundExt := self externalArrayFrom: bound.
 	patternsExt := self externalArrayFrom: patterns.
 	retval := lib _mk_quantifier_const: c _: is_forall _: weight _: num_bound _: boundExt _: num_patterns _: patternsExt _: body.
@@ -10511,6 +11324,10 @@ Z3 class >> mk_quantifier_const_ex: c _: is_forall _: weight _: quantifier_id _:
 	"
 	| retval boundExt patternsExt no_patternsExt |
 
+	c ensureValidZ3Object.
+	quantifier_id ensureValidZ3Object.
+	skolem_id ensureValidZ3Object.
+	body ensureValidZ3Object.
 	boundExt := self externalArrayFrom: bound.
 	patternsExt := self externalArrayFrom: patterns.
 	no_patternsExt := self externalArrayFrom: no_patterns.
@@ -10556,6 +11373,10 @@ Z3 class >> mk_quantifier_ex: c _: is_forall _: weight _: quantifier_id _: skole
 	"
 	| retval patternsExt no_patternsExt sortsExt decl_namesExt |
 
+	c ensureValidZ3Object.
+	quantifier_id ensureValidZ3Object.
+	skolem_id ensureValidZ3Object.
+	body ensureValidZ3Object.
 	patternsExt := self externalArrayFrom: patterns.
 	no_patternsExt := self externalArrayFrom: no_patterns.
 	sortsExt := self externalArrayFrom: sorts.
@@ -10584,6 +11405,8 @@ Z3 class >> mk_re_allchar: c _: regex_sort [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	regex_sort ensureValidZ3Object.
 	retval := lib _mk_re_allchar: c _: regex_sort.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10604,6 +11427,8 @@ Z3 class >> mk_re_complement: c _: re [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	re ensureValidZ3Object.
 	retval := lib _mk_re_complement: c _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10626,6 +11451,7 @@ Z3 class >> mk_re_concat: c _: n _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_re_concat: c _: n _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -10648,6 +11474,9 @@ Z3 class >> mk_re_diff: c _: re1 _: re2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	re1 ensureValidZ3Object.
+	re2 ensureValidZ3Object.
 	retval := lib _mk_re_diff: c _: re1 _: re2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10670,6 +11499,8 @@ Z3 class >> mk_re_empty: c _: re [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	re ensureValidZ3Object.
 	retval := lib _mk_re_empty: c _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10692,6 +11523,8 @@ Z3 class >> mk_re_full: c _: re [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	re ensureValidZ3Object.
 	retval := lib _mk_re_full: c _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10714,6 +11547,7 @@ Z3 class >> mk_re_intersect: c _: n _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_re_intersect: c _: n _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -10739,6 +11573,8 @@ Z3 class >> mk_re_loop: c _: r _: lo _: hi [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	r ensureValidZ3Object.
 	retval := lib _mk_re_loop: c _: r _: lo _: hi.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10759,6 +11595,8 @@ Z3 class >> mk_re_option: c _: re [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	re ensureValidZ3Object.
 	retval := lib _mk_re_option: c _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10779,6 +11617,8 @@ Z3 class >> mk_re_plus: c _: re [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	re ensureValidZ3Object.
 	retval := lib _mk_re_plus: c _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10799,6 +11639,8 @@ Z3 class >> mk_re_power: c _: arg1 _: n [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	arg1 ensureValidZ3Object.
 	retval := lib _mk_re_power: c _: arg1 _: n.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10819,6 +11661,9 @@ Z3 class >> mk_re_range: c _: lo _: hi [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	lo ensureValidZ3Object.
+	hi ensureValidZ3Object.
 	retval := lib _mk_re_range: c _: lo _: hi.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10839,6 +11684,8 @@ Z3 class >> mk_re_sort: c _: seq [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	seq ensureValidZ3Object.
 	retval := lib _mk_re_sort: c _: seq.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -10859,6 +11706,8 @@ Z3 class >> mk_re_star: c _: re [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	re ensureValidZ3Object.
 	retval := lib _mk_re_star: c _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10881,6 +11730,7 @@ Z3 class >> mk_re_union: c _: n _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_re_union: c _: n _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -10909,6 +11759,8 @@ Z3 class >> mk_real2int: c _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_real2int: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10939,6 +11791,7 @@ Z3 class >> mk_real: c _: num _: den [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_real: c _: num _: den.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10961,6 +11814,7 @@ Z3 class >> mk_real_sort: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_real_sort: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -10995,6 +11849,9 @@ Z3 class >> mk_rec_func_decl: c _: s _: domain_size _: domain _: range [
 	"
 	| retval domainExt |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	range ensureValidZ3Object.
 	domainExt := self externalArrayFrom: domain.
 	retval := lib _mk_rec_func_decl: c _: s _: domain_size _: domainExt _: range.
 	domainExt notNil ifTrue:[domainExt free].
@@ -11019,6 +11876,9 @@ Z3 class >> mk_rem: c _: arg1 _: arg2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	arg1 ensureValidZ3Object.
+	arg2 ensureValidZ3Object.
 	retval := lib _mk_rem: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11041,6 +11901,8 @@ Z3 class >> mk_repeat: c _: i _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_repeat: c _: i _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11063,6 +11925,8 @@ Z3 class >> mk_rotate_left: c _: i _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_rotate_left: c _: i _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11085,6 +11949,8 @@ Z3 class >> mk_rotate_right: c _: i _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_rotate_right: c _: i _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11105,6 +11971,8 @@ Z3 class >> mk_sbv_to_str: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_sbv_to_str: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11133,6 +12001,9 @@ Z3 class >> mk_select: c _: a _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	i ensureValidZ3Object.
 	retval := lib _mk_select: c _: a _: i.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11155,6 +12026,8 @@ Z3 class >> mk_select_n: c _: a _: n _: idxs [
 	"
 	| retval idxsExt |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	idxsExt := self externalArrayFrom: idxs.
 	retval := lib _mk_select_n: c _: a _: n _: idxsExt.
 	idxsExt notNil ifTrue:[idxsExt free].
@@ -11178,6 +12051,9 @@ Z3 class >> mk_seq_at: c _: s _: index [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	index ensureValidZ3Object.
 	retval := lib _mk_seq_at: c _: s _: index.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11200,6 +12076,7 @@ Z3 class >> mk_seq_concat: c _: n _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_seq_concat: c _: n _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -11224,6 +12101,9 @@ Z3 class >> mk_seq_contains: c _: container _: containee [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	container ensureValidZ3Object.
+	containee ensureValidZ3Object.
 	retval := lib _mk_seq_contains: c _: container _: containee.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11246,6 +12126,8 @@ Z3 class >> mk_seq_empty: c _: seq [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	seq ensureValidZ3Object.
 	retval := lib _mk_seq_empty: c _: seq.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11266,6 +12148,10 @@ Z3 class >> mk_seq_extract: c _: s _: offset _: length [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	offset ensureValidZ3Object.
+	length ensureValidZ3Object.
 	retval := lib _mk_seq_extract: c _: s _: offset _: length.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11286,6 +12172,9 @@ Z3 class >> mk_seq_in_re: c _: seq _: re [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	seq ensureValidZ3Object.
+	re ensureValidZ3Object.
 	retval := lib _mk_seq_in_re: c _: seq _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11308,6 +12197,10 @@ Z3 class >> mk_seq_index: c _: s _: substr _: offset [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	substr ensureValidZ3Object.
+	offset ensureValidZ3Object.
 	retval := lib _mk_seq_index: c _: s _: substr _: offset.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11328,6 +12221,9 @@ Z3 class >> mk_seq_last_index: c _: arg1 _: substr [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	arg1 ensureValidZ3Object.
+	substr ensureValidZ3Object.
 	retval := lib _mk_seq_last_index: c _: arg1 _: substr.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11348,6 +12244,8 @@ Z3 class >> mk_seq_length: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_seq_length: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11369,6 +12267,9 @@ Z3 class >> mk_seq_nth: c _: s _: index [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	index ensureValidZ3Object.
 	retval := lib _mk_seq_nth: c _: s _: index.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11391,6 +12292,9 @@ Z3 class >> mk_seq_prefix: c _: prefix _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	prefix ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_seq_prefix: c _: prefix _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11411,6 +12315,10 @@ Z3 class >> mk_seq_replace: c _: s _: src _: dst [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	src ensureValidZ3Object.
+	dst ensureValidZ3Object.
 	retval := lib _mk_seq_replace: c _: s _: src _: dst.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11431,6 +12339,8 @@ Z3 class >> mk_seq_sort: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_seq_sort: c _: s.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -11453,6 +12363,9 @@ Z3 class >> mk_seq_suffix: c _: suffix _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	suffix ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_seq_suffix: c _: suffix _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11473,6 +12386,8 @@ Z3 class >> mk_seq_to_re: c _: seq [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	seq ensureValidZ3Object.
 	retval := lib _mk_seq_to_re: c _: seq.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11493,6 +12408,8 @@ Z3 class >> mk_seq_unit: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _mk_seq_unit: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11515,6 +12432,9 @@ Z3 class >> mk_set_add: c _: set _: elem [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	set ensureValidZ3Object.
+	elem ensureValidZ3Object.
 	retval := lib _mk_set_add: c _: set _: elem.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11535,6 +12455,8 @@ Z3 class >> mk_set_complement: c _: arg [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	arg ensureValidZ3Object.
 	retval := lib _mk_set_complement: c _: arg.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11557,6 +12479,9 @@ Z3 class >> mk_set_del: c _: set _: elem [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	set ensureValidZ3Object.
+	elem ensureValidZ3Object.
 	retval := lib _mk_set_del: c _: set _: elem.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11577,6 +12502,9 @@ Z3 class >> mk_set_difference: c _: arg1 _: arg2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	arg1 ensureValidZ3Object.
+	arg2 ensureValidZ3Object.
 	retval := lib _mk_set_difference: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11597,6 +12525,9 @@ Z3 class >> mk_set_has_size: c _: set _: k [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	set ensureValidZ3Object.
+	k ensureValidZ3Object.
 	retval := lib _mk_set_has_size: c _: set _: k.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11617,6 +12548,7 @@ Z3 class >> mk_set_intersect: c _: num_args _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_set_intersect: c _: num_args _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -11641,6 +12573,9 @@ Z3 class >> mk_set_member: c _: elem _: set [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	elem ensureValidZ3Object.
+	set ensureValidZ3Object.
 	retval := lib _mk_set_member: c _: elem _: set.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11661,6 +12596,8 @@ Z3 class >> mk_set_sort: c _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_set_sort: c _: ty.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -11681,6 +12618,9 @@ Z3 class >> mk_set_subset: c _: arg1 _: arg2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	arg1 ensureValidZ3Object.
+	arg2 ensureValidZ3Object.
 	retval := lib _mk_set_subset: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11701,6 +12641,7 @@ Z3 class >> mk_set_union: c _: num_args _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_set_union: c _: num_args _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -11727,6 +12668,8 @@ Z3 class >> mk_sign_ext: c _: i _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_sign_ext: c _: i _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11767,6 +12710,7 @@ Z3 class >> mk_simple_solver: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_simple_solver: c.
 	c errorCheck.
 	^ Z3Solver fromExternalAddress: retval inContext: c.
@@ -11818,6 +12762,7 @@ Z3 class >> mk_solver: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_solver: c.
 	c errorCheck.
 	^ Z3Solver fromExternalAddress: retval inContext: c.
@@ -11842,6 +12787,8 @@ Z3 class >> mk_solver_for_logic: c _: logic [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	logic ensureValidZ3Object.
 	retval := lib _mk_solver_for_logic: c _: logic.
 	c errorCheck.
 	^ Z3Solver fromExternalAddress: retval inContext: c.
@@ -11893,6 +12840,10 @@ Z3 class >> mk_store: c _: a _: i _: v [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	i ensureValidZ3Object.
+	v ensureValidZ3Object.
 	retval := lib _mk_store: c _: a _: i _: v.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11914,6 +12865,9 @@ Z3 class >> mk_store_n: c _: a _: n _: idxs _: v [
 	"
 	| retval idxsExt |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	v ensureValidZ3Object.
 	idxsExt := self externalArrayFrom: idxs.
 	retval := lib _mk_store_n: c _: a _: n _: idxsExt _: v.
 	idxsExt notNil ifTrue:[idxsExt free].
@@ -11938,6 +12892,9 @@ Z3 class >> mk_str_le: c _: prefix _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	prefix ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_str_le: c _: prefix _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11960,6 +12917,9 @@ Z3 class >> mk_str_lt: c _: prefix _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	prefix ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_str_lt: c _: prefix _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11980,6 +12940,8 @@ Z3 class >> mk_str_to_int: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_str_to_int: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12004,6 +12966,7 @@ Z3 class >> mk_string: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_string: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12024,6 +12987,8 @@ Z3 class >> mk_string_from_code: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _mk_string_from_code: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12048,6 +13013,7 @@ Z3 class >> mk_string_sort: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_string_sort: c.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -12073,6 +13039,7 @@ Z3 class >> mk_string_symbol: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_string_symbol: c _: s.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -12093,6 +13060,8 @@ Z3 class >> mk_string_to_code: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _mk_string_to_code: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12118,6 +13087,7 @@ Z3 class >> mk_sub: c _: num_args _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_sub: c _: num_args _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].
@@ -12163,6 +13133,8 @@ Z3 class >> mk_transitive_closure: c _: f [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	f ensureValidZ3Object.
 	retval := lib _mk_transitive_closure: c _: f.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12183,6 +13155,8 @@ Z3 class >> mk_tree_order: c _: a _: id [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _mk_tree_order: c _: a _: id.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12203,6 +13177,7 @@ Z3 class >> mk_true: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _mk_true: c.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12234,6 +13209,8 @@ Z3 class >> mk_tuple_sort: c _: mk_tuple_name _: num_fields _: field_names _: fi
 	"
 	| retval field_namesExt field_sortsExt mk_tuple_declExt proj_declExt |
 
+	c ensureValidZ3Object.
+	mk_tuple_name ensureValidZ3Object.
 	field_namesExt := self externalArrayFrom: field_names.
 	field_sortsExt := self externalArrayFrom: field_sorts.
 	mk_tuple_declExt := self externalArrayFrom: mk_tuple_decl.
@@ -12276,6 +13253,7 @@ Z3 class >> mk_u32string: c _: len _: chars [
 	"
 	| retval charsExt |
 
+	c ensureValidZ3Object.
 	charsExt := Z3Object externalU32ArrayFrom: chars.
 	retval := lib _mk_u32string: c _: len _: charsExt.
 	charsExt notNil ifTrue:[charsExt free].
@@ -12298,6 +13276,8 @@ Z3 class >> mk_ubv_to_str: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_ubv_to_str: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12320,6 +13300,8 @@ Z3 class >> mk_unary_minus: c _: arg [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	arg ensureValidZ3Object.
 	retval := lib _mk_unary_minus: c _: arg.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12342,6 +13324,8 @@ Z3 class >> mk_uninterpreted_sort: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _mk_uninterpreted_sort: c _: s.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -12367,6 +13351,8 @@ Z3 class >> mk_unsigned_int64: c _: v _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_unsigned_int64: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12392,6 +13378,8 @@ Z3 class >> mk_unsigned_int: c _: v _: ty [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	ty ensureValidZ3Object.
 	retval := lib _mk_unsigned_int: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12414,6 +13402,9 @@ Z3 class >> mk_xor: c _: t1 _: t2 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
+	t2 ensureValidZ3Object.
 	retval := lib _mk_xor: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12438,6 +13429,8 @@ Z3 class >> mk_zero_ext: c _: i _: t1 [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	t1 ensureValidZ3Object.
 	retval := lib _mk_zero_ext: c _: i _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12458,6 +13451,8 @@ Z3 class >> model_dec_ref: c _: m [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
 	retval := lib _model_dec_ref: c _: m.
 	c errorCheck.
 	^ retval
@@ -12495,6 +13490,9 @@ Z3 class >> model_eval: c _: m _: t _: model_completion _: v [
 	"
 	| retval vExt |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
+	t ensureValidZ3Object.
 	vExt := self externalArrayFrom: v.
 	retval := lib _model_eval: c _: m _: t _: model_completion _: vExt.
 	1 to: v size do: [ :i |
@@ -12522,6 +13520,9 @@ Z3 class >> model_extrapolate: c _: m _: fml [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
+	fml ensureValidZ3Object.
 	retval := lib _model_extrapolate: c _: m _: fml.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12546,6 +13547,8 @@ Z3 class >> model_get_const_decl: c _: m _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
 	retval := lib _model_get_const_decl: c _: m _: i.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12570,6 +13573,9 @@ Z3 class >> model_get_const_interp: c _: m _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _model_get_const_interp: c _: m _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12594,6 +13600,8 @@ Z3 class >> model_get_func_decl: c _: m _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
 	retval := lib _model_get_func_decl: c _: m _: i.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12638,6 +13646,8 @@ Z3 class >> model_get_num_consts: c _: m [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
 	retval := lib _model_get_num_consts: c _: m.
 	c errorCheck.
 	^ retval
@@ -12660,6 +13670,8 @@ Z3 class >> model_get_num_funcs: c _: m [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
 	retval := lib _model_get_num_funcs: c _: m.
 	c errorCheck.
 	^ retval
@@ -12686,6 +13698,8 @@ Z3 class >> model_get_num_sorts: c _: m [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
 	retval := lib _model_get_num_sorts: c _: m.
 	c errorCheck.
 	^ retval
@@ -12710,6 +13724,8 @@ Z3 class >> model_get_sort: c _: m _: i [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
 	retval := lib _model_get_sort: c _: m _: i.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -12733,6 +13749,9 @@ Z3 class >> model_get_sort_universe: c _: m _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _model_get_sort_universe: c _: m _: s.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -12753,6 +13772,9 @@ Z3 class >> model_has_interp: c _: m _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _model_has_interp: c _: m _: a.
 	c errorCheck.
 	^ retval
@@ -12772,6 +13794,8 @@ Z3 class >> model_inc_ref: c _: m [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
 	retval := lib _model_inc_ref: c _: m.
 	c errorCheck.
 	^ retval
@@ -12795,6 +13819,8 @@ Z3 class >> model_to_string: c _: m [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
 	retval := lib _model_to_string: c _: m.
 	c errorCheck.
 	^ retval
@@ -12818,6 +13844,9 @@ Z3 class >> model_translate: c _: m _: dst [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
+	dst ensureValidZ3Object.
 	retval := lib _model_translate: c _: m _: dst.
 	c errorCheck.
 	^ Z3Model fromExternalAddress: retval inContext: c.
@@ -13448,6 +14477,8 @@ Z3 class >> params_dec_ref: c _: p [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
 	retval := lib _params_dec_ref: c _: p.
 	c errorCheck.
 	^ retval
@@ -13467,6 +14498,8 @@ Z3 class >> params_inc_ref: c _: p [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
 	retval := lib _params_inc_ref: c _: p.
 	c errorCheck.
 	^ retval
@@ -13486,6 +14519,9 @@ Z3 class >> params_set_bool: c _: p _: k _: v [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
+	k ensureValidZ3Object.
 	retval := lib _params_set_bool: c _: p _: k _: v.
 	c errorCheck.
 	^ retval
@@ -13505,6 +14541,9 @@ Z3 class >> params_set_double: c _: p _: k _: v [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
+	k ensureValidZ3Object.
 	retval := lib _params_set_double: c _: p _: k _: v.
 	c errorCheck.
 	^ retval
@@ -13524,6 +14563,10 @@ Z3 class >> params_set_symbol: c _: p _: k _: v [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
+	k ensureValidZ3Object.
+	v ensureValidZ3Object.
 	retval := lib _params_set_symbol: c _: p _: k _: v.
 	c errorCheck.
 	^ retval
@@ -13543,6 +14586,9 @@ Z3 class >> params_set_uint: c _: p _: k _: v [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
+	k ensureValidZ3Object.
 	retval := lib _params_set_uint: c _: p _: k _: v.
 	c errorCheck.
 	^ retval
@@ -13563,6 +14609,8 @@ Z3 class >> params_to_string: c _: p [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
 	retval := lib _params_to_string: c _: p.
 	c errorCheck.
 	^ retval
@@ -13599,6 +14647,7 @@ Z3 class >> parse_smtlib2_file: c _: file_name _: num_sorts _: sort_names _: sor
 	"
 	| retval sort_namesExt sortsExt decl_namesExt declsExt |
 
+	c ensureValidZ3Object.
 	sort_namesExt := self externalArrayFrom: sort_names.
 	sortsExt := self externalArrayFrom: sorts.
 	decl_namesExt := self externalArrayFrom: decl_names.
@@ -13630,6 +14679,7 @@ Z3 class >> parse_smtlib2_string: c _: str _: num_sorts _: sort_names _: sorts _
 	"
 	| retval sort_namesExt sortsExt decl_namesExt declsExt |
 
+	c ensureValidZ3Object.
 	sort_namesExt := self externalArrayFrom: sort_names.
 	sortsExt := self externalArrayFrom: sorts.
 	decl_namesExt := self externalArrayFrom: decl_names.
@@ -13658,6 +14708,8 @@ Z3 class >> pattern_to_ast: c _: p [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
 	retval := lib _pattern_to_ast: c _: p.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13676,6 +14728,8 @@ Z3 class >> pattern_to_string: c _: p [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
 	retval := lib _pattern_to_string: c _: p.
 	c errorCheck.
 	^ retval
@@ -13700,6 +14754,10 @@ Z3 class >> polynomial_subresultants: c _: p _: q _: x [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	p ensureValidZ3Object.
+	q ensureValidZ3Object.
+	x ensureValidZ3Object.
 	retval := lib _polynomial_subresultants: c _: p _: q _: x.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -13817,6 +14875,7 @@ Z3 class >> probe_get_descr: c _: name [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _probe_get_descr: c _: name.
 	c errorCheck.
 	^ retval
@@ -13936,6 +14995,9 @@ Z3 class >> qe_model_project: c _: m _: num_bounds _: bound _: body [
 	"
 	| retval boundExt |
 
+	c ensureValidZ3Object.
+	m ensureValidZ3Object.
+	body ensureValidZ3Object.
 	boundExt := self externalArrayFrom: bound.
 	retval := lib _qe_model_project: c _: m _: num_bounds _: boundExt _: body.
 	boundExt notNil ifTrue:[boundExt free].
@@ -13982,6 +15044,8 @@ Z3 class >> query_constructor: c _: constr _: num_fields _: constructor _: teste
 	"
 	| retval constructorExt testerExt accessorsExt |
 
+	c ensureValidZ3Object.
+	constr ensureValidZ3Object.
 	constructorExt := self externalArrayFrom: constructor.
 	testerExt := self externalArrayFrom: tester.
 	accessorsExt := self externalArrayFrom: accessors.
@@ -14425,6 +15489,7 @@ Z3 class >> set_error: c _: e [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _set_error: c _: e.
 	c errorCheck.
 	^ retval
@@ -14469,6 +15534,7 @@ Z3 class >> set_param_value: c _: param_id _: param_value [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _set_param_value: c _: param_id _: param_value.
 	^ retval
 
@@ -14494,6 +15560,8 @@ Z3 class >> simplify: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _simplify: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -14522,6 +15590,9 @@ Z3 class >> simplify_ex: c _: a _: p [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
+	p ensureValidZ3Object.
 	retval := lib _simplify_ex: c _: a _: p.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -14545,6 +15616,7 @@ Z3 class >> simplify_get_help: c [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _simplify_get_help: c.
 	c errorCheck.
 	^ retval
@@ -14588,6 +15660,9 @@ Z3 class >> solver_assert: c _: s _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _solver_assert: c _: s _: a.
 	c errorCheck.
 	^ retval
@@ -14619,6 +15694,10 @@ Z3 class >> solver_assert_and_track: c _: s _: a _: p [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	a ensureValidZ3Object.
+	p ensureValidZ3Object.
 	retval := lib _solver_assert_and_track: c _: s _: a _: p.
 	c errorCheck.
 	^ retval
@@ -14651,6 +15730,8 @@ Z3 class >> solver_check: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_check: c _: s.
 	c errorCheck.
 	^ retval
@@ -14676,6 +15757,8 @@ Z3 class >> solver_check_assumptions: c _: s _: num_assumptions _: assumptions [
 	"
 	| retval assumptionsExt |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	assumptionsExt := self externalArrayFrom: assumptions.
 	retval := lib _solver_check_assumptions: c _: s _: num_assumptions _: assumptionsExt.
 	assumptionsExt notNil ifTrue:[assumptionsExt free].
@@ -14709,6 +15792,9 @@ Z3 class >> solver_cube: c _: s _: vars _: backtrack_level [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	vars ensureValidZ3Object.
 	retval := lib _solver_cube: c _: s _: vars _: backtrack_level.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -14729,6 +15815,8 @@ Z3 class >> solver_dec_ref: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_dec_ref: c _: s.
 	c errorCheck.
 	^ retval
@@ -14751,6 +15839,8 @@ Z3 class >> solver_from_file: c _: s _: file_name [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_from_file: c _: s _: file_name.
 	c errorCheck.
 	^ retval
@@ -14773,6 +15863,8 @@ Z3 class >> solver_from_string: c _: s _: file_name [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_from_string: c _: s _: file_name.
 	c errorCheck.
 	^ retval
@@ -14792,6 +15884,8 @@ Z3 class >> solver_get_assertions: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_get_assertions: c _: s.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -14812,6 +15906,11 @@ Z3 class >> solver_get_consequences: c _: s _: assumptions _: variables _: conse
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	assumptions ensureValidZ3Object.
+	variables ensureValidZ3Object.
+	consequences ensureValidZ3Object.
 	retval := lib _solver_get_consequences: c _: s _: assumptions _: variables _: consequences.
 	c errorCheck.
 	^ retval
@@ -14834,6 +15933,8 @@ Z3 class >> solver_get_help: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_get_help: c _: s.
 	c errorCheck.
 	^ retval
@@ -14854,6 +15955,9 @@ Z3 class >> solver_get_levels: c _: s _: literals _: sz _: levels [
 	"
 	| retval levelsExt |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	literals ensureValidZ3Object.
 	levelsExt := Z3Object externalU32ArrayFrom: levels.
 	retval := lib _solver_get_levels: c _: s _: literals _: sz _: levelsExt.
 	levelsExt notNil ifTrue:[levelsExt free].
@@ -14878,6 +15982,8 @@ Z3 class >> solver_get_model: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_get_model: c _: s.
 	c errorCheck.
 	^ Z3Model fromExternalAddress: retval inContext: c.
@@ -14898,6 +16004,8 @@ Z3 class >> solver_get_non_units: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_get_non_units: c _: s.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -14921,6 +16029,8 @@ Z3 class >> solver_get_num_scopes: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_get_num_scopes: c _: s.
 	c errorCheck.
 	^ retval
@@ -14962,6 +16072,8 @@ Z3 class >> solver_get_proof: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_get_proof: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -14983,6 +16095,8 @@ Z3 class >> solver_get_reason_unknown: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_get_reason_unknown: c _: s.
 	c errorCheck.
 	^ retval
@@ -15020,6 +16134,8 @@ Z3 class >> solver_get_trail: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_get_trail: c _: s.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -15040,6 +16156,8 @@ Z3 class >> solver_get_units: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_get_units: c _: s.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -15066,6 +16184,8 @@ Z3 class >> solver_get_unsat_core: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_get_unsat_core: c _: s.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -15094,6 +16214,9 @@ Z3 class >> solver_import_model_converter: ctx _: src _: dst [
 	"
 	| retval |
 
+	ctx ensureValidZ3Object.
+	src ensureValidZ3Object.
+	dst ensureValidZ3Object.
 	retval := lib _solver_import_model_converter: ctx _: src _: dst.
 	ctx errorCheck.
 	^ retval
@@ -15113,6 +16236,8 @@ Z3 class >> solver_inc_ref: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_inc_ref: c _: s.
 	c errorCheck.
 	^ retval
@@ -15137,6 +16262,8 @@ Z3 class >> solver_interrupt: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_interrupt: c _: s.
 	c errorCheck.
 	^ retval
@@ -15161,6 +16288,8 @@ Z3 class >> solver_pop: c _: s _: n [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_pop: c _: s _: n.
 	c errorCheck.
 	^ retval
@@ -15203,6 +16332,9 @@ Z3 class >> solver_propagate_declare: c _: name _: n _: domain _: range [
 	"
 	| retval domainExt |
 
+	c ensureValidZ3Object.
+	name ensureValidZ3Object.
+	range ensureValidZ3Object.
 	domainExt := self externalArrayFrom: domain.
 	retval := lib _solver_propagate_declare: c _: name _: n _: domainExt _: range.
 	domainExt notNil ifTrue:[domainExt free].
@@ -15226,6 +16358,9 @@ Z3 class >> solver_propagate_register: c _: s _: e [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	e ensureValidZ3Object.
 	retval := lib _solver_propagate_register: c _: s _: e.
 	c errorCheck.
 	^ retval
@@ -15268,6 +16403,8 @@ Z3 class >> solver_push: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_push: c _: s.
 	c errorCheck.
 	^ retval
@@ -15290,6 +16427,8 @@ Z3 class >> solver_reset: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_reset: c _: s.
 	c errorCheck.
 	^ retval
@@ -15312,6 +16451,9 @@ Z3 class >> solver_set_params: c _: s _: p [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
+	p ensureValidZ3Object.
 	retval := lib _solver_set_params: c _: s _: p.
 	c errorCheck.
 	^ retval
@@ -15332,6 +16474,8 @@ Z3 class >> solver_to_dimacs_string: c _: s _: include_names [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_to_dimacs_string: c _: s _: include_names.
 	c errorCheck.
 	^ retval
@@ -15354,6 +16498,8 @@ Z3 class >> solver_to_string: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _solver_to_string: c _: s.
 	c errorCheck.
 	^ retval
@@ -15373,6 +16519,9 @@ Z3 class >> solver_translate: source _: s _: target [
 	"
 	| retval |
 
+	source ensureValidZ3Object.
+	s ensureValidZ3Object.
+	target ensureValidZ3Object.
 	retval := lib _solver_translate: source _: s _: target.
 	source errorCheck.
 	^ Z3Solver fromExternalAddress: retval inContext: source.
@@ -15393,6 +16542,8 @@ Z3 class >> sort_to_ast: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _sort_to_ast: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -15411,6 +16562,8 @@ Z3 class >> sort_to_string: c _: s [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	s ensureValidZ3Object.
 	retval := lib _sort_to_string: c _: s.
 	c errorCheck.
 	^ retval
@@ -15577,6 +16730,8 @@ Z3 class >> substitute: c _: a _: num_exprs _: from _: to [
 	"
 	| retval fromExt toExt |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	fromExt := self externalArrayFrom: from.
 	toExt := self externalArrayFrom: to.
 	retval := lib _substitute: c _: a _: num_exprs _: fromExt _: toExt.
@@ -15602,6 +16757,8 @@ Z3 class >> substitute_vars: c _: a _: num_exprs _: to [
 	"
 	| retval toExt |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	toExt := self externalArrayFrom: to.
 	retval := lib _substitute_vars: c _: a _: num_exprs _: toExt.
 	toExt notNil ifTrue:[toExt free].
@@ -15747,6 +16904,7 @@ Z3 class >> tactic_get_descr: c _: name [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _tactic_get_descr: c _: name.
 	c errorCheck.
 	^ retval
@@ -15938,6 +17096,8 @@ Z3 class >> to_app: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _to_app: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -15960,6 +17120,8 @@ Z3 class >> to_func_decl: c _: a [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	retval := lib _to_func_decl: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -16003,6 +17165,9 @@ Z3 class >> translate: source _: a _: target [
 	"
 	| retval |
 
+	source ensureValidZ3Object.
+	a ensureValidZ3Object.
+	target ensureValidZ3Object.
 	retval := lib _translate: source _: a _: target.
 	source errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: source.
@@ -16025,6 +17190,7 @@ Z3 class >> update_param_value: c _: param_id _: param_value [
 	"
 	| retval |
 
+	c ensureValidZ3Object.
 	retval := lib _update_param_value: c _: param_id _: param_value.
 	c errorCheck.
 	^ retval
@@ -16047,6 +17213,8 @@ Z3 class >> update_term: c _: a _: num_args _: args [
 	"
 	| retval argsExt |
 
+	c ensureValidZ3Object.
+	a ensureValidZ3Object.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _update_term: c _: a _: num_args _: argsExt.
 	argsExt notNil ifTrue:[argsExt free].

--- a/MachineArithmetic/Z3Symbol.class.st
+++ b/MachineArithmetic/Z3Symbol.class.st
@@ -34,6 +34,20 @@ Z3Symbol >> asString [
 
 ]
 
+{ #category : #utilities }
+Z3Symbol >> ensureValidZ3Object [
+    "This method is no-op if the object appears to be valid 
+     (based on the pointer value). Othwewise, thrown and
+     error."
+
+    "
+    Here we do not check for NULL pointer as NULL pointer represents
+    'no symbol' in current versions of Z3. 
+    "
+    self isPoisoned ifTrue: [ self error:'Invalid Z3 object (poisoned)!' ].
+
+]
+
 { #category : #API }
 Z3Symbol >> getInt [
 	self assert: self isIntSymbol.


### PR DESCRIPTION
… objects early

This commit calls `#ensureValidZ3Object` upon entry to public API methods
(in class `Z3`) in order to catch clearly invalid objects before passing
them down to Z3 library (which may cause whole Smalltalk to crash).

This can happen, for example, when one keeps hold on object whose context
has been destroyed or when an image is restarted.