### PR TITLE
Some little improvements

### DIFF
--- a/MachineArithmetic-Tests/ContextlessZ3Test.class.st
+++ b/MachineArithmetic-Tests/ContextlessZ3Test.class.st
@@ -59,10 +59,11 @@ ContextlessZ3Test >> testSymbolFromString [
 { #category : #tests }
 ContextlessZ3Test >> testTwoContexts [
 	"Several logical context can be used simultaneously."
-	| ctx1 ctx2 x y str |
+
+	| ctx1 ctx2 x y |
 	ctx1 := Z3Context fromDefault.
 	ctx2 := Z3Context fromDefault.
-	self deny: ctx1 handle asInteger = ctx2 handle asInteger.
+	self deny: ctx1 getHandle asInteger = ctx2 getHandle asInteger.
 	x := ctx1 mkBoolVar: 'x'.
 	y := ctx2 mkBoolVar: 'y'.
 	ctx1 del.

--- a/MachineArithmetic-Tests/SimpleZ3Test.class.st
+++ b/MachineArithmetic-Tests/SimpleZ3Test.class.st
@@ -42,10 +42,13 @@ SimpleZ3Test >> test0lt1 [
 
 { #category : #tests }
 SimpleZ3Test >> testAllBoolSortHandlesAreSame [
+
 	| boolSort1 boolSort2 |
 	boolSort1 := Z3Sort bool.
 	boolSort2 := Z3Sort bool.
-	self assert: boolSort1 handle value equals: boolSort2 handle value
+	self
+		assert: boolSort1 getHandle value
+		equals: boolSort2 getHandle value
 ]
 
 { #category : #tests }


### PR DESCRIPTION
- updated for Pharo 11
- finding z3 in M1 installations
- add a comment to bit vector class with an example