### PR TITLE
Restore Z3Sort>>mkSetSort

### DIFF
--- a/MachineArithmetic/Z3Sort.class.st
+++ b/MachineArithmetic/Z3Sort.class.st
@@ -161,6 +161,11 @@ Z3Sort >> mkLinearOrder: id [
 	^Z3 mk_linear_order: ctx _: self _: id
 ]
 
+{ #category : #'type theory' }
+Z3Sort >> mkSetSort [
+	^Z3 mk_set_sort: ctx _: self
+]
+
 { #category : #accessing }
 Z3Sort >> name [
 	^Z3 get_sort_name: ctx _:self


### PR DESCRIPTION
This is the only sender of #mk_set_sort:_:, and you really need a way to call mk_set_sort() API because there isn't much point in having Sets without type constructors.

(See the next commit for a downstream sender).