### PR TITLE
Refactor #assertExpectedResult: to go through #proveSafe/Unsafe:

### DIFF
--- a/SpriteLang-Tests/SpriteLangNegTest.class.st
+++ b/SpriteLang-Tests/SpriteLangNegTest.class.st
@@ -5,6 +5,6 @@ Class {
 }
 
 { #category : #running }
-SpriteLangNegTest >> assertExpectedResult: aFixResult [
-	^self deny: aFixResult isSafe
+SpriteLangNegTest >> processString: source [
+	self proveUnsafe: source
 ]

--- a/SpriteLang-Tests/SpriteLangPosTest.class.st
+++ b/SpriteLang-Tests/SpriteLangPosTest.class.st
@@ -5,6 +5,6 @@ Class {
 }
 
 { #category : #running }
-SpriteLangPosTest >> assertExpectedResult: aFixResult [
-	^self assert: aFixResult isSafe
+SpriteLangPosTest >> processString: source [
+	self proveSafe: source
 ]

--- a/SpriteLang-Tests/SpriteLangTest.class.st
+++ b/SpriteLang-Tests/SpriteLangTest.class.st
@@ -5,14 +5,22 @@ Class {
 }
 
 { #category : #running }
-SpriteLangTest >> assertExpectedResult: aFixResult [
+SpriteLangTest >> processString: source [
 	self subclassResponsibility
 ]
 
 { #category : #running }
-SpriteLangTest >> processString: source [
+SpriteLangTest >> proveSafe: source [
 	| prog |
 	prog := ΛκParser parse: source.
 	self deny: prog isPetitFailure.
-	self assertExpectedResult: prog solve
+	self assert: prog solve isSafe
+]
+
+{ #category : #running }
+SpriteLangTest >> proveUnsafe: source [
+	| prog |
+	prog := ΛκParser parse: source.
+	self deny: prog isPetitFailure.
+	self deny: prog solve isSafe
 ]


### PR DESCRIPTION
In some tests (like the upcoming BoolGaloisConnectionTest), it doesn't make sense to split the test class into pos/neg.  With this change, pos/neg test methods can coexist within a single class.