### PR TITLE
Uniquify all Sprite preterms in [Chk-Lam]

### DIFF
--- a/src/Refinements/EVar.class.st
+++ b/src/Refinements/EVar.class.st
@@ -122,6 +122,12 @@ EVar >> readStream [
 	^sym readStream
 ]
 
+{ #category : #'α-renaming' }
+EVar >> rename: a to: b [
+	sym = a ifTrue: [ ^self class of: b ].
+	^self
+]
+
 { #category : #'SMT interface' }
 EVar >> smt2: aSymEnv [
 	^(aSymEnv sort at: sym) z3sort mkConst: sym

--- a/src/Refinements/Expr.class.st
+++ b/src/Refinements/Expr.class.st
@@ -354,6 +354,11 @@ cf. Refinements.hs
 
 { #category : #'α-renaming' }
 Expr >> rename: a to: b [
+	"Rename occurrences of expression-level var a, to b.
+	 NB: This is polymorphic with Sprite expressions and
+	 RTypes, the latter possibly polymorphic over some
+	 tvar; do NOT rename tvar 'a to 'b.
+	 "
 	^DelayedSubst from: a toVar: b in: self
 ]
 

--- a/src/Refinements/HPred.class.st
+++ b/src/Refinements/HPred.class.st
@@ -89,6 +89,11 @@ HPred >> pruneTautsGoP [
 	self subclassResponsibility
 ]
 
+{ #category : #'α-renaming' }
+HPred >> rename: a to: b [
+	self subclassResponsibility
+]
+
 { #category : #'F.Subable' }
 HPred >> subst1: su [
 	self subclassResponsibility

--- a/src/Refinements/HPredAnd.class.st
+++ b/src/Refinements/HPredAnd.class.st
@@ -103,6 +103,11 @@ HPredAnd >> ps: anObject [
 	ps := anObject
 ]
 
+{ #category : #'α-renaming' }
+HPredAnd >> rename: a to: b [
+	^self class of: (ps collect: [ :each | each rename: a to: b ])
+]
+
 { #category : #'F.Subable' }
 HPredAnd >> subst1: su [
 	^HPredAnd of: (ps collect: [ :p | p subst1: su ])

--- a/src/Refinements/HReft.class.st
+++ b/src/Refinements/HReft.class.st
@@ -65,6 +65,12 @@ goP (Reft e) = if F.isTautoPred e then Nothing else Just $ Reft e
 	^self
 ]
 
+{ #category : #'α-renaming' }
+HReft >> rename: a to: b [
+	^self class
+		expr: (expr rename: a to: b)
+]
+
 { #category : #'F.Subable' }
 HReft >> subst1: su [
 	^HReft expr: (expr subst1: su)

--- a/src/SpriteLang-Tests/BoolGaloisConnectionTest.class.st
+++ b/src/SpriteLang-Tests/BoolGaloisConnectionTest.class.st
@@ -93,7 +93,6 @@ BoolGaloisConnectionTest >> testAlphaClash [
 	 so must end up in the same UNSAFE result.
 	 However, this breaks, see issue #139.
 	"
-	self skip. "Remove this skip after #139 is resolved."
 	self proveUnsafe: '
 ⟦val b2i : b:bool => int[i | ((i===0) not <=> b) & ((i===0)|(i===1)) ] ⟧
 let b2i = (b) => {

--- a/src/SpriteLang/Alt.class.st
+++ b/src/SpriteLang/Alt.class.st
@@ -59,3 +59,11 @@ Alt >> expr [
 Alt >> expr: anObject [
 	expr := anObject
 ]
+
+{ #category : #'α-renaming' }
+Alt >> rename: a to: b [
+	^self class
+		daCon: daCon
+		binds: (binds collect: [ :each | each rename: a to: b])
+		expr: (expr rename: a to: b)
+]

--- a/src/SpriteLang/EAnn.class.st
+++ b/src/SpriteLang/EAnn.class.st
@@ -60,6 +60,13 @@ EAnn >> gtChildren [
 	^{ expr . ann }
 ]
 
+{ #category : #'α-renaming' }
+EAnn >> rename: a to: b [
+	^self class
+		expr: (expr rename: a to: b)
+		ann:  (ann  rename: a to: b)
+]
+
 { #category : #'as yet unclassified' }
 EAnn >> synth: Γ [
 "

--- a/src/SpriteLang/ECase.class.st
+++ b/src/SpriteLang/ECase.class.st
@@ -58,6 +58,15 @@ ECase >> goSubsTyExpr: su [
 		])
 ]
 
+{ #category : #'α-renaming' }
+ECase >> rename: a to: b [
+	| x′ alts′ |
+	x′ := x=a ifTrue: [b] ifFalse: [x].
+	alts′ := alts collect: [ :each | each rename: a to: b ].
+	^self class
+		x: x′ alts: alts′
+]
+
 { #category : #accessing }
 ECase >> x [
 	^ x

--- a/src/SpriteLang/ECon.class.st
+++ b/src/SpriteLang/ECon.class.st
@@ -45,6 +45,11 @@ ECon >> prim: anObject [
 	prim := anObject
 ]
 
+{ #category : #'α-renaming' }
+ECon >> rename: a to: b [
+	^self
+]
+
 { #category : #accessing }
 ECon >> sym [
 	^nil

--- a/src/SpriteLang/EFun.class.st
+++ b/src/SpriteLang/EFun.class.st
@@ -38,17 +38,19 @@ EFun >> check: Γ rtype: f [
       ---------------------------- [Chk-Lam]
       Γ ⊦ λx.e <== y:s -> t
 "
-	| bx x e  y s t  s1 t1  Γ1  c |
+	| bx x x′ e e′ y s t  s1 t1  Γ′  c |
 	bx := bind. x := bx id. e := expr.
 	(f isKindOf: TFun) ifFalse: [ ^super check: Γ rtype: f ].
-	y := f x. s := f s. t := f t.
-
-	s1 := s subst: y with: x.
-	t1 := t subst: y with: x.
 	
-	Γ1 := Γ extEnv: x rtype: s1.
-	c := e check: Γ1 rtype: t1.
-	^s cAll: x cstr: c
+	y := f x. s := f s. t := f t.
+	x′ := x spriteλuniquify.
+	e′ := e rename: x to: x′.
+	s1 := s subst: y with: x′.
+	t1 := t subst: y with: x′.
+	
+	Γ′ := Γ extEnv: x′ rtype: s1.
+	c := e′ check: Γ′ rtype: t1.
+	^s cAll: x′ cstr: c
 ]
 
 { #category : #polymorphism }
@@ -78,6 +80,13 @@ EFun >> goSubsTyExpr: su [
 { #category : #GT }
 EFun >> gtChildren [
 	^expr gtChildren
+]
+
+{ #category : #'α-renaming' }
+EFun >> rename: a to: b [
+	^self class
+		bind: (bind rename: a to: b)
+		expr: (expr rename: a to: b)
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/SpriteLang/EIf.class.st
+++ b/src/SpriteLang/EIf.class.st
@@ -68,6 +68,14 @@ EIf >> goSubsTyExpr: su [
 	^EIf cond: cond trueE: (trueE goSubsTyExpr: su) falseE: (falseE goSubsTyExpr: su)
 ]
 
+{ #category : #'α-renaming' }
+EIf >> rename: a to: b [
+	^EIf
+		cond: (cond rename: a to: b)
+		trueE: (trueE rename: a to: b)
+		falseE: (falseE rename: a to: b)
+]
+
 { #category : #accessing }
 EIf >> trueE [
 	^ trueE

--- a/src/SpriteLang/EImm.class.st
+++ b/src/SpriteLang/EImm.class.st
@@ -39,6 +39,11 @@ EImm >> immYourself [
 	^self
 ]
 
+{ #category : #'α-renaming' }
+EImm >> rename: a to: b [
+	^EImm imm: (imm rename: a to: b)
+]
+
 { #category : #'as yet unclassified' }
 EImm >> synth: Γ [
 "

--- a/src/SpriteLang/ELet.class.st
+++ b/src/SpriteLang/ELet.class.st
@@ -79,3 +79,11 @@ ELet >> goSubsTyExpr: su [
 ELet >> gtChildren [
 	^{decl . expr}
 ]
+
+{ #category : #'α-renaming' }
+ELet >> rename: a to: b [
+	^ELet
+		decl: (decl rename: a to: b)
+		expr: (expr rename: a to: b)
+		
+]

--- a/src/SpriteLang/ERApp.class.st
+++ b/src/SpriteLang/ERApp.class.st
@@ -29,6 +29,12 @@ ERApp >> goSubsTyExpr: su [
 	^ERApp expr: (expr goSubsTyExpr: su)
 ]
 
+{ #category : #'α-renaming' }
+ERApp >> rename: a to: b [
+	^self class
+		expr: (expr rename: a to: b)
+]
+
 { #category : #'as yet unclassified' }
 ERApp >> synth: Γ [
 "

--- a/src/SpriteLang/ETApp.class.st
+++ b/src/SpriteLang/ETApp.class.st
@@ -31,6 +31,13 @@ ETApp >> goSubsTyExpr: su [
 	^ETApp expr: (expr goSubsTyExpr: su) rtype: (rtype subsTy: su)
 ]
 
+{ #category : #'α-renaming' }
+ETApp >> rename: a to: b [
+	^self class
+		expr:  (expr  rename: a to: b)
+		rtype: (rtype rename: a to: b)
+]
+
 { #category : #accessing }
 ETApp >> rtype [
 	^ rtype

--- a/src/SpriteLang/KnownReft.class.st
+++ b/src/SpriteLang/KnownReft.class.st
@@ -111,6 +111,13 @@ can determine whether a DecidableRefinement is an RVar-application.
 	^KnownReft symbol: symbol expr: (expr refactorAppP: amendedEnv)
 ]
 
+{ #category : #'α-renaming' }
+KnownReft >> rename: a to: b [
+	^self class
+		symbol: symbol
+		expr: (expr rename: a to: b)
+]
+
 { #category : #SubsARef }
 KnownReft >> subs: p ar: ar [
 "

--- a/src/SpriteLang/SpriteBind.class.st
+++ b/src/SpriteLang/SpriteBind.class.st
@@ -29,3 +29,9 @@ SpriteBind >> printOn: aStream [
 		nextPutAll: id;
 		nextPutAll: '"'
 ]
+
+{ #category : #'α-renaming' }
+SpriteBind >> rename: a to: b [
+	id = a ifFalse: [ ^self ].
+	^self class id: b
+]

--- a/src/SpriteLang/SpriteDecl.class.st
+++ b/src/SpriteLang/SpriteDecl.class.st
@@ -69,6 +69,13 @@ SpriteDecl >> printOn: aStream [
 	self printStructOn: aStream
 ]
 
+{ #category : #'α-renaming' }
+SpriteDecl >> rename: a to: b [
+	^self class
+		bind: bind
+		expr: (expr rename: a to: b)
+]
+
 { #category : #'as yet unclassified' }
 SpriteDecl >> subsTy: su [ 
 	^self class bind: bind expr: (expr subsTy: su)

--- a/src/SpriteLang/String.extension.st
+++ b/src/SpriteLang/String.extension.st
@@ -40,6 +40,11 @@ rVar :: F.Symbol -> RType
 ]
 
 { #category : #'*SpriteLang' }
+String >> spriteλuniquify [
+	^self, '__ß', VariableAlphabet nextJ printString
+]
+
+{ #category : #'*SpriteLang' }
 String >> unifyX: anotherString [ 
 	^self
 ]

--- a/src/SpriteLang/TBase.class.st
+++ b/src/SpriteLang/TBase.class.st
@@ -126,6 +126,13 @@ TBase >> reft [
 	^r
 ]
 
+{ #category : #'α-renaming' }
+TBase >> rename: x to: y [
+	^self class
+		b: b
+		r: (r rename: x to: y)
+]
+
 { #category : #'as yet unclassified' }
 TBase >> rtypeSort [
 	^b baseSort

--- a/src/SpriteLang/TCon.class.st
+++ b/src/SpriteLang/TCon.class.st
@@ -120,6 +120,15 @@ TCon >> reft [
 	^r
 ]
 
+{ #category : #'α-renaming' }
+TCon >> rename: a to: b [
+	^self class
+		c: c
+		ts: (ts collect: [ :each | each rename: a to: b])
+		ars: (ars collect: [ :each | each rename: a to: b])
+		r: (r collect: [ :each | each rename: a to: b])
+]
+
 { #category : #'synthesis constraints' }
 TCon >> singleton: x [
 	^TCon

--- a/src/SpriteLang/TFun.class.st
+++ b/src/SpriteLang/TFun.class.st
@@ -133,6 +133,11 @@ TFun >> refactorAppR: anEvalEnv [
 		t: (t refactorAppR: amendedEnv)
 ]
 
+{ #category : #'α-renaming' }
+TFun >> rename: a to: b [
+	^self
+]
+
 { #category : #'as yet unclassified' }
 TFun >> rtypeSort [
 	^self sort "TODO: figure out the difference?"

--- a/src/SpriteLang/UnknownReft.class.st
+++ b/src/SpriteLang/UnknownReft.class.st
@@ -37,6 +37,11 @@ UnknownReft >> printOn: aStream [
 	aStream nextPut: Character starOperator
 ]
 
+{ #category : #'α-renaming' }
+UnknownReft >> rename: a to: b [
+	^self
+]
+
 { #category : #SubsARef }
 UnknownReft >> subs: p ar: ar [
 "

--- a/src/SpriteLang/Val.class.st
+++ b/src/SpriteLang/Val.class.st
@@ -3,3 +3,13 @@ Class {
 	#superclass : #SpriteAnn,
 	#category : #SpriteLang
 }
+
+{ #category : #'α-renaming' }
+Val >> rename: a to: b [
+	| symbol′ rtype′ metric′ |
+	symbol′ := symbol=a ifTrue: [b] ifFalse: [symbol].
+	rtype′ := rtype rename: a to: b.
+	metric isNil ifFalse: [ self shouldBeImplemented  ].
+	^self class
+		symbol: symbol′ rtype: rtype′ metric: metric
+]

--- a/src/SpriteLang/ΛBase.class.st
+++ b/src/SpriteLang/ΛBase.class.st
@@ -38,3 +38,11 @@ RType where r=Reft, here Reft meaning ΛReft.
 ΛBase >> freeTVarsGoB [
 	^Set new
 ]
+
+{ #category : #'α-renaming' }
+ΛBase >> rename: a to: b [
+	"Because #rename:to: only renames expr-level vars
+	 (cf. Expr>>rename:to:), and Sprite base types are
+	 not dependent on expressions, do nothing."
+	^self
+]

--- a/src/SpriteLang/ΛEApp.class.st
+++ b/src/SpriteLang/ΛEApp.class.st
@@ -87,6 +87,13 @@ cf. Parser.hs
 	imm := anObject
 ]
 
+{ #category : #'α-renaming' }
+ΛEApp >> rename: a to: b [
+	^self class
+		expr: (expr rename: a to: b)
+		imm:  (imm  rename: a to: b)
+]
+
 { #category : #'as yet unclassified' }
 ΛEApp >> synth: Γ [
 "


### PR DESCRIPTION
Here is another attempt at resolving #139.
Introducing λ-abstractions may result in disastrous name capture, as #testAlphaClash demonstrates.
This proposed fix uniquifies all λ-abstractions at [Chk-Lam] time.