### PR TITLE
Check that arguments passed to `mk_func_decl()` are Z3Sorts

### DIFF
--- a/MachineArithmetic/Z3Symbol.class.st
+++ b/MachineArithmetic/Z3Symbol.class.st
@@ -90,6 +90,8 @@ Z3Symbol >> kind [
 
 { #category : #API }
 Z3Symbol >> mkFuncFrom: domainSorts to: rangeSort [
+	(domainSorts allSatisfy: [ :ds | ds isKindOf: Z3Sort]) ifFalse: [ self error ].
+	(rangeSort isKindOf: Z3Sort) ifFalse: [ self error ].
 	^ Z3 mk_func_decl: ctx _: self _: domainSorts size _: domainSorts _: rangeSort.
 
 ]


### PR DESCRIPTION
It is possible to pass a non-Z3Sort argument to `mk_func_decl()` and Z3 will only complain later (e.g. when trying to `mk_const()` over such corrupt Z3FuncDecl).  Several times in practical debugging of Refinements, I found it very tedious to hunt down where these corrupt Z3FuncDecls are created.  Therefore, let's catch them early.