### PR TITLE
Rename package "MachineArithmetic-MathNotation" to just "MathNotation"

### DIFF
--- a/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
+++ b/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
@@ -41,11 +41,11 @@ BaselineOfMachineArithmetic >> baseline: spec [
 				package: #'CardanoTartaglia-Tests' with:
 					[spec requires: 'CardanoTartaglia'];
 
-				package: #'MachineArithmetic-MathNotation-Pharo' with:
+				package: #'MathNotation-Pharo' with:
 					[spec requires: 'Z3'];
 
-				package: #'MachineArithmetic-MathNotation' with:
-					[spec requires: 'MachineArithmetic-MathNotation-Pharo'];
+				package: #'MathNotation' with:
+					[spec requires: 'MathNotation-Pharo'];
 
 				package: #'Z3-FFI-Pharo';
 
@@ -57,8 +57,8 @@ BaselineOfMachineArithmetic >> baseline: spec [
 				package: #'Z3-Tests' with:
 					[spec requires: 'Z3'];
 
-				package: #'MachineArithmetic-MathNotation-Tests' with:
-					[spec requires: 'MachineArithmetic-MathNotation'];
+				package: #'MathNotation-Tests' with:
+					[spec requires: 'MathNotation'];
 
 				package: #'DepthFirstSearch' with:
 					[spec requires: 'PreSmalltalks'];
@@ -72,7 +72,7 @@ BaselineOfMachineArithmetic >> baseline: spec [
 					spec requires: 'CardanoTartaglia'.
 					spec requires: 'DepthFirstSearch'.
 					spec requires: 'Z3'.
-					spec requires: 'MachineArithmetic-MathNotation'];
+					spec requires: 'MathNotation'];
 
 				package: #'Refinements-Parsing' with:
 					[

--- a/MachineArithmetic-MathNotation-Pharo/package.st
+++ b/MachineArithmetic-MathNotation-Pharo/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'MachineArithmetic-MathNotation-Pharo' }

--- a/MachineArithmetic-MathNotation-Tests/package.st
+++ b/MachineArithmetic-MathNotation-Tests/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'MachineArithmetic-MathNotation-Tests' }

--- a/MachineArithmetic-MathNotation/package.st
+++ b/MachineArithmetic-MathNotation/package.st
@@ -1,1 +1,0 @@
-Package { #name : #'MachineArithmetic-MathNotation' }

--- a/MathNotation-Pharo/Character.extension.st
+++ b/MathNotation-Pharo/Character.extension.st
@@ -1,11 +1,11 @@
 Extension { #name : #Character }
 
-{ #category : #'*MachineArithmetic-MathNotation-Pharo' }
+{ #category : #'*MathNotation-Pharo' }
 Character class >> nonAsciiSpecialCharacters [
 	^'·÷±×∀∃⋆'
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation-Pharo' }
+{ #category : #'*MathNotation-Pharo' }
 Character class >> specialCharacters [
 	^ '+-/\*~<>=@,%|&?!' , self nonAsciiSpecialCharacters
 ]

--- a/MathNotation-Pharo/Form.extension.st
+++ b/MathNotation-Pharo/Form.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #Form }
 
-{ #category : #'*MachineArithmetic-MathNotation-Pharo' }
+{ #category : #'*MathNotation-Pharo' }
 Form >> printOn: aStream [
 	aStream collectionSpecies = Text ifTrue: [
 		aStream

--- a/MathNotation-Pharo/ManifestMathNotationPharo.class.st
+++ b/MathNotation-Pharo/ManifestMathNotationPharo.class.st
@@ -2,7 +2,7 @@
 I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
 "
 Class {
-	#name : #ManifestMachineArithmeticMathNotationPharo,
+	#name : #ManifestMathNotationPharo,
 	#superclass : #PackageManifest,
-	#category : #'MachineArithmetic-MathNotation-Pharo-Manifest'
+	#category : #'MathNotation-Pharo-Manifest'
 }

--- a/MathNotation-Pharo/RBScanner.extension.st
+++ b/MathNotation-Pharo/RBScanner.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #RBScanner }
 
-{ #category : #'*MachineArithmetic-MathNotation-Pharo' }
+{ #category : #'*MathNotation-Pharo' }
 RBScanner >> classify: aCharacter [
 	| index |
 	aCharacter ifNil: [ ^ nil ].
@@ -16,7 +16,7 @@ RBScanner >> classify: aCharacter [
 	^ classificationTable at: index
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation-Pharo' }
+{ #category : #'*MathNotation-Pharo' }
 RBScanner >> isBinary [
 	characterType = #binary
 		ifTrue: [ [ characterType = #binary ] whileTrue: [ self step ].
@@ -24,7 +24,7 @@ RBScanner >> isBinary [
 	^false
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation-Pharo' }
+{ #category : #'*MathNotation-Pharo' }
 RBScanner class >> isBinary: aSymbol [
 	| scanner |
 	scanner := self basicNew.
@@ -33,20 +33,20 @@ RBScanner class >> isBinary: aSymbol [
 	^ scanner isBinary
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation-Pharo' }
+{ #category : #'*MathNotation-Pharo' }
 RBScanner >> isUnicodeArrow: aCharacter [
 	^#(16r2190 16r2191 16r2192 16r2193 "only the first 4 of the Arrows block appear to work"
 	) includes: aCharacter asInteger
 
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation-Pharo' }
+{ #category : #'*MathNotation-Pharo' }
 RBScanner >> isUnicodeBinary: aCharacter [
 	^ (self isUnicodeArrow: aCharacter) or:[self isUnicodeMathOperator: aCharacter]
 
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation-Pharo' }
+{ #category : #'*MathNotation-Pharo' }
 RBScanner >> isUnicodeInfix: aCharacter [
 	^#(
 	16r2208
@@ -61,7 +61,7 @@ RBScanner >> isUnicodeInfix: aCharacter [
 	collect: [ :codepoint | Character value: codepoint ]"
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation-Pharo' }
+{ #category : #'*MathNotation-Pharo' }
 RBScanner >> isUnicodeMathOperator: aCharacter [
 	"Unicode binary selectors"
 	^ #(

--- a/MathNotation-Pharo/String.extension.st
+++ b/MathNotation-Pharo/String.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #String }
 
-{ #category : #'*MachineArithmetic-MathNotation-Pharo' }
+{ #category : #'*MathNotation-Pharo' }
 String >> numArgs [ 
 	"Answer either the number of arguments that the receiver would take if considered a selector.  Answer -1 if it couldn't be a selector. It is intended mostly for the assistance of spelling correction."
 

--- a/MathNotation-Pharo/package.st
+++ b/MathNotation-Pharo/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'MathNotation-Pharo' }

--- a/MathNotation-Tests/A.class.st
+++ b/MathNotation-Tests/A.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		's'
 	],
-	#category : #'MachineArithmetic-MathNotation-Tests'
+	#category : #'MathNotation-Tests'
 }
 
 { #category : #accessing }

--- a/MathNotation-Tests/AorB.class.st
+++ b/MathNotation-Tests/AorB.class.st
@@ -6,5 +6,5 @@ AorB =
 Class {
 	#name : #AorB,
 	#superclass : #Sum,
-	#category : #'MachineArithmetic-MathNotation-Tests'
+	#category : #'MathNotation-Tests'
 }

--- a/MathNotation-Tests/B.class.st
+++ b/MathNotation-Tests/B.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'i'
 	],
-	#category : #'MachineArithmetic-MathNotation-Tests'
+	#category : #'MathNotation-Tests'
 }
 
 { #category : #accessing }

--- a/MathNotation-Tests/ProductTest.class.st
+++ b/MathNotation-Tests/ProductTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ProductTest,
 	#superclass : #TestCaseWithZ3Context,
-	#category : #'MachineArithmetic-MathNotation-Tests'
+	#category : #'MathNotation-Tests'
 }
 
 { #category : #tests }

--- a/MathNotation-Tests/SumTest.class.st
+++ b/MathNotation-Tests/SumTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SumTest,
 	#superclass : #TestCaseWithZ3Context,
-	#category : #'MachineArithmetic-MathNotation-Tests'
+	#category : #'MathNotation-Tests'
 }
 
 { #category : #tests }

--- a/MathNotation-Tests/package.st
+++ b/MathNotation-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'MathNotation-Tests' }

--- a/MathNotation/BlockClosure.extension.st
+++ b/MathNotation/BlockClosure.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #BlockClosure }
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 BlockClosure >> ∘ [ thenBlock
 	"Answer the block that is the composition of self, then thenBlock.
 	 I.e. f∘g means f, then g.

--- a/MathNotation/Character.extension.st
+++ b/MathNotation/Character.extension.st
@@ -1,241 +1,241 @@
 Extension { #name : #Character }
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Alpha [
 	^self codePoint: 16r0391
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Beta [
 	^self codePoint: 16r0392
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Chi [
 	^self codePoint: 16r03A7
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Delta [
 	^self codePoint: 16r0394
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Epsilon [
 	^self codePoint: 16r0395
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Eta [
 	^self codePoint: 16r0397
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Gamma [
 	^self codePoint: 16r0393
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Iota [
 	^self codePoint: 16r0399
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Kappa [
 	^self codePoint: 16r039A
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Lambda [
 	^self codePoint: 16r039B
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Mu [
 	^self codePoint: 16r039C
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Nu [
 	^self codePoint: 16r039D
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Omega [
 	^self codePoint: 16r03A9
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Omicron [
 	^self codePoint: 16r039F
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Phi [
 	^self codePoint: 16r03A6
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Pi [
 	^self codePoint: 16r03A0
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Psi [
 	^self codePoint: 16r03A8
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Rho [
 	^self codePoint: 16r03A1
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Sigma [
 	^self codePoint: 16r03A3
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Tau [
 	^self codePoint: 16r03A4
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Theta [
 	^self codePoint: 16r0398
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Upsilon [
 	^self codePoint: 16r03A5
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Xi [
 	^self codePoint: 16r039E
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> Zeta [
 	^self codePoint: 16r0396
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> alpha [
 	^self codePoint: 16r03B1
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> ballotBox [
 	^self codePoint: 16r2610
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> beta [
 	^self codePoint: 16r03B2
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> brokenBar [
 	^self codePoint: 16rA6
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> centSign [
 	^self codePoint: 16rA2
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> containsAsNormalSubgroup [
 	^self codePoint: 16r22B3
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> copyrightSign [
 	^self codePoint: 16rA9
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> currencySign [
 	^self codePoint: 16rA4
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> degreeSign [
 	^self codePoint: 16rB0
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> delta [
 	^self codePoint: 16r03B4
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> diaeresis [
 	^self codePoint: 16rA8
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> directSum [
 	^self codePoint: 16r2295
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> divisionSign [
 	^self codePoint: 16rF7
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> emptySet [
 	^self codePoint: 16r2205
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> epsilon [
 	^self codePoint: 16r03B5
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> eta [
 	^self codePoint: 16r03B7
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> exists [
 	^self codePoint: 16r2203
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> feminineOrdinalIndicator [
 	^self codePoint: 16rAA
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> forall [
 	^self codePoint: 16r2200
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> gamma [
 	^self codePoint: 16r03B3
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> invertedExclamationMark [
 	^self codePoint: 16rA1
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> invertedQuestionMark [
 	^self codePoint: 16rBF
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> iota [
 	^self codePoint: 16r03B9
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character >> isLetter [
 	"Return whether the receiver is a letter."
 	"$a isLetter >>> true"
@@ -246,184 +246,184 @@ Character >> isLetter [
 
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character >> isWeirdLetter [
 	^self class weirdLetterCodepoints includes: self charCode
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> isomorphicTo [
 	^self codePoint: 16r2245
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> kappa [
 	^self codePoint: 16r03BA
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> lambda [
 	^self codePoint: 16r03BB
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> leftDoubleBracket [
 	^self codePoint: 16r27E6
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> leftPointingDoubleAngleQuotationMark [
 	^self codePoint: 16rAB
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> macron [
 	^self codePoint: 16rAF
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> masculineOrdinalIndicator [
 	^self codePoint: 16rBA
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> microSign [
 	^self codePoint: 16rB5
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> mu [
 	^self codePoint: 16r03BC
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> multiplicationSign [
 	^self codePoint: 16rD7
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> normalSubgroupOf [
 	^self codePoint: 16r22B2
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> notSign [
 	^self codePoint: 16rAC
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> nu [
 	^self codePoint: 16r03BD
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> omega [
 	^self codePoint: 16r03B9
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> omicron [
 	^self codePoint: 16r03BF
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> oneHalf [
 	^self codePoint: 16rBD
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> oneQuarter [
 	^self codePoint: 16rBC
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> phi [
 	^self codePoint: 16r03C6
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> pi [
 	^self codePoint: 16r03C0
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> pilcrowSign [
 	^self codePoint: 16rB6
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> plusMinusSign [
 	^self codePoint: 16rB1
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> poundSign [
 	^self codePoint: 16rA3
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> psi [
 	^self codePoint: 16r03C8
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> reals [
 	^self codePoint: 16r211D
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> registeredSign [
 	^self codePoint: 16rAE
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> replacementCharacter [
 	"Used to represent unknown/unrecognized/unrepresentable data in Unicode 3.0.
 	 Often displayed as a black rhombus with a white question mark."
 	^self codePoint: 16rFFFD
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> rho [
 	^self codePoint: 16r03C1
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> rightDoubleBracket [
 	^self codePoint: 16r27E7
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> rightPointingDoubleAngleQuotationMark [
 	^self codePoint: 16rBB
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> ringOperator [
 	^self codePoint: 16r2218
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> sectionSign [
 	^self codePoint: 16rA7
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> sigma [
 	^self codePoint: 16r03C3
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> softHyphen [
 	^self codePoint: 16rAD
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> starOperator [
 	^self codePoint: 16r22C6
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> subscriptCodepoints [
 	^#(
 	16r2080 "SUBSCRIPT ZERO"
@@ -462,27 +462,27 @@ Character class >> subscriptCodepoints [
 	    Character subscriptCodepoints collect: #asCharacter. 	"
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> tau [
 	^self codePoint: 16r03C4
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> theta [
 	^self codePoint: 16r03B8
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> threeQuarters [
 	^self codePoint: 16rBE
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> upsilon [
 	^self codePoint: 16r03C5
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> weirdLetterCodepoints [
 	"We classify them as letters for the Smalltalk scanner, so they can be receivers,
 	 and not binary selectors."
@@ -501,22 +501,22 @@ Character class >> weirdLetterCodepoints [
 	), self subscriptCodepoints
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> xi [
 	^self codePoint: 16r03BE
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> yenSign [
 	^self codePoint: 16rA5
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> zahlen [
 	^self codePoint: 16r2124
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Character class >> zeta [
 	^self codePoint: 16r03B6
 ]

--- a/MathNotation/Class.extension.st
+++ b/MathNotation/Class.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #Class }
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Class >> ∪ [ anotherClass
 	"Join in the semilattice of classes partially-ordered by 'is-subclass-of'.
 	
@@ -14,7 +14,7 @@ Class >> ∪ [ anotherClass
 	^self superclass ∪ anotherClass
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Class >> ⊆ [ anotherClass
 	"Answer whether the receiver is a subclass of anotherClass,
 	 reflexive case included.

--- a/MathNotation/Collection.extension.st
+++ b/MathNotation/Collection.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #Collection }
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Collection >> ⊗ [ anotherCollection
 	| answer |
 	answer := OrderedCollection new.

--- a/MathNotation/ManifestMathNotation.class.st
+++ b/MathNotation/ManifestMathNotation.class.st
@@ -2,7 +2,7 @@
 I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
 "
 Class {
-	#name : #ManifestMachineArithmeticMathNotation,
+	#name : #ManifestMathNotation,
 	#superclass : #PackageManifest,
-	#category : #'MachineArithmetic-MathNotation-Manifest'
+	#category : #'MathNotation-Manifest'
 }

--- a/MathNotation/Object.extension.st
+++ b/MathNotation/Object.extension.st
@@ -1,11 +1,11 @@
 Extension { #name : #Object }
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Object >> ∈ [ aCollection
 	^aCollection includes: self
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Object >> ∘ [ f
 	"Compose 'self before f', in the left-to-right order
 	 like in P.M.Cohn's 'Universal Algebra' and opposite 
@@ -14,17 +14,17 @@ Object >> ∘ [ f
 	^f value: self
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Object >> ≅ [ anObject
 	^self = anObject
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Object >> ⊛ [ Fa
 	^Fa collect: self
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Object >> ⨰ [ rhs
 	^(Product with: self) ⨰ rhs
 ]

--- a/MathNotation/Product.class.st
+++ b/MathNotation/Product.class.st
@@ -8,7 +8,7 @@ Class {
 	#name : #Product,
 	#superclass : #Array,
 	#type : #variable,
-	#category : #'MachineArithmetic-MathNotation'
+	#category : #MathNotation
 }
 
 { #category : #converting }

--- a/MathNotation/Sum.class.st
+++ b/MathNotation/Sum.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #Sum,
 	#superclass : #Object,
-	#category : #'MachineArithmetic-MathNotation'
+	#category : #MathNotation
 }
 
 { #category : #'as yet unclassified' }

--- a/MathNotation/SumArgumentDecoder.class.st
+++ b/MathNotation/SumArgumentDecoder.class.st
@@ -6,7 +6,7 @@ Class {
 		'object',
 		'stillLeft'
 	],
-	#category : #'MachineArithmetic-MathNotation'
+	#category : #MathNotation
 }
 
 { #category : #'instance creation' }

--- a/MathNotation/SumConstructorDecoder.class.st
+++ b/MathNotation/SumConstructorDecoder.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'sumClass'
 	],
-	#category : #'MachineArithmetic-MathNotation'
+	#category : #MathNotation
 }
 
 { #category : #'instance creation' }

--- a/MathNotation/SumDecoder.class.st
+++ b/MathNotation/SumDecoder.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'jsonReader'
 	],
-	#category : #'MachineArithmetic-MathNotation'
+	#category : #MathNotation
 }
 
 { #category : #accessing }

--- a/MathNotation/UndefinedObject.extension.st
+++ b/MathNotation/UndefinedObject.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #UndefinedObject }
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 UndefinedObject >> ⊆ [ aClass 
 	^false
 ]

--- a/MathNotation/Z3BoolSort.extension.st
+++ b/MathNotation/Z3BoolSort.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #Z3BoolSort }
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Z3BoolSort >> printString [
 	^String with: (Character codePoint: 16r1D539)
 ]

--- a/MathNotation/Z3IntSort.extension.st
+++ b/MathNotation/Z3IntSort.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #Z3IntSort }
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Z3IntSort >> printString [
 	^String with: Character zahlen
 ]

--- a/MathNotation/Z3Set.extension.st
+++ b/MathNotation/Z3Set.extension.st
@@ -1,21 +1,21 @@
 Extension { #name : #Z3Set }
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Z3Set >> ∩ [ anotherSet
 	^self intersection: anotherSet
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Z3Set >> ∪ [ anotherSet
 	^self union: anotherSet
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Z3Set >> ⊆ [ anotherSet
 	^self isSubsetOf: anotherSet
 ]
 
-{ #category : #'*MachineArithmetic-MathNotation' }
+{ #category : #'*MathNotation' }
 Z3Set >> ⊖ [ anotherSet
 	"Symmetric difference, acting as the additive operation of the Boolean ring
 	 (#∩ being its multiplicative operation.)"

--- a/MathNotation/package.st
+++ b/MathNotation/package.st
@@ -1,0 +1,1 @@
+Package { #name : #MathNotation }


### PR DESCRIPTION
This commits rename package "MachineArithmetic-MathNotation" (and related) to just "MathNotation" to reduce confusion. See issue #163.