### PR TITLE
Fixes for Smalltalk/X

### DIFF
--- a/PreSmalltalks-Pharo/Trie.class.st
+++ b/PreSmalltalks-Pharo/Trie.class.st
@@ -30,7 +30,7 @@ Class {
 		'children',
 		'nodeValue'
 	],
-	#category : #PreSmalltalks
+	#category : #PreSmalltalks-Pharo
 }
 
 { #category : #'instance creation' }

--- a/stx.gmk
+++ b/stx.gmk
@@ -1,7 +1,7 @@
 # A helper makefile to download Smalltalk/X
 
 # Smalltalk/X download script URL
-STX_DOWNLOADER_SCRIPT_URL := https://swing.fit.cvut.cz/download/smalltalkx/get-stx.py
+STX_DOWNLOADER_SCRIPT_URL := https://dl.vrany.io/public/smalltalkx/get-stx.py
 
 
 #


### PR DESCRIPTION
This PR contains two fixes for Smalltalk/X:

 * Moves `Trie` to `PreSmalltalks-Pharo` to avoid name clash
 * Updates Smalltalk/X download URL to "new" server.