### PR TITLE
Rephrase comment in CardanoTartagliaContext>>evaluate:

### DIFF
--- a/CardanoTartaglia/CardanoTartagliaContext.class.st
+++ b/CardanoTartaglia/CardanoTartagliaContext.class.st
@@ -34,7 +34,7 @@ CardanoTartagliaContext >> evaluate: source [
 	 as context (providing variable values). Return the result.
 	
 	 If the code contains a variable not defined in the receiver,
-	 this method throws `VariableNotDeclared` exception.
+	 throw `VariableNotDeclared` exception.
 	"
 	
 	| compiler |


### PR DESCRIPTION
Both the first and the second paragraph of the comment are equal in  that they both talk about what #evaluate: does, i.e. they both relate to the contract, not the method.  Therefore the tense disparity is potentially confusing, because it can hint that the second paragraph does not talk about the contract.