### PR TITLE
Assert `EApp`'s `f` is in ANF

### DIFF
--- a/Refinements/EApp.class.st
+++ b/Refinements/EApp.class.st
@@ -49,18 +49,14 @@ EApp >> elab: anElabEnv [
 		"EAPP-EAPP:
 		 The receiver is a curried function application, (EApp (EApp f x) y).
 		 The higher-order function f takes x and produces  a function g
-		 which is then applied to y.
-		
-		"
+		 which is then applied to y."
 	r := anElabEnv elabEApp: expr _: imm.
 	e₁′ := r first. s₁ := r second. e₂′ := r third. s₂ := r fourth. s := r fifth.
 	e :=  ECst eAppC: s e1: e₁′ e2: (ECst expr: e₂′ sort: s₂).	
 	^{e . s}
-		
-		
-		
 	].
 
+	(expr isKindOf: EVar) ifFalse: [ self error ]. "any application (f x) has f in ANF, and we are just about to wrap it in cast"
 	r := anElabEnv elabEApp: expr _: imm.
 	e₁′ := r first. s₁ := r second. e₂′ := r third. s₂ := r fourth. s := r fifth.
 	e :=  ECst eAppC: s e1: (ECst expr: e₁′ sort: s₁) e2: (ECst expr: e₂′ sort: s₂).	


### PR DESCRIPTION
This should be refactored to real Smalltalk.
At least now the programmer is not distracted by the question, "what if expr is not an EVar".

Also, a similar guard should be applied in the EAPP-EAPP case.