### PR TITLE
Generalize support for coercion of arguments

### DIFF
--- a/MachineArithmetic/BitVector.class.st
+++ b/MachineArithmetic/BitVector.class.st
@@ -45,15 +45,21 @@ BitVector >> & rhs [
 BitVector >> * rhs [
 	"Signed multiplication"
 
-	^ Z3 mk_bvmul: ctx _: self _: (self coerce: rhs) .
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_bvmul: ctx _: self _: rhs.
+	].
+	^self retry: #* coercing: rhs
 
 ]
 
 { #category : #arithmetic }
 BitVector >> + rhs [
-	"Signed addition"
+	"Signed multiplication"
 
-	^ Z3 mk_bvadd: ctx _: self _: (self coerce: rhs) .
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_bvadd: ctx _: self _: rhs.
+	].
+	^self retry: #+ coercing: rhs
 
 ]
 
@@ -71,7 +77,10 @@ BitVector >> , anotherBitVector [
 BitVector >> - rhs [
 	"Signed subtraction"
 
-	^ Z3 mk_bvsub: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_bvsub: ctx _: self _: rhs.
+	].
+	^self retry: #- coercing: rhs
 
 ]
 
@@ -79,13 +88,19 @@ BitVector >> - rhs [
 BitVector >> / rhs [
 	"Signed division"
 
-	^ Z3 mk_bvsdiv: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_bvsdiv: ctx _: self _: rhs.
+	].
+	^self retry: #/ coercing: rhs
 
 ]
 
-{ #category : #comparing }
+{ #category : #arithmetic }
 BitVector >> < rhs [
-	^ Z3 mk_bvslt: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_bvslt: ctx _: self _: rhs.
+	].
+	^self retry: #< coercing: rhs
 
 ]
 
@@ -95,21 +110,30 @@ BitVector >> << shamt [
 
 ]
 
-{ #category : #comparing }
+{ #category : #arithmetic }
 BitVector >> <= rhs [
-	^ Z3 mk_bvsle: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_bvsle: ctx _: self _: rhs.
+	].
+	^self retry: #<= coercing: rhs
 
 ]
 
-{ #category : #comparing }
+{ #category : #arithmetic }
 BitVector >> > rhs [
-	^ Z3 mk_bvsgt: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_bvsgt: ctx _: self _: rhs.
+	].
+	^self retry: #> coercing: rhs
 
 ]
 
-{ #category : #comparing }
+{ #category : #arithmetic }
 BitVector >> >= rhs [
-	^ Z3 mk_bvsge: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_bvsge: ctx _: self _: rhs.
+	].
+	^self retry: #>= coercing: rhs
 
 ]
 
@@ -133,7 +157,12 @@ BitVector >> between: min and: max [
 { #category : #'bit operators' }
 BitVector >> bitAnd: rhs [
 	"Bitwise and"
-	^ Z3 mk_bvand: ctx _: self _: (self coerce: rhs)
+	
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_bvand: ctx _: self _: rhs.
+	].
+	^self retry: #bitAnd: coercing: rhs
+
 
 ]
 
@@ -147,7 +176,12 @@ BitVector >> bitInvert [
 { #category : #'bit operators' }
 BitVector >> bitOr: rhs [
 	"Bitwise or"
-	^ Z3 mk_bvor: ctx _: self _: (self coerce: rhs)
+	
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_bvor: ctx _: self _: rhs.
+	].
+	^self retry: #bitOr: coercing: rhs
+
 
 ]
 
@@ -165,22 +199,30 @@ BitVector >> bitRotateRight: shamt [
 
 { #category : #'bit operators' }
 BitVector >> bitShiftLeft: shamt [
-	^ Z3 mk_bvshl: ctx _: self _: (self coerce: shamt)
-
+	(self isLikeMe: shamt) ifTrue:[
+		^ Z3 mk_bvshl: ctx _: self _: shamt.
+	].
+	^self retry: #bitShiftLeft: coercing: shamt
 ]
 
 { #category : #'bit operators' }
 BitVector >> bitShiftRight: shamt [
 	"Perform logical shift right by `shamt` bits"
 
-	^ Z3 mk_bvlshr: ctx _: self _: (self coerce: shamt)
+	(self isLikeMe: shamt) ifTrue:[
+		^ Z3 mk_bvlshr: ctx _: self _: shamt.
+	].
+	^self retry: #bitShiftRight: coercing: shamt
 ]
 
 { #category : #'bit operators' }
 BitVector >> bitShiftRightArithmetic: shamt [
 	"Perform arithmetic shift right by `shamt` bits"
 
-	^ Z3 mk_bvashr: ctx _: self _: (self coerce: shamt)
+	(self isLikeMe: shamt) ifTrue:[
+		^ Z3 mk_bvashr: ctx _: self _: shamt.
+	].
+	^self retry: #bitShiftRightArithmetic: coercing: shamt
 ]
 
 { #category : #slicing }
@@ -251,7 +293,10 @@ BitVector >> toBitVector: xlen [
 BitVector >> udiv: rhs [
 	"Unsigned division"
 
-	^ Z3 mk_bvudiv: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_bvudiv: ctx _: self _: rhs.
+	].
+	^self retry: #udiv: coercing: rhs
 
 ]
 

--- a/MachineArithmetic/BitVector.class.st
+++ b/MachineArithmetic/BitVector.class.st
@@ -215,6 +215,11 @@ BitVector >> repeat: n [
 
 ]
 
+{ #category : #adapting }
+BitVector >> retry: selector coercing: rhs [
+	^rhs adaptToBitVector: self length: self length andSend: selector
+]
+
 { #category : #accessing }
 BitVector >> signedValue [
 	| unsignedValue topBit |

--- a/MachineArithmetic/Bool.class.st
+++ b/MachineArithmetic/Bool.class.st
@@ -59,13 +59,22 @@ Bool >> <=> rhs [
 
 { #category : #'logical operations' }
 Bool >> ==> rhs [
-	^ Z3 mk_implies: ctx _: self _: rhs
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_implies: ctx _: self _: rhs.
+	].
+	^self retry: #'==>' coercing: rhs
+	
+
 
 ]
 
 { #category : #'logical operations' }
 Bool >> and: rhs [
-	^ Z3 mk_and: ctx _: 2 _: { self. (self coerce: rhs) }
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_and: ctx _: 2 _: { self . rhs }.
+	].
+	^self retry: #and: coercing: rhs
+	
 
 ]
 
@@ -88,7 +97,12 @@ Bool >> ifTrue: trueAlternativeBlock ifFalse: falseAlternativeBlock [
 
 { #category : #'logical operations' }
 Bool >> iff: rhs [
-	^ Z3 mk_iff: ctx _: self _: rhs
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_iff: ctx _: self _: rhs.
+	].
+	^self retry: #iff: coercing: rhs
+	
+
 
 ]
 
@@ -127,7 +141,11 @@ Bool >> not [
 
 { #category : #'logical operations' }
 Bool >> or: rhs [
-	^ Z3 mk_or: ctx _: 2 _: { self. (self coerce: rhs) }
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_or: ctx _: 2 _: { self . rhs }.
+	].
+	^self retry: #or: coercing: rhs
+	
 
 ]
 
@@ -182,7 +200,12 @@ Bool >> value [
 
 { #category : #'logical operations' }
 Bool >> xor: rhs [
-	^ Z3 mk_xor: ctx _: self _: (self coerce: rhs)
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_xor: ctx _: self _: rhs.
+	].
+	^self retry: #xor: coercing: rhs
+	
+
 
 ]
 

--- a/MachineArithmetic/Bool.class.st
+++ b/MachineArithmetic/Bool.class.st
@@ -136,6 +136,11 @@ Bool >> printString [
 	^ self astToString
 ]
 
+{ #category : #adapting }
+Bool >> retry: selector coercing: rhs [
+	^rhs adaptToBool: self andSend: selector
+]
+
 { #category : #'refinement typing' }
 Bool >> singletonExpr: varName [
 	"Consider whether the receiver, taken as a predicate over variable varName,

--- a/MachineArithmetic/Int.class.st
+++ b/MachineArithmetic/Int.class.st
@@ -32,6 +32,11 @@ Int >> isInt [
 	^true
 ]
 
+{ #category : #adapting }
+Int >> retry: selector coercing: rhs [
+	^rhs adaptToInt: self andSend: selector
+]
+
 { #category : #converting }
 Int >> toBitVector: size [
 	^ Z3 mk_int2bv: ctx _: size _: self

--- a/MachineArithmetic/Object.extension.st
+++ b/MachineArithmetic/Object.extension.st
@@ -1,6 +1,26 @@
 Extension { #name : #Object }
 
 { #category : #'*MachineArithmetic' }
+Object >> adaptToBitVector: receiver length: length andSend: selector [
+	^receiver perform: selector with: (self toBitVector: length)
+]
+
+{ #category : #'*MachineArithmetic' }
+Object >> adaptToBool: receiver andSend: selector [
+	^receiver perform: selector with: self toBool
+]
+
+{ #category : #'*MachineArithmetic' }
+Object >> adaptToInt: receiver andSend: selector [
+	^receiver perform: selector with: self toInt
+]
+
+{ #category : #'*MachineArithmetic' }
+Object >> adaptToReal: receiver andSend: selector [
+	^receiver perform: selector with: self toReal
+]
+
+{ #category : #'*MachineArithmetic' }
 Object >> isAST [
 	^false
 ]
@@ -17,6 +37,11 @@ Object >> isBool [
 
 { #category : #'*MachineArithmetic' }
 Object >> isInt [ 
+	^false
+]
+
+{ #category : #'*MachineArithmetic' }
+Object >> isNode [
 	^false
 ]
 

--- a/MachineArithmetic/Real.class.st
+++ b/MachineArithmetic/Real.class.st
@@ -19,6 +19,11 @@ Real >> isReal [
 	^true
 ]
 
+{ #category : #adapting }
+Real >> retry: selector coercing: rhs [
+	^rhs adaptToReal: self andSend: selector
+]
+
 { #category : #converting }
 Real >> toInt [
 	^ Z3 mk_real2int: ctx _: self

--- a/MachineArithmetic/Z3ArithmeticNode.class.st
+++ b/MachineArithmetic/Z3ArithmeticNode.class.st
@@ -40,60 +40,101 @@ Z3ArithmeticNode class >> var: name [
 
 { #category : #arithmetic }
 Z3ArithmeticNode >> * rhs [
-	^ Z3 mk_mul: ctx _: 2 _: { self . (self coerce: rhs) }.
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_mul: ctx _: 2 _: { self . rhs }.
+	].
+	^self retry: #* coercing: rhs
+	
 
 ]
 
 { #category : #arithmetic }
 Z3ArithmeticNode >> ** rhs [
-	^ Z3 mk_power: ctx _:  self _: (self coerce: rhs) .
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_power: ctx _: self _: rhs.
+	].
+	^self retry: #'**' coercing: rhs
+	
+
 ]
 
 { #category : #arithmetic }
 Z3ArithmeticNode >> + rhs [
-	^ Z3 mk_add: ctx _: 2 _: { self . (self coerce: rhs) }.
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_add: ctx _: 2 _: { self . rhs }.
+	].
+	^self retry: #+ coercing: rhs
+	
 
 ]
 
 { #category : #arithmetic }
 Z3ArithmeticNode >> - rhs [
-	^ Z3 mk_sub: ctx _: 2 _: { self . (self coerce: rhs) }
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_sub: ctx _: 2 _: { self . rhs }.
+	].
+	^self retry: #- coercing: rhs
+	
 
 ]
 
 { #category : #arithmetic }
 Z3ArithmeticNode >> / rhs [
-	^ Z3 mk_div: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_div: ctx _: self _: rhs.
+	].
+	^self retry: #/ coercing: rhs
+	
 
 ]
 
-{ #category : #comparing }
+{ #category : #arithmetic }
 Z3ArithmeticNode >> < rhs [
-	^ Z3 mk_lt: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_lt: ctx _: self _: rhs.
+	].
+	^self retry: #< coercing: rhs
+	
 
 ]
 
-{ #category : #comparing }
+{ #category : #arithmetic }
 Z3ArithmeticNode >> <= rhs [
-	^ Z3 mk_le: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_le: ctx _: self _: rhs.
+	].
+	^self retry: #<= coercing: rhs
+	
 
 ]
 
-{ #category : #comparing }
+{ #category : #arithmetic }
 Z3ArithmeticNode >> > rhs [
-	^ Z3 mk_gt: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_gt: ctx _: self _: rhs.
+	].
+	^self retry: #> coercing: rhs
+	
 
 ]
 
-{ #category : #comparing }
+{ #category : #arithmetic }
 Z3ArithmeticNode >> >= rhs [
-	^ Z3 mk_ge: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_ge: ctx _: self _: rhs.
+	].
+	^self retry: #>= coercing: rhs
+	
 
 ]
 
 { #category : #arithmetic }
 Z3ArithmeticNode >> \\ rhs [
-	^ Z3 mk_mod: ctx _: self _: (self coerce: rhs).
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_mod: ctx _: self _: rhs.
+	].
+	^self retry: #'\\' coercing: rhs
+	
 
 ]
 

--- a/MachineArithmetic/Z3Node.class.st
+++ b/MachineArithmetic/Z3Node.class.st
@@ -29,13 +29,6 @@ Z3Node >> adaptToInteger: x andSend: selector [
 
 ]
 
-{ #category : #adapting }
-Z3Node >> adaptToNumber: x andSend: selector [
-	"Pharo specific"
-	self shouldBeImplemented.
-
-]
-
 { #category : #accessing }
 Z3Node >> argAt: index [
 	"Answer the i-th argument.

--- a/MachineArithmetic/Z3Node.class.st
+++ b/MachineArithmetic/Z3Node.class.st
@@ -23,9 +23,9 @@ Z3Node >> === rhs [
 ]
 
 { #category : #adapting }
-Z3Node >> adaptToInteger: x andSend: selector [
+Z3Node >> adaptToInteger: receiver andSend: selector [
 	"Pharo specific"
-	^(self coerce: x) perform: selector with: self
+	^(self coerce: receiver) perform: selector with: self
 
 ]
 

--- a/MachineArithmetic/Z3Node.class.st
+++ b/MachineArithmetic/Z3Node.class.st
@@ -229,8 +229,22 @@ Z3Node >> isLeaf [
 ]
 
 { #category : #testing }
+Z3Node >> isLikeMe: object [
+	^ object isNode and:[ self sort = object sort ]
+	
+	"
+	1 toInt isLikeMe: 2 toReal
+	"
+]
+
+{ #category : #testing }
 Z3Node >> isNamedConstant [
 	^self isApp and: [self arity == 0]
+]
+
+{ #category : #testing }
+Z3Node >> isNode [
+	^ true
 ]
 
 { #category : #testing }
@@ -277,6 +291,11 @@ Z3Node >> productFromInteger:anInteger [
 	^ (self coerce: anInteger) * self
 
 	"Modified: / 09-09-2020 / 11:27:27 / Jan Vrany <jan.vrany@labware.com>"
+]
+
+{ #category : #adapting }
+Z3Node >> retry: selector coercing: rhs [
+	^self subclassResponsibility 
 ]
 
 { #category : #operations }

--- a/MachineArithmetic/Z3Node.class.st
+++ b/MachineArithmetic/Z3Node.class.st
@@ -108,8 +108,10 @@ Z3Node >> elementOfModel: aZ3Model [
 
 { #category : #operations }
 Z3Node >> eq: rhs [
-	^Z3 mk_eq: ctx _: self _: (self coerce: rhs)
-
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_eq: ctx _: self _: rhs.
+	].
+	^self retry: #eq: coercing: rhs
 ]
 
 { #category : #'double dispatching' }


### PR DESCRIPTION
This PR addresses issue #55. The crux of it is in 9c345cc4e9a3a98183f05e66d5141ddd21215b35, see commit message. 

This commit does not touch anything outside MA-proper -  to allow `1 toInt + A` where `A` is an `Expr` one has yet to implement `Expr >> adaptToInt:andSend:`  (similarly all other  `adaptTo???:andSend:` for other sort kinds)