### PR TITLE
Introduce a `Z3Set`

### DIFF
--- a/MachineArithmetic-MathNotation-Pharo/RBScanner.extension.st
+++ b/MachineArithmetic-MathNotation-Pharo/RBScanner.extension.st
@@ -80,6 +80,7 @@ RBScanner >> isUnicodeMathOperator: aCharacter [
 		16r227B" ≻ "
 		16r2286" ⊆ "
 		16r2295" ⊕ "
+		16r2296" ⊖ "
 		16r2297" ⊗ "
 		16r229B" ⊛ "
 		16r22B2" ⊲ "

--- a/MachineArithmetic-MathNotation/Z3Set.extension.st
+++ b/MachineArithmetic-MathNotation/Z3Set.extension.st
@@ -14,3 +14,10 @@ Z3Set >> ∪ [ anotherSet
 Z3Set >> ⊆ [ anotherSet
 	^self isSubsetOf: anotherSet
 ]
+
+{ #category : #'*MachineArithmetic-MathNotation' }
+Z3Set >> ⊖ [ anotherSet
+	"Symmetric difference, acting as the additive operation of the Boolean ring
+	 (#∩ being its multiplicative operation.)"
+	^(self\anotherSet) ∪ (anotherSet\self)
+]

--- a/MachineArithmetic-MathNotation/Z3Set.extension.st
+++ b/MachineArithmetic-MathNotation/Z3Set.extension.st
@@ -1,16 +1,16 @@
-Extension { #name : #McCarthyArray }
+Extension { #name : #Z3Set }
 
 { #category : #'*MachineArithmetic-MathNotation' }
-McCarthyArray >> ∩ [ anotherSet
+Z3Set >> ∩ [ anotherSet
 	^self intersection: anotherSet
 ]
 
 { #category : #'*MachineArithmetic-MathNotation' }
-McCarthyArray >> ∪ [ anotherSet
+Z3Set >> ∪ [ anotherSet
 	^self union: anotherSet
 ]
 
 { #category : #'*MachineArithmetic-MathNotation' }
-McCarthyArray >> ⊆ [ anotherSet
+Z3Set >> ⊆ [ anotherSet
 	^self isSubsetOf: anotherSet
 ]

--- a/MachineArithmetic-Tests/IntSymbolTest.class.st
+++ b/MachineArithmetic-Tests/IntSymbolTest.class.st
@@ -61,6 +61,7 @@ IntSymbolTest >> testImplication [
 IntSymbolTest >> testImplicationQuantified [
 	| f x y v fxy  lhs rhs solver |
 	f := 'f' functionFrom: { Int sort. Int sort } to: Bool sort.	
+	f := 'f' functionFrom: { Int sort. Int sort } to: Bool sort.        
 	x := 'x' toInt.
 	y := 'y' toInt.
 	v := 'v' toInt.

--- a/MachineArithmetic-Tests/Z3SetTest.class.st
+++ b/MachineArithmetic-Tests/Z3SetTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #tests }
 Z3SetTest >> testEmptySet [
 	| set |
-	set := Z3Set of: Z3Sort int.
+	set := Z3Set emptyOf: Z3Sort int.
 	self assert: set sort domain equals: Int sort.
 	self assert: set sort class equals: Z3ArraySort.
 	self assert: set sort nodeClass equals: Z3Set.
@@ -33,7 +33,7 @@ Z3SetTest >> testFullSet [
 { #category : #tests }
 Z3SetTest >> testSetAdd [
 	| emp s solver |
-	emp := Z3Set of: Int sort.
+	emp := Z3Set emptyOf: Int sort.
 	s := emp add: 42.
 	self assert: (s includes: 42) simplify.
 	self deny: (emp includes: 42) simplify.
@@ -53,15 +53,14 @@ Z3SetTest >> testSetAdd [
 { #category : #tests }
 Z3SetTest >> testSetAddInvalidValue [
 	| set |
-
-	set := Z3Set of: Int sort.
+	set := Z3Set emptyOf: Int sort.
 	self should: [ set add: (42 toBitVector: 8) ] raise: Error
 ]
 
 { #category : #tests }
 Z3SetTest >> testSetComplement [
 	| s |
-	s := ((Z3Set of: Z3Sort int) add: 1) complement. "ℤ\{1}"
+	s := ((Z3Set emptyOf: Z3Sort int) add: 1) complement. "ℤ\{1}"
 	self assert: (s includes: 2).
 	self deny:   (s includes: 1).
 ]
@@ -69,8 +68,8 @@ Z3SetTest >> testSetComplement [
 { #category : #tests }
 Z3SetTest >> testSetDifference [
 	| onetwo one |
-	onetwo := ((Z3Set of: Int sort) add: 1) add: 2.
-	one    :=  (Z3Set of: Int sort) add: 1.
+	onetwo := ((Z3Set emptyOf: Int sort) add: 1) add: 2.
+	one    :=  (Z3Set emptyOf: Int sort) add: 1.
 
 	self assert: (onetwo \ one includes: 2) simplify.
 	self deny:   (onetwo \ one includes: 1) simplify.
@@ -79,8 +78,8 @@ Z3SetTest >> testSetDifference [
 { #category : #tests }
 Z3SetTest >> testSetIU [
 	| onetwo threefour |
-	onetwo    := ((Z3Set of: Int sort) add: 1) add: 2.
-	threefour := ((Z3Set of: Int sort) add: 3) add: 4.
+	onetwo    := ((Z3Set emptyOf: Int sort) add: 1) add: 2.
+	threefour := ((Z3Set emptyOf: Int sort) add: 3) add: 4.
 
 	self assert: ((onetwo union: threefour) includes: 1) simplify.
 	self assert: ((onetwo union: threefour) includes: 2) simplify.
@@ -97,8 +96,8 @@ Z3SetTest >> testSetIU [
 { #category : #tests }
 Z3SetTest >> testSetIU2 [
 	| onetwo threefour solver |
-	onetwo    := ((Z3Set of: Int sort) add: 1) add: 2.
-	threefour := ((Z3Set of: Int sort) add: 3) add: 4.
+	onetwo    := ((Z3Set emptyOf: Int sort) add: 1) add: 2.
+	threefour := ((Z3Set emptyOf: Int sort) add: 3) add: 4.
 	
 	solver := Z3Solver new.
 	solver proveValid: (((onetwo union: threefour) includes: 'x') exists: 'x' toInt).
@@ -109,7 +108,7 @@ Z3SetTest >> testSetIU2 [
 { #category : #tests }
 Z3SetTest >> testSetIdentity [
 	| emp s t |
-	emp := Z3Set of: Int sort.
+	emp := Z3Set emptyOf: Int sort.
 	s := emp add: 42.
 	t := s remove: 42.
 	self assert: (t===emp) simplify "however, t simplify==emp is not true!!!"
@@ -118,7 +117,7 @@ Z3SetTest >> testSetIdentity [
 { #category : #tests }
 Z3SetTest >> testSetRemove [
 	| set removed |
-	set := (Z3Set of: Z3Sort int) add: 1.
+	set := (Z3Set emptyOf: Z3Sort int) add: 1.
 	self assert: (set includes: 1).
 	removed := set remove: 1.
 	self deny: (removed includes: 1).
@@ -128,9 +127,7 @@ Z3SetTest >> testSetRemove [
 { #category : #tests }
 Z3SetTest >> testSetRemoveInvalid [
 	| set |
-
-
-	set := Z3Set of: Z3Sort int.
+	set := Z3Set emptyOf: Z3Sort int.
 	set add: 1.
 	self should: [set remove: (1 toBitVector: 16)] raise: Error
 ]
@@ -138,8 +135,8 @@ Z3SetTest >> testSetRemoveInvalid [
 { #category : #tests }
 Z3SetTest >> testSetUnionInvalid [
 	| onetwo threefour |
-	onetwo    := ((Z3Set of: Int sort) add: 1) add: 2.
-	threefour := ((Z3Set of: Real sort) add: 3) add: 4.
+	onetwo    := ((Z3Set emptyOf: Int sort) add: 1) add: 2.
+	threefour := ((Z3Set emptyOf: Real sort) add: 3) add: 4.
 
 	self should: [onetwo union: threefour] raise: Error.
 ]

--- a/MachineArithmetic-Tests/Z3SetTest.class.st
+++ b/MachineArithmetic-Tests/Z3SetTest.class.st
@@ -51,6 +51,14 @@ Z3SetTest >> testSetAdd [
 ]
 
 { #category : #tests }
+Z3SetTest >> testSetAddInvalidValue [
+	| set |
+
+	set := Int sort mkEmptySet.
+	self should: [ set add: (42 toBitVector: 8) ] raise: Error
+]
+
+{ #category : #tests }
 Z3SetTest >> testSetComplement [
 	| s |
 	s := (Z3Sort int mkEmptySet add: 1) complement. "ℤ\{1}"
@@ -116,4 +124,23 @@ Z3SetTest >> testSetRemove [
 	removed := set remove: 1.
 	self deny: (removed includes: 1).
 	self assert: (set includes: 1).	
+]
+
+{ #category : #tests }
+Z3SetTest >> testSetRemoveInvalid [
+	| set |
+
+
+	set := Z3Sort int mkEmptySet.
+	set add: 1.
+	self should: [set remove: (1 toBitVector: 16)] raise: Error
+]
+
+{ #category : #tests }
+Z3SetTest >> testSetUnionInvalid [
+	| onetwo threefour |
+	onetwo    := (Int sort mkEmptySet add: 1) add: 2.
+	threefour := (Real sort mkEmptySet add: 3) add: 4.
+
+	self should: [onetwo union: threefour] raise: Error.
 ]

--- a/MachineArithmetic-Tests/Z3SetTest.class.st
+++ b/MachineArithmetic-Tests/Z3SetTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #tests }
 Z3SetTest >> testEmptySet [
 	| set |
-	set := Z3Sort int mkEmptySet.
+	set := Z3Set of: Z3Sort int.
 	self assert: set sort domain equals: Int sort.
 	self assert: set sort class equals: Z3ArraySort.
 	self assert: set sort nodeClass equals: Z3Set.
@@ -20,7 +20,7 @@ Z3SetTest >> testEmptySet [
 { #category : #tests }
 Z3SetTest >> testFullSet [
 	| set |
-	set := Z3Sort int mkFullSet.
+	set := Z3Set fullOf: Z3Sort int.
 	self assert: set sort domain equals: Int sort.
 	self assert: set sort class equals: Z3ArraySort.
 	self assert: set sort nodeClass equals: Z3Set.
@@ -33,7 +33,7 @@ Z3SetTest >> testFullSet [
 { #category : #tests }
 Z3SetTest >> testSetAdd [
 	| emp s solver |
-	emp := Int sort mkEmptySet.
+	emp := Z3Set of: Int sort.
 	s := emp add: 42.
 	self assert: (s includes: 42) simplify.
 	self deny: (emp includes: 42) simplify.
@@ -54,14 +54,14 @@ Z3SetTest >> testSetAdd [
 Z3SetTest >> testSetAddInvalidValue [
 	| set |
 
-	set := Int sort mkEmptySet.
+	set := Z3Set of: Int sort.
 	self should: [ set add: (42 toBitVector: 8) ] raise: Error
 ]
 
 { #category : #tests }
 Z3SetTest >> testSetComplement [
 	| s |
-	s := (Z3Sort int mkEmptySet add: 1) complement. "ℤ\{1}"
+	s := ((Z3Set of: Z3Sort int) add: 1) complement. "ℤ\{1}"
 	self assert: (s includes: 2).
 	self deny:   (s includes: 1).
 ]
@@ -69,19 +69,18 @@ Z3SetTest >> testSetComplement [
 { #category : #tests }
 Z3SetTest >> testSetDifference [
 	| onetwo one |
-	onetwo := (Int sort mkEmptySet add: 1) add: 2.
-	one    :=  Int sort mkEmptySet add: 1.
+	onetwo := ((Z3Set of: Int sort) add: 1) add: 2.
+	one    :=  (Z3Set of: Int sort) add: 1.
 
 	self assert: (onetwo \ one includes: 2) simplify.
 	self deny:   (onetwo \ one includes: 1) simplify.
-
 ]
 
 { #category : #tests }
 Z3SetTest >> testSetIU [
 	| onetwo threefour |
-	onetwo    := (Int sort mkEmptySet add: 1) add: 2.
-	threefour := (Int sort mkEmptySet add: 3) add: 4.
+	onetwo    := ((Z3Set of: Int sort) add: 1) add: 2.
+	threefour := ((Z3Set of: Int sort) add: 3) add: 4.
 
 	self assert: ((onetwo union: threefour) includes: 1) simplify.
 	self assert: ((onetwo union: threefour) includes: 2) simplify.
@@ -98,8 +97,8 @@ Z3SetTest >> testSetIU [
 { #category : #tests }
 Z3SetTest >> testSetIU2 [
 	| onetwo threefour solver |
-	onetwo    := (Int sort mkEmptySet add: 1) add: 2.
-	threefour := (Int sort mkEmptySet add: 3) add: 4.
+	onetwo    := ((Z3Set of: Int sort) add: 1) add: 2.
+	threefour := ((Z3Set of: Int sort) add: 3) add: 4.
 	
 	solver := Z3Solver new.
 	solver proveValid: (((onetwo union: threefour) includes: 'x') exists: 'x' toInt).
@@ -110,7 +109,7 @@ Z3SetTest >> testSetIU2 [
 { #category : #tests }
 Z3SetTest >> testSetIdentity [
 	| emp s t |
-	emp := Int sort mkEmptySet.
+	emp := Z3Set of: Int sort.
 	s := emp add: 42.
 	t := s remove: 42.
 	self assert: (t===emp) simplify "however, t simplify==emp is not true!!!"
@@ -119,7 +118,7 @@ Z3SetTest >> testSetIdentity [
 { #category : #tests }
 Z3SetTest >> testSetRemove [
 	| set removed |
-	set := Z3Sort int mkEmptySet add: 1.
+	set := (Z3Set of: Z3Sort int) add: 1.
 	self assert: (set includes: 1).
 	removed := set remove: 1.
 	self deny: (removed includes: 1).
@@ -131,7 +130,7 @@ Z3SetTest >> testSetRemoveInvalid [
 	| set |
 
 
-	set := Z3Sort int mkEmptySet.
+	set := Z3Set of: Z3Sort int.
 	set add: 1.
 	self should: [set remove: (1 toBitVector: 16)] raise: Error
 ]
@@ -139,8 +138,8 @@ Z3SetTest >> testSetRemoveInvalid [
 { #category : #tests }
 Z3SetTest >> testSetUnionInvalid [
 	| onetwo threefour |
-	onetwo    := (Int sort mkEmptySet add: 1) add: 2.
-	threefour := (Real sort mkEmptySet add: 3) add: 4.
+	onetwo    := ((Z3Set of: Int sort) add: 1) add: 2.
+	threefour := ((Z3Set of: Real sort) add: 3) add: 4.
 
 	self should: [onetwo union: threefour] raise: Error.
 ]

--- a/MachineArithmetic-Tests/Z3SetTest.class.st
+++ b/MachineArithmetic-Tests/Z3SetTest.class.st
@@ -10,7 +10,7 @@ Z3SetTest >> testEmptySet [
 	set := Z3Sort int mkEmptySet.
 	self assert: set sort domain equals: Int sort.
 	self assert: set sort class equals: Z3ArraySort.
-	self assert: set sort nodeClass equals: McCarthyArray.
+	self assert: set sort nodeClass equals: Z3Set.
 	
 	"Prove that no element belongs to the empty set.
 	 We don't even need a Solver for that: #simplify is enough."
@@ -23,7 +23,7 @@ Z3SetTest >> testFullSet [
 	set := Z3Sort int mkFullSet.
 	self assert: set sort domain equals: Int sort.
 	self assert: set sort class equals: Z3ArraySort.
-	self assert: set sort nodeClass equals: McCarthyArray.
+	self assert: set sort nodeClass equals: Z3Set.
 	
 	"Prove that every int element belongs to the full set.
 	 We don't even need a Solver for that: #simplify is enough."

--- a/MachineArithmetic/BitVector.class.st
+++ b/MachineArithmetic/BitVector.class.st
@@ -144,11 +144,6 @@ BitVector >> >> shamt [
 	^ self bitShiftRight: shamt
 ]
 
-{ #category : #converting }
-BitVector >> beLikeMe: value [
-	^value toBitVector: self length
-]
-
 { #category : #'as yet unclassified' }
 BitVector >> between: min and: max [
 	^self >= min & (self <= max)

--- a/MachineArithmetic/Bool.class.st
+++ b/MachineArithmetic/Bool.class.st
@@ -78,11 +78,6 @@ Bool >> and: rhs [
 
 ]
 
-{ #category : #adapting }
-Bool >> beLikeMe: value [
-	^value toBool
-]
-
 { #category : #'logical operations' }
 Bool >> ifThen: trueAST else: falseAST [
 	trueAST sort == falseAST sort ifFalse: [ self error: 'Branches must have same sort' ].

--- a/MachineArithmetic/Int.class.st
+++ b/MachineArithmetic/Int.class.st
@@ -22,11 +22,6 @@ Int >> asInteger [
 	^ self value
 ]
 
-{ #category : #adapting }
-Int >> beLikeMe: value [
-	^value toInt
-]
-
 { #category : #testing }
 Int >> isInt [
 	^true

--- a/MachineArithmetic/McCarthyArray.class.st
+++ b/MachineArithmetic/McCarthyArray.class.st
@@ -9,21 +9,6 @@ McCarthyArray class >> name: aString domain: d range: r [
 	^ d-->r mkConst: aString
 ]
 
-{ #category : #'set theory' }
-McCarthyArray >> \ anotherSet [
-	^ self difference: anotherSet
-]
-
-{ #category : #'set theory' }
-McCarthyArray >> add: element [
-	"Assume the receiver is a set.
-	 Non-destructively add element to the receiver."
-	self ensureSet.
-	^Z3 mk_set_add: ctx _: self _: (self sort domain cast: element)
-	"domain cast: takes care of both making sure element is of the right sort,
-	 and coercing those that can be coerced"
-]
-
 { #category : #enumerating }
 McCarthyArray >> arraySelect: i [
 	^ Z3 mk_select: ctx _: self _: i
@@ -33,69 +18,5 @@ McCarthyArray >> arraySelect: i [
 { #category : #enumerating }
 McCarthyArray >> arrayStore: i put: v [
 	^ Z3 mk_store: ctx _: self _: i _: v
-
-]
-
-{ #category : #'set theory' }
-McCarthyArray >> canBeSet [
-	^self sort range == Z3Sort bool
-]
-
-{ #category : #'set theory' }
-McCarthyArray >> complement [
-	^Z3 mk_set_complement: self ctx _: self
-]
-
-{ #category : #'set theory' }
-McCarthyArray >> difference: anotherSet [
-	"Take the set difference between two sets."
-	self ensureSet.
-	anotherSet ensureSet.
-	^Z3 mk_set_difference: ctx _: self _: anotherSet
-]
-
-{ #category : #'set theory' }
-McCarthyArray >> ensureSet [
-	self canBeSet ifFalse: [ self error ]
-]
-
-{ #category : #'set theory' }
-McCarthyArray >> includes: element [
-	"Assume the receiver is a set.
-	 Answer the Z3 Bool formula for set membership."
-	self ensureSet.
-	^Z3 mk_set_member: ctx _: (self sort domain cast: element) _: self
-]
-
-{ #category : #'set theory' }
-McCarthyArray >> intersection: anotherSet [
-	self ensureSet.
-	anotherSet ensureSet.
-	
-	^Z3 mk_set_intersect: ctx _: 2 _: { self . anotherSet }
-]
-
-{ #category : #'set theory' }
-McCarthyArray >> isSubsetOf: anotherSet [
-	"Check for subsetness of sets."
-	self ensureSet.
-	anotherSet ensureSet.
-	^Z3 mk_set_subset: ctx _: self _: anotherSet
-]
-
-{ #category : #'set theory' }
-McCarthyArray >> remove: oldElement [
-	"Assume the receiver is a set.
-	 Non-destructively remove element from the receiver."
-	self ensureSet.
-	^Z3 mk_set_del: self ctx _: self _: (self sort domain cast: oldElement)
-]
-
-{ #category : #'set theory' }
-McCarthyArray >> union: anotherSet [
-	self ensureSet.
-	anotherSet ensureSet.
-	
-	^Z3 mk_set_union: ctx _: 2 _: { self . anotherSet }
 
 ]

--- a/MachineArithmetic/Real.class.st
+++ b/MachineArithmetic/Real.class.st
@@ -9,11 +9,6 @@ Real class >> sort [
 	^ Z3Sort real
 ]
 
-{ #category : #adapting }
-Real >> beLikeMe: value [
-	^value toReal
-]
-
 { #category : #testing }
 Real >> isReal [
 	^true

--- a/MachineArithmetic/Z3AST.class.st
+++ b/MachineArithmetic/Z3AST.class.st
@@ -86,6 +86,12 @@ Z3AST >> astToString [
 ]
 
 { #category : #utilities }
+Z3AST >> ensureSet [
+	"No-op is receiver is a set, error otherwise"
+	self error: 'Receiver is not Z3 set'
+]
+
+{ #category : #utilities }
 Z3AST >> ensureValidZ3AST [
 	self ensureValidZ3Object
 ]

--- a/MachineArithmetic/Z3ArraySort.class.st
+++ b/MachineArithmetic/Z3ArraySort.class.st
@@ -24,8 +24,10 @@ Z3ArraySort >> domain [
 
 { #category : #'type theory' }
 Z3ArraySort >> nodeClass [
+	self range isBoolSort ifTrue: [ 
+		^ Z3Set
+	].
 	^ McCarthyArray
-
 ]
 
 { #category : #'type theory' }

--- a/MachineArithmetic/Z3ArraySort.class.st
+++ b/MachineArithmetic/Z3ArraySort.class.st
@@ -18,6 +18,11 @@ Z3ArraySort >> anyOne [
 ]
 
 { #category : #'type theory' }
+Z3ArraySort >> cast: value [
+	^ self shouldImplement
+]
+
+{ #category : #'type theory' }
 Z3ArraySort >> domain [
 	^Z3 get_array_sort_domain: self ctx _: self
 ]

--- a/MachineArithmetic/Z3BitVectorSort.class.st
+++ b/MachineArithmetic/Z3BitVectorSort.class.st
@@ -9,6 +9,11 @@ Z3BitVectorSort >> anyOne [
 	^0 /// self length
 ]
 
+{ #category : #'type theory' }
+Z3BitVectorSort >> cast: value [
+	^ value toBitVector: self length
+]
+
 { #category : #accessing }
 Z3BitVectorSort >> length [
 	"Return length in bits"

--- a/MachineArithmetic/Z3BoolSort.class.st
+++ b/MachineArithmetic/Z3BoolSort.class.st
@@ -9,6 +9,11 @@ Z3BoolSort >> cast: val [
 	^val toBool
 ]
 
+{ #category : #testing }
+Z3BoolSort >> isBoolSort [
+	^ true
+]
+
 { #category : #'type theory' }
 Z3BoolSort >> nodeClass [
 	^ Bool

--- a/MachineArithmetic/Z3Node.class.st
+++ b/MachineArithmetic/Z3Node.class.st
@@ -65,12 +65,6 @@ Z3Node >> arity [
 
 ]
 
-{ #category : #adapting }
-Z3Node >> beLikeMe: value [
-	"Convert and return value to value of receiver's sort"
-	self subclassResponsibility 
-]
-
 { #category : #GT }
 Z3Node >> childrenForInspector [
 	self isApp ifTrue: [^self args].
@@ -82,8 +76,7 @@ Z3Node >> coerce: value [
 	"Convert value to be of the same sort as receiver and return it"
 	
 	(value isAST and:[self sort == value sort]) ifTrue:[ ^ value ].
-	^self beLikeMe: value.
-
+	^self sort cast: value.
 ]
 
 { #category : #'double dispatching' }

--- a/MachineArithmetic/Z3RealSort.class.st
+++ b/MachineArithmetic/Z3RealSort.class.st
@@ -5,6 +5,11 @@ Class {
 }
 
 { #category : #'type theory' }
+Z3RealSort >> cast: value [
+	^ value toReal
+]
+
+{ #category : #'type theory' }
 Z3RealSort >> nodeClass [
 	^ Real
 

--- a/MachineArithmetic/Z3Set.class.st
+++ b/MachineArithmetic/Z3Set.class.st
@@ -4,19 +4,14 @@ Class {
 	#category : #'MachineArithmetic-Core'
 }
 
-{ #category : #'instance creation' }
+{ #category : #Monoid }
 Z3Set class >> emptyOf: elementSort [
 	^ Z3 mk_empty_set: elementSort ctx _: elementSort
 ]
 
-{ #category : #'instance creation' }
+{ #category : #Monoid }
 Z3Set class >> fullOf: elementSort [
 	^ Z3 mk_full_set: elementSort ctx _: elementSort
-]
-
-{ #category : #'instance creation' }
-Z3Set class >> of: aZ3Sort [
-	^ self emptyOf: aZ3Sort
 ]
 
 { #category : #'set theory' }

--- a/MachineArithmetic/Z3Set.class.st
+++ b/MachineArithmetic/Z3Set.class.st
@@ -1,0 +1,71 @@
+Class {
+	#name : #Z3Set,
+	#superclass : #McCarthyArray,
+	#category : #'MachineArithmetic-Core'
+}
+
+{ #category : #'set theory' }
+Z3Set >> \ anotherSet [
+	^ self difference: anotherSet
+]
+
+{ #category : #'set theory' }
+Z3Set >> add: element [
+	"Assume the receiver is a set.
+	 Non-destructively add element to the receiver."
+	^Z3 mk_set_add: ctx _: self _: (self sort domain cast: element)
+	"domain cast: takes care of both making sure element is of the right sort,
+	 and coercing those that can be coerced"
+]
+
+{ #category : #'set theory' }
+Z3Set >> complement [
+	^Z3 mk_set_complement: self ctx _: self
+]
+
+{ #category : #'set theory' }
+Z3Set >> difference: anotherSet [
+	"Take the set difference between two sets."
+	anotherSet ensureSet.
+	^Z3 mk_set_difference: ctx _: self _: anotherSet
+]
+
+{ #category : #utilities }
+Z3Set >> ensureSet [
+	"No-op - an instance of Z3Set is indeed a set"
+]
+
+{ #category : #'set theory' }
+Z3Set >> includes: element [
+	"Assume the receiver is a set.
+	 Answer the Z3 Bool formula for set membership."
+	^Z3 mk_set_member: ctx _: (self sort domain cast: element) _: self
+]
+
+{ #category : #'set theory' }
+Z3Set >> intersection: anotherSet [
+	anotherSet ensureSet.
+	
+	^Z3 mk_set_intersect: ctx _: 2 _: { self . anotherSet }
+]
+
+{ #category : #'set theory' }
+Z3Set >> isSubsetOf: anotherSet [
+	"Check for subsetness of sets."
+	anotherSet ensureSet.
+	^Z3 mk_set_subset: ctx _: self _: anotherSet
+]
+
+{ #category : #'set theory' }
+Z3Set >> remove: oldElement [
+	"Assume the receiver is a set.
+	 Non-destructively remove element from the receiver."
+	^Z3 mk_set_del: self ctx _: self _: (self sort domain cast: oldElement)
+]
+
+{ #category : #'set theory' }
+Z3Set >> union: anotherSet [
+	anotherSet ensureSet.
+	
+	^Z3 mk_set_union: ctx _: 2 _: { self . anotherSet }
+]

--- a/MachineArithmetic/Z3Set.class.st
+++ b/MachineArithmetic/Z3Set.class.st
@@ -4,6 +4,21 @@ Class {
 	#category : #'MachineArithmetic-Core'
 }
 
+{ #category : #'instance creation' }
+Z3Set class >> emptyOf: elementSort [
+	^ Z3 mk_empty_set: elementSort ctx _: elementSort
+]
+
+{ #category : #'instance creation' }
+Z3Set class >> fullOf: elementSort [
+	^ Z3 mk_full_set: elementSort ctx _: elementSort
+]
+
+{ #category : #'instance creation' }
+Z3Set class >> of: aZ3Sort [
+	^ self emptyOf: aZ3Sort
+]
+
 { #category : #'set theory' }
 Z3Set >> \ anotherSet [
 	^ self difference: anotherSet

--- a/MachineArithmetic/Z3Sort.class.st
+++ b/MachineArithmetic/Z3Sort.class.st
@@ -108,6 +108,16 @@ Z3Sort >> anyOne [
 	self subclassResponsibility
 ]
 
+{ #category : #'type theory' }
+Z3Sort >> cast: value [
+	"Convert and return given value as (new) value of this sort.
+	 For example: 
+		( Z3Sort int cast: 42) -> 42 toInt
+		((Z3Sort bv: 8) cast: 0xF) -> #xxx
+	"
+	self subclassResponsibility
+]
+
 { #category : #testing }
 Z3Sort >> isBoolSort [
 	^ false

--- a/MachineArithmetic/Z3Sort.class.st
+++ b/MachineArithmetic/Z3Sort.class.st
@@ -108,6 +108,11 @@ Z3Sort >> anyOne [
 	self subclassResponsibility
 ]
 
+{ #category : #testing }
+Z3Sort >> isBoolSort [
+	^ false
+]
+
 { #category : #accessing }
 Z3Sort >> kind [
 	^ SORT_AST

--- a/MachineArithmetic/Z3Sort.class.st
+++ b/MachineArithmetic/Z3Sort.class.st
@@ -142,21 +142,11 @@ Z3Sort >> mkConst: name [
 
 ]
 
-{ #category : #sets }
-Z3Sort >> mkEmptySet [
-	^Z3 mk_empty_set: ctx _: self
-]
-
 { #category : #'instance creation' }
 Z3Sort >> mkFreshConst: prefix [
 	"Declare and create a fresh constant of the receiver sort.
 	If prefix is nil, then it is assumed to be the empty string"
 	^Z3 mk_fresh_const: self ctx _: prefix _: self
-]
-
-{ #category : #sets }
-Z3Sort >> mkFullSet [
-	^Z3 mk_full_set: ctx _: self
 ]
 
 { #category : #'instance creation' }
@@ -169,11 +159,6 @@ Z3Sort >> mkInt: anInteger [
 { #category : #'special relations' }
 Z3Sort >> mkLinearOrder: id [ 
 	^Z3 mk_linear_order: ctx _: self _: id
-]
-
-{ #category : #sets }
-Z3Sort >> mkSetSort [
-	^Z3 mk_set_sort: ctx _: self
 ]
 
 { #category : #accessing }

--- a/MachineArithmetic/Z3UninterpretedSort.class.st
+++ b/MachineArithmetic/Z3UninterpretedSort.class.st
@@ -5,6 +5,11 @@ Class {
 }
 
 { #category : #'type theory' }
+Z3UninterpretedSort >> cast: value [
+	^ self shouldImplement
+]
+
+{ #category : #'type theory' }
 Z3UninterpretedSort >> nodeClass [
 	^ Uninterpreted
 


### PR DESCRIPTION
This PR introduces a new class `Z3Set` as was discussed privately earlier today. 

Whike working on this PR, I removed `#beLikeMe:` (see 4f8bdec0adab8a662fdbd078a33996c0451c399d). Strictly speaking , this does not have anything to do with sets. 