### PR TITLE
Fix automatic creation of `GNUmakefile.local`

### DIFF
--- a/pharo/GNUmakefile
+++ b/pharo/GNUmakefile
@@ -1,6 +1,6 @@
 PROJECT=MachineArithmetic
 
-include GNUmakefile.local
+-include GNUmakefile.local
 
 # Pharo version to use. Currently, only 8.0 is supported,
 # Pharo 9.0 and later is known to crash when using Z3.
@@ -9,7 +9,7 @@ PHARO_VERSION ?= 80
 # Metacello group to load.
 GROUP ?= default
 
-all: $(PROJECT).image check
+all: GNUmakefile.local $(PROJECT).image check
 
 include ../pharo.gmk
 

--- a/stx/GNUmakefile
+++ b/stx/GNUmakefile
@@ -1,8 +1,8 @@
 PROJECT=MachineArithmetic
 
-include GNUmakefile.local
+-include GNUmakefile.local
 
-all: build
+all: GNUmakefile.local build
 
 include ../stx.gmk
 


### PR DESCRIPTION
The problem was that we need to include `GNUmakefile.local` early on (before other makefiles) as it contains customizations. The default template for it is however defined in those makefiles, so attempt to build it would cause a loop. GNU make detects that and abort it's creation.

To circumvent that, we include `GNUmakefile.local` only if it exists and recreate it as part of `all` target. Not ideal, but better than forcing user to create it manually.