### PR TITLE
Fix `EvalEnv >> #evaluate:`

### DIFF
--- a/CardanoTartaglia-Tests/CardanoTartagliaContextTest.class.st
+++ b/CardanoTartaglia-Tests/CardanoTartagliaContextTest.class.st
@@ -15,16 +15,16 @@ CardanoTartagliaContextTest >> abc [
 
 { #category : #tests }
 CardanoTartagliaContextTest >> testCompileInCTContext [
-	| compiler |
-	compiler := self class compiler class new.
-	compiler context: self abc.
-	self assert: (compiler evaluate: 'a, b') equals: 'AB'
+	| context |
+	
+	context := self abc.
+	self assert: (context evaluate: 'a, b') equals: 'AB'
 ]
 
 { #category : #tests }
 CardanoTartagliaContextTest >> testUndeclaredVar [
-	| compiler |
-	compiler := self class compiler class new.
-	compiler context: self abc.
-	self should: [compiler evaluate: 'x+1'] raise: VariableNotDeclared
+	| context | 
+	
+	context := self abc.
+	self should: [context evaluate: 'x+1'] raise: VariableNotDeclared
 ]

--- a/CardanoTartaglia-Tests/CardanoTartagliaContextTest.class.st
+++ b/CardanoTartaglia-Tests/CardanoTartagliaContextTest.class.st
@@ -26,5 +26,6 @@ CardanoTartagliaContextTest >> testUndeclaredVar [
 	| context | 
 	
 	context := self abc.
-	self should: [context evaluate: 'x+1'] raise: VariableNotDeclared
+	self should: [context evaluate: 'x+1'] raise: VariableNotDeclared.
+	self should: [context evaluate: '1+x'] raise: VariableNotDeclared.
 ]

--- a/CardanoTartaglia-Tests/CardanoTartagliaContextTest.class.st
+++ b/CardanoTartaglia-Tests/CardanoTartagliaContextTest.class.st
@@ -1,11 +1,11 @@
 Class {
-	#name : #CTContextTest,
+	#name : #CardanoTartagliaContextTest,
 	#superclass : #TestCase,
 	#category : #'CardanoTartaglia-Tests'
 }
 
 { #category : #tests }
-CTContextTest >> abc [
+CardanoTartagliaContextTest >> abc [
 	^CardanoTartagliaContext ofVariables: (Dictionary newFromAssociations: {
 		'a' -> 'A'.
 		'b' -> 'B'.
@@ -14,7 +14,7 @@ CTContextTest >> abc [
 ]
 
 { #category : #tests }
-CTContextTest >> testCompileInCTContext [
+CardanoTartagliaContextTest >> testCompileInCTContext [
 	| compiler |
 	compiler := self class compiler class new.
 	compiler context: self abc.
@@ -22,7 +22,7 @@ CTContextTest >> testCompileInCTContext [
 ]
 
 { #category : #tests }
-CTContextTest >> testUndeclaredVar [
+CardanoTartagliaContextTest >> testUndeclaredVar [
 	| compiler |
 	compiler := self class compiler class new.
 	compiler context: self abc.

--- a/CardanoTartaglia/CardanoTartagliaContext.class.st
+++ b/CardanoTartaglia/CardanoTartagliaContext.class.st
@@ -31,13 +31,23 @@ CardanoTartagliaContext >> env: aDictionary [
 { #category : #evaluating }
 CardanoTartagliaContext >> evaluate: source [
 	"Evaluate given smalltalk source with receiver 
-	 as context (providing variable values). Return the result."
+	 as context (providing variable values). Return the result.
+	
+	 If the code contains a variable not defined in the receiver,
+	 this method throws `VariableNotDeclared` exception.
+	"
 	
 	| compiler |
 	
 	compiler := self class compilerClass new.
 	compiler context: self.
-	^compiler evaluate: source.	
+	[ 
+		^compiler evaluate: source 
+	] on: OCUndeclaredVariableWarning do: [ :warning |
+		VariableNotDeclared new
+			variableNode: warning node;
+			signal.
+	]
 ]
 
 { #category : #GT }

--- a/CardanoTartaglia/CardanoTartagliaContext.class.st
+++ b/CardanoTartaglia/CardanoTartagliaContext.class.st
@@ -28,6 +28,18 @@ CardanoTartagliaContext >> env: aDictionary [
 	env := aDictionary
 ]
 
+{ #category : #evaluating }
+CardanoTartagliaContext >> evaluate: source [
+	"Evaluate given smalltalk source with receiver 
+	 as context (providing variable values). Return the result."
+	
+	| compiler |
+	
+	compiler := self class compilerClass new.
+	compiler context: self.
+	^compiler evaluate: source.	
+]
+
 { #category : #GT }
 CardanoTartagliaContext >> gtInspectorItemsIn: composite [
 	<gtInspectorPresentationOrder: 0>

--- a/Refinements/EvalEnv.class.st
+++ b/Refinements/EvalEnv.class.st
@@ -49,19 +49,11 @@ EvalEnv >> constants: anObject [
 ]
 
 { #category : #compilation }
-EvalEnv >> createCompiler [
-	| compiler |
-	compiler := self class compiler class new.
-	compiler context: self ctContext.
-	^compiler
-]
-
-{ #category : #compilation }
 EvalEnv >> ctContext [
 	^CardanoTartagliaContext ofVariables: self constants
 ]
 
 { #category : #compilation }
 EvalEnv >> evaluate: smalltalkSource [
-	^self createCompiler evaluate: smalltalkSource
+	^self ctContext evaluate: smalltalkSource
 ]


### PR DESCRIPTION
This PR fixes "Opal crash" discussed privately with @shingarov. The meat of the fix is in last commit, previous commits are mostly cleanup and preparatory work. 