### PR TITLE
Use full smalltalk parser when parsing refinement expression

### DIFF
--- a/src/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
+++ b/src/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
@@ -85,8 +85,15 @@ BaselineOfMachineArithmetic >> baseline: spec [
 				package: #'Refinements-Doodles' with:
 					[spec requires: 'Refinements-Parsing'];
 
+				package: #'PetitSmalltalk' with:
+					[
+					spec requires: 'PetitParser'.
+					spec repository: 'github://shingarov/PetitParser:ULD'];
+
 				package: #'SpriteLang' with:
-					[spec requires: 'Refinements'];
+					[
+					spec requires: 'PetitSmalltalk'.
+					spec requires: 'Refinements'];
 
 				package: #'SpriteLang-Tests' with:
 					[spec requires: 'SpriteLang'].

--- a/src/SpriteLang/RefinementExpressionParser.class.st
+++ b/src/SpriteLang/RefinementExpressionParser.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : #RefinementExpressionParser,
+	#superclass : #PPSmalltalkParser,
+	#instVars : [
+		'binaryChar'
+	],
+	#category : #'SpriteLang-Parsing'
+}
+
+{ #category : #primitives }
+RefinementExpressionParser >> binary [
+	^binaryChar plus
+]
+
+{ #category : #primitives }
+RefinementExpressionParser >> binaryChar [
+	| scanner |
+	
+	"Here we delegate decisiton whether or not a character can occur in 
+	 binary selector to RBScanner. For example: MathNotation hacks RBScanner
+	 to allow fancy math characters and we do not want to duplicate that code
+	 here."
+	
+	scanner := RBScanner on:'' readStream.
+	^ (PPPredicateObjectParser on: [:c | (scanner classify: c) == #binary ] message:'binary')
+]
+
+{ #category : #accessing }
+RefinementExpressionParser >> start [
+	^sequence
+]

--- a/src/SpriteLang/RefinementParser.class.st
+++ b/src/SpriteLang/RefinementParser.class.st
@@ -2,6 +2,7 @@ Class {
 	#name : #RefinementParser,
 	#superclass : #PPCompositeParser,
 	#instVars : [
+		'concReftBExpr',
 		'matchedParen',
 		'funArg',
 		'reftB',
@@ -43,12 +44,17 @@ RefinementParser >> aRefBody [
 
 { #category : #grammar }
 RefinementParser >> concReftB [
-	^ self lowerId trim, $| asParser trim, self nonBracket plus flatten
+	^ self lowerId trim, $| asParser trim, concReftBExpr
 	==> [ :id_pred |
 			| id pred |
 			id := id_pred first.
 			pred := id_pred last.
 			(Reft symbol: id expr: (DecidableRefinement text: pred)) known ]
+]
+
+{ #category : #grammar }
+RefinementParser >> concReftBExpr [
+	^RefinementExpressionParser new ==> [ :seq | seq formattedCode ]
 ]
 
 { #category : #grammar }


### PR DESCRIPTION
This commit uses a full smalltalk parser (based on `PetitSmalltalk`) when parsing refining expression in refinement type (as opposed to simply reading everything up first closing bracket).

Note, that one still cannot do something like:
```
⟦val x : int [v|v===42 ifTrue:[Bool true] ifFalse:[Bool false]]⟧
let x = 42;
```

Not because parser does not allow it, but because the way Opal handles "evaluate in context" (being passed down Cardano-Tartaglia) just does not seem to work with must-be-boolean deoptimization machinery. But that's a different story. 