### PR TITLE
Raise structured InvalidZ3Object if ensureValidZ3Object fails

### DIFF
--- a/MachineArithmetic-FFI-Pharo/Z3Object.class.st
+++ b/MachineArithmetic-FFI-Pharo/Z3Object.class.st
@@ -66,20 +66,6 @@ Z3Object class >> fromExternalAddress: address [
 ]
 
 { #category : #utilities }
-Z3Object >> ensureValidZ3Object [
-    "This method is no-op if the object appears to be valid 
-     (based on the pointer value). Othwewise, throw an error.
-
-     If you encounter this during a test, maybe you want to do:
-     Z3Context createGlobalContext
-    "
-
-    self isNull ifTrue: [ self error:'Invalid Z3 object (null)!' ].
-    self isPoisoned ifTrue: [ self error:'Invalid Z3 object (poisoned)!' ].
-
-]
-
-{ #category : #utilities }
 Z3Object >> externalArray: anFFIExternalArray  pointerAt: anInteger [
 	^ anFFIExternalArray at: anInteger 
 		

--- a/MachineArithmetic-Tests/SimpleZ3Test.class.st
+++ b/MachineArithmetic-Tests/SimpleZ3Test.class.st
@@ -418,6 +418,15 @@ SimpleZ3Test >> testNonBVSortSize [
 ]
 
 { #category : #tests }
+SimpleZ3Test >> testNotZ3Object [
+	| bogusObject |
+	bogusObject := 3@4.
+	self
+		should: [ bogusObject ensureValidZ3Object ]
+		raise: InvalidZ3Object
+]
+
+{ #category : #tests }
 SimpleZ3Test >> testPTop [
 	"The empty disjunction simplifies to true.
 	 This is crucial to the functioning of isShortExpr not needing PTop as an explicit case."

--- a/MachineArithmetic/InvalidZ3Object.class.st
+++ b/MachineArithmetic/InvalidZ3Object.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #InvalidZ3Object,
+	#superclass : #Error,
+	#instVars : [
+		'object'
+	],
+	#category : #'MachineArithmetic-Core'
+}
+
+{ #category : #signaling }
+InvalidZ3Object class >> object: anObject [
+	^self new 
+		object: anObject;
+		signal
+]
+
+{ #category : #accessing }
+InvalidZ3Object >> object [
+	^ object
+]
+
+{ #category : #accessing }
+InvalidZ3Object >> object: anObject [
+	object := anObject
+]

--- a/MachineArithmetic/NullZ3Object.class.st
+++ b/MachineArithmetic/NullZ3Object.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #NullZ3Object,
+	#superclass : #InvalidZ3Object,
+	#category : #'MachineArithmetic-Core'
+}

--- a/MachineArithmetic/Object.extension.st
+++ b/MachineArithmetic/Object.extension.st
@@ -1,6 +1,12 @@
 Extension { #name : #Object }
 
 { #category : #'*MachineArithmetic' }
+Object >> ensureValidZ3Object [
+	"The receiver is not even a Z3Object, let alone a valid one."
+	^InvalidZ3Object object: self
+]
+
+{ #category : #'*MachineArithmetic' }
 Object >> isAST [
 	^false
 ]

--- a/MachineArithmetic/PoisonedZ3Object.class.st
+++ b/MachineArithmetic/PoisonedZ3Object.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #PoisonedZ3Object,
+	#superclass : #InvalidZ3Object,
+	#category : #'MachineArithmetic-Core'
+}

--- a/MachineArithmetic/Z3Object.extension.st
+++ b/MachineArithmetic/Z3Object.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #Z3Object }
+
+{ #category : #'*MachineArithmetic' }
+Z3Object >> ensureValidZ3Object [
+    "This method is no-op if the object appears to be valid 
+     (based on the pointer value). Othwewise, throw an error.
+
+     If you encounter this during a test, maybe you want to do:
+     Z3Context createGlobalContext
+    "
+
+    self isNull ifTrue: [ NullZ3Object object: self ].
+    self isPoisoned ifTrue: [ PoisonedZ3Object object: self ].
+
+]

--- a/MachineArithmetic/Z3Symbol.class.st
+++ b/MachineArithmetic/Z3Symbol.class.st
@@ -53,7 +53,7 @@ Z3Symbol >> ensureValidZ3Object [
     Here we do not check for NULL pointer as NULL pointer represents
     'no symbol' in current versions of Z3. 
     "
-    self isPoisoned ifTrue: [ self error:'Invalid Z3 object (poisoned)!' ].
+    self isPoisoned ifTrue: [ PoisonedZ3Object object: self ].
 
 ]
 


### PR DESCRIPTION
This trivial change prepares the way for working on `#coerce:`