### PR TITLE
Move Product to MathNotation

### DIFF
--- a/MachineArithmetic-MathNotation/Product.class.st
+++ b/MachineArithmetic-MathNotation/Product.class.st
@@ -8,17 +8,12 @@ Class {
 	#name : #Product,
 	#superclass : #Array,
 	#type : #variable,
-	#category : #Refinements
+	#category : #'MachineArithmetic-MathNotation'
 }
 
 { #category : #converting }
 Product >> asArray [
 	^Array withAll: self
-]
-
-{ #category : #'as yet unclassified' }
-Product >> inventFormalArgumentsFor: functor [ 
-	^self asArray collectWithIndex: [ :argSort :j | ('nnf_argºº', functor intSymbol: j-1) -> argSort ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/Refinements/Product.extension.st
+++ b/Refinements/Product.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Product }
+
+{ #category : #'*Refinements' }
+Product >> inventFormalArgumentsFor: functor [ 
+	^self asArray collectWithIndex: [ :argSort :j | ('nnf_argºº', functor intSymbol: j-1) -> argSort ]
+]


### PR DESCRIPTION
It has nothing to do with refinements in particular.

NB: `#mkRelationNamed:` is Z3-specific, but it is in MathNotation so that no circular dependency is created.