### PR TITLE
Literally embed Form when pretty-printing to a rich-text stream

### DIFF
--- a/MachineArithmetic-MathNotation-Pharo/Form.extension.st
+++ b/MachineArithmetic-MathNotation-Pharo/Form.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #Form }
+
+{ #category : #'*MachineArithmetic-MathNotation-Pharo' }
+Form >> printOn: aStream [
+	aStream collectionSpecies = Text ifTrue: [
+		aStream
+			withAttribute: (TextAnchor new anchoredMorph: self)
+			do: [ aStream nextPutAll: (String value: 1) ].
+		^self ].
+	aStream
+        nextPutAll: self class name;
+        nextPut: $(; print: width;
+        nextPut: $x; print: height;
+        nextPut: $x; print: depth;
+        nextPut: $).
+]


### PR DESCRIPTION
This commits lays the ground for implementing Notarfrancesco-style pretty-printing of multiline mathematical objects