### PR TITLE
Expand comment in ensureValidZ3Object

### DIFF
--- a/MachineArithmetic-FFI-Pharo/Z3Object.class.st
+++ b/MachineArithmetic-FFI-Pharo/Z3Object.class.st
@@ -68,8 +68,11 @@ Z3Object class >> fromExternalAddress: address [
 { #category : #utilities }
 Z3Object >> ensureValidZ3Object [
     "This method is no-op if the object appears to be valid 
-     (based on the pointer value). Othwewise, thrown and
-     error."
+     (based on the pointer value). Othwewise, throw an error.
+
+     If you encounter this during a test, maybe you want to do:
+     Z3Context createGlobalContext
+    "
 
     self isNull ifTrue: [ self error:'Invalid Z3 object (null)!' ].
     self isPoisoned ifTrue: [ self error:'Invalid Z3 object (poisoned)!' ].


### PR DESCRIPTION
In the case if control reached here simply because the user didn't create the global context, having this comment right in front of him is handy instead of remembering what to type each time.