### PR TITLE
What's the deal with auto-creating Global Z3Context?

### DIFF
--- a/MachineArithmetic/Z3Context.class.st
+++ b/MachineArithmetic/Z3Context.class.st
@@ -38,6 +38,7 @@ Z3Context class >> fromDefault [
 { #category : #'global context' }
 Z3Context class >> global [
 	Global isNil ifTrue: [ self createGlobalContext ].
+	Global isNull ifTrue: [ self createGlobalContext ].
 	^Global
 ]
 

--- a/MachineArithmetic/Z3Context.class.st
+++ b/MachineArithmetic/Z3Context.class.st
@@ -38,7 +38,7 @@ Z3Context class >> fromDefault [
 { #category : #'global context' }
 Z3Context class >> global [
 	Global isNil ifTrue: [ self createGlobalContext ].
-	Global isNull ifTrue: [ self createGlobalContext ].
+	Global isNull ifTrue: [ self createGlobalContext ]. "see PR#76"
 	^Global
 ]
 


### PR DESCRIPTION
I was under the impression that at one point this was resolved forever, so one just runs any Z3 code without having to explicitly worry about the context. Am I too naïve?