### PR TITLE
[MathNotation] Allow "Prime" symbol in identifiers

### DIFF
--- a/MachineArithmetic-MathNotation/Character.extension.st
+++ b/MachineArithmetic-MathNotation/Character.extension.st
@@ -472,6 +472,8 @@ Character class >> weirdLetterCodepoints [
 	16r211A "Rational"
 	16r2107 "Euler constant"
 	16r210F "Planck"
+	
+	16r2032 "Prime"
 	)
 ]
 


### PR DESCRIPTION
When your language allows *neither* nontrivial typography [in identifiers] *nor* passing agglomerates across return, trying to understand-by-translation some code which extensively uses both, can end up in a lot of frustration.  For example try writing

> (x₁′, y₁′) = f(x₁, y₁)
> return $ y₁′ + 1

in Smalltalk and then reading it back a few months later.

Allowing "′" at least makes life a tiny bit easier.