### PR TITLE
Uniquify all Sprite preterms in separate step prior elaboration

### DIFF
--- a/src/SpriteLang-Tests/BoolGaloisConnectionTest.class.st
+++ b/src/SpriteLang-Tests/BoolGaloisConnectionTest.class.st
@@ -93,7 +93,6 @@ BoolGaloisConnectionTest >> testAlphaClash [
 	 so must end up in the same UNSAFE result.
 	 However, this breaks, see issue #139.
 	"
-	self skip. "Remove this skip after #139 is resolved."
 	self proveUnsafe: '
 ⟦val b2i : b:bool => int[i | ((i===0) not <=> b) & ((i===0)|(i===1)) ] ⟧
 let b2i = (b) => {

--- a/src/SpriteLang-Tests/BoolGaloisConnectionTest.class.st
+++ b/src/SpriteLang-Tests/BoolGaloisConnectionTest.class.st
@@ -115,6 +115,18 @@ let i2i = (i) => {
 ]
 
 { #category : #tests }
+BoolGaloisConnectionTest >> testAlphaClash2 [
+	self proveSafe: '
+⟦val f1 : x:int => y:int => int[z | z === (x + y + 3) ] ⟧
+let f1 = (x,y) => {
+	let x = x + 1;
+	let y = y + x;	
+	y + 2
+};
+'
+]
+
+{ #category : #tests }
 BoolGaloisConnectionTest >> testB2I [
 	self proveSafe: '
 ⟦val b2i : b:bool => int[i | (i===0) not <=> b ] ⟧

--- a/src/SpriteLang-Tests/L7NegTest.class.st
+++ b/src/SpriteLang-Tests/L7NegTest.class.st
@@ -47,6 +47,24 @@ let rec sum = (n) => {
 ]
 
 { #category : #tests }
+L7NegTest >> test_sum02 [
+	self processString: '
+[--check-termination]
+⟦val sum : x:int => int[v|0 <= v] / [x]⟧
+let rec sum = (n) => {
+    let cond = n == 0;
+    if (cond) {
+        0
+    } else {
+        let n1 = n-1;
+        let t1 = sum(n1);
+        n + t1
+    }
+};
+'
+]
+
+{ #category : #tests }
 L7NegTest >> test_sumAcc [
 	self processString: '
 [--check-termination]

--- a/src/SpriteLang/ARef.class.st
+++ b/src/SpriteLang/ARef.class.st
@@ -99,6 +99,18 @@ ARef >> tsubstGoA: outerT tVar: outerA [
 			x -> (t rSortToRType tsubstGo: outerT tVar: outerA) rTypeToRSort ])
 ]
 
+{ #category : #'α-renaming' }
+ARef >> uniq2: α [
+	| α′ |
+	
+	α′ := α.
+	arArgs do:[:a|α′ := α′ extMap: a key to: a key uniq]. 
+
+	^self class
+		arArgs: (arArgs collect:[:a|(α′ at: a key) -> (a value uniq2: α′)])
+		arPred: (arPred uniq2: α′)
+]
+
 { #category : #'as yet unclassified' }
 ARef >> ≺+ rhs [
 	| xts1 p1 xts2 p2 su |

--- a/src/SpriteLang/Alt.class.st
+++ b/src/SpriteLang/Alt.class.st
@@ -59,3 +59,11 @@ Alt >> expr [
 Alt >> expr: anObject [
 	expr := anObject
 ]
+
+{ #category : #'α-renaming' }
+Alt >> uniq2: α [
+	^self class
+		daCon: daCon
+		binds: (binds collect: [ :each | each uniq2: α])
+		expr: (expr uniq2: α)
+]

--- a/src/SpriteLang/EAnn.class.st
+++ b/src/SpriteLang/EAnn.class.st
@@ -72,3 +72,13 @@ EAnn >> synth: Γ [
 	c := expr check: Γ rtype: t.
 	^{ c . t }
 ]
+
+{ #category : #'α-renaming' }
+EAnn >> uniq2: α [
+
+	^self class
+		expr: (expr uniq2: α)
+		ann:  (ann uniq2: α)
+
+
+]

--- a/src/SpriteLang/ECase.class.st
+++ b/src/SpriteLang/ECase.class.st
@@ -58,6 +58,16 @@ ECase >> goSubsTyExpr: su [
 		])
 ]
 
+{ #category : #'α-renaming' }
+ECase >> uniq2: α [
+	| x′ alts′ |
+	x′ := α at: x ifAbsent:[x].
+	alts′ := alts collect: [ :each | each uniq2: α ].
+	^self class
+		x: x′ alts: alts′
+
+]
+
 { #category : #accessing }
 ECase >> x [
 	^ x

--- a/src/SpriteLang/ECon.class.st
+++ b/src/SpriteLang/ECon.class.st
@@ -59,3 +59,8 @@ ECon >> synthImm: Γ [
 ECon >> toFX [
 	^self shouldBeImplemented 
 ]
+
+{ #category : #'α-renaming' }
+ECon >> uniq2: α [
+	"Nothing to do"
+]

--- a/src/SpriteLang/EFun.class.st
+++ b/src/SpriteLang/EFun.class.st
@@ -82,11 +82,13 @@ EFun >> gtChildren [
 
 { #category : #'as yet unclassified' }
 EFun >> renameTy: ty metric: m [
-	| x y s′ t′ t′′_m′ t′′ m′ |
+	| x y s′ t′ m′ t′′_m′′ t′′ m′′ |
 	(ty isKindOf: TFun) ifFalse: [ ^super renameTy: ty metric: m ].
 	x := bind id. y:= ty x.
 	s′ := ty s subst: y _: x.
 	t′ := ty t subst: y _: x.
-	t′′_m′ := expr renameTy: t′ metric: m.  t′′ := t′′_m′ key. m′ := t′′_m′ value.
-	^(TFun x: x s: s′ t: t′′) -> m′
+	m′ := m subst: y _: x.
+
+	t′′_m′′ := expr renameTy: t′ metric: m′.  t′′ := t′′_m′′ key. m′′ := t′′_m′′ value.
+	^(TFun x: x s: s′ t: t′′) -> m′′
 ]

--- a/src/SpriteLang/EFun.class.st
+++ b/src/SpriteLang/EFun.class.st
@@ -92,3 +92,16 @@ EFun >> renameTy: ty metric: m [
 	t′′_m′′ := expr renameTy: t′ metric: m′.  t′′ := t′′_m′′ key. m′′ := t′′_m′′ value.
 	^(TFun x: x s: s′ t: t′′) -> m′′
 ]
+
+{ #category : #'α-renaming' }
+EFun >> uniq2: α [
+	| id id′ α′ |
+
+	id  := bind id.
+	id′ := α at: id ifAbsent:[id uniq].
+	α′  := α extMap: id to: id′.
+
+	^self class
+		bind: (bind uniq2: α′)
+		expr: (expr uniq2: α′)
+]

--- a/src/SpriteLang/EIf.class.st
+++ b/src/SpriteLang/EIf.class.st
@@ -77,3 +77,12 @@ EIf >> trueE [
 EIf >> trueE: anObject [
 	trueE := anObject
 ]
+
+{ #category : #'α-renaming' }
+EIf >> uniq2: α [
+	^self class
+		cond: (cond uniq2: α)
+		trueE: (trueE uniq2: α)
+		falseE: (falseE uniq2: α).
+
+]

--- a/src/SpriteLang/EImm.class.st
+++ b/src/SpriteLang/EImm.class.st
@@ -51,3 +51,14 @@ EImm >> synth: Γ [
 	t := imm synthImm: Γ.
 	^{ HCstr cTrue . t }
 ]
+
+{ #category : #'as yet unclassified' }
+EImm >> uniq [
+	"Nothing to do. This is only called on 'sentinel' EImm terminating list of ELet decls"
+]
+
+{ #category : #'α-renaming' }
+EImm >> uniq2: α [
+	^self class imm: (imm uniq2: α)
+
+]

--- a/src/SpriteLang/ELet.class.st
+++ b/src/SpriteLang/ELet.class.st
@@ -79,3 +79,38 @@ ELet >> goSubsTyExpr: su [
 ELet >> gtChildren [
 	^{decl . expr}
 ]
+
+{ #category : #'α-renaming' }
+ELet >> uniq [
+	"α-rename all variables ensuring all have unique names.
+	 Returns a new instance."
+
+	| α decl′ expr′ |
+
+	α := αRenames empty.
+	decl′ := decl class bind: decl bind expr: (decl expr uniq2: α).
+	expr′ := expr uniq.
+
+	^self class
+		decl: decl′
+		expr: expr′
+
+
+
+
+]
+
+{ #category : #'α-renaming' }
+ELet >> uniq2: α [
+	| id id′ α′ decl′ expr′ |
+
+	id := decl bind id.
+	id′:= α at: id ifAbsent:[id uniq].
+	α′ := α extMap: id to: id′.
+
+	decl′ := decl class bind: (decl bind uniq2: α′) expr: (decl expr uniq2: α)."<-- CERTAINLY NOT α′!!!"
+	expr′ := expr uniq2: α′.
+
+	^self class decl: decl′ expr: expr′
+
+]

--- a/src/SpriteLang/ERApp.class.st
+++ b/src/SpriteLang/ERApp.class.st
@@ -41,3 +41,10 @@ ERApp >> synth: Γ [
 	s′ := s rinst.
 	^{ c . s′ }
 ]
+
+{ #category : #'α-renaming' }
+ERApp >> uniq2: α [
+	^self class
+		expr: (expr uniq2: α)
+
+]

--- a/src/SpriteLang/ETApp.class.st
+++ b/src/SpriteLang/ETApp.class.st
@@ -55,3 +55,11 @@ ETApp >> synth: Γ [
 	tt := Γ refresh: rtype.
 	^{ ce . te type tsubst: tt tVar: te var }
 ]
+
+{ #category : #'α-renaming' }
+ETApp >> uniq2: α [
+	^self class
+		expr: (expr uniq2: α)
+		rtype: (rtype uniq2: α)
+
+]

--- a/src/SpriteLang/ETLam.class.st
+++ b/src/SpriteLang/ETLam.class.st
@@ -64,3 +64,8 @@ ETLam >> tvar [
 ETLam >> tvar: anObject [
 	tvar := anObject
 ]
+
+{ #category : #'α-renaming' }
+ETLam >> uniq2: α [
+	self shouldBeImplemented
+]

--- a/src/SpriteLang/EVar.extension.st
+++ b/src/SpriteLang/EVar.extension.st
@@ -53,3 +53,12 @@ synthImm :: Env -> SrcImm -> CG RType
 	t := Γ getEnvDamit: sym. 
 	^t singleton: sym
 ]
+
+{ #category : #'*SpriteLang' }
+EVar >> uniq2: α [
+	| sym′ |
+
+	sym′ := α at: sym ifAbsent:[ ^ self ].
+	^self class of: sym′
+
+]

--- a/src/SpriteLang/Expr.extension.st
+++ b/src/SpriteLang/Expr.extension.st
@@ -12,6 +12,21 @@ predRType p = TBase TBool (known $ F.predReft p)
 ]
 
 { #category : #'*SpriteLang' }
+Expr >> uniq2: α [
+	"α-rename all variables. Returns a copy of receiver with all names unique."
+
+	| self′ |
+
+	self′ := self.
+	α keysAndValuesDo: [ :orig :uniq |
+		self′ := self′ rename: orig to: uniq.
+	].
+	^ self′
+
+
+]
+
+{ #category : #'*SpriteLang' }
 Expr >> ΛpredReft [
 	^self predReft known
 ]

--- a/src/SpriteLang/HPred.extension.st
+++ b/src/SpriteLang/HPred.extension.st
@@ -47,3 +47,11 @@ smash p           = [p]
 HPred >> subsAR: p ar: ar [
 	^self "No κ-apps can happen, because those have been refactored to RefVarApps"
 ]
+
+{ #category : #'*SpriteLang' }
+HPred >> uniq2: α [
+	"α-rename all variables. Returns a copy of receiver with all names unique."
+
+	self shouldBeImplemented
+
+]

--- a/src/SpriteLang/HPredAnd.extension.st
+++ b/src/SpriteLang/HPredAnd.extension.st
@@ -23,3 +23,9 @@ HPredAnd >> subs: p ar: ar [
 HPredAnd >> subsAR: aString ar: anARef [
 	^HPredAnd of: (ps collect: [ :each | each subsAR: aString ar: anARef ])
 ]
+
+{ #category : #'*SpriteLang' }
+HPredAnd >> uniq2: α [
+	^self class of: (ps collect: [:e|e uniq2: α])
+
+]

--- a/src/SpriteLang/HReft.extension.st
+++ b/src/SpriteLang/HReft.extension.st
@@ -14,3 +14,9 @@ HReft >> predExprsGo [
 HReft >> subs: p ar: ar [
 	^self
 ]
+
+{ #category : #'*SpriteLang' }
+HReft >> uniq2: α [
+	^self class expr: (expr uniq2: α)
+
+]

--- a/src/SpriteLang/KnownReft.class.st
+++ b/src/SpriteLang/KnownReft.class.st
@@ -163,3 +163,14 @@ KnownReft >> symbol: anObject [
 KnownReft >> syms [
 	^{symbol}, expr syms
 ]
+
+{ #category : #'α-renaming' }
+KnownReft >> uniq2: α [
+	| symbol′ α′ expr′ |
+
+	symbol′ := α at: symbol ifAbsent:[symbol uniq].
+	α′ := α extMap: symbol to: symbol′.
+	expr′ := expr uniq2: α′.
+
+	^self class symbol: symbol′ expr: expr′
+]

--- a/src/SpriteLang/MetricExpression.class.st
+++ b/src/SpriteLang/MetricExpression.class.st
@@ -59,6 +59,16 @@ MetricExpression >> subst: su [
 	^self class source: replacement sym
 ]
 
+{ #category : #'α-renaming' }
+MetricExpression >> uniq2: α [
+	| source′ |
+	
+	source′ := α at: source ifAbsent:[^self].
+	^self class source: source′
+	
+
+]
+
 { #category : #'as yet unclassified' }
 MetricExpression >> wfExpr: γ sort: t [
 "

--- a/src/SpriteLang/Prog.class.st
+++ b/src/SpriteLang/Prog.class.st
@@ -82,11 +82,13 @@ Prog >> solve [
 
 { #category : #verification }
 Prog >> vcgen [
-	| env eL cstr query |
+	| expr′ env expr′′ cstr query |
+
+	expr′ := expr uniq.
 	env := ΓContext empEnv: meas typs: data.
-	eL := expr elaborate: env.
+	expr′′ := expr′ elaborate: env.
 	CGState reset.
-	cstr := eL check: env rtype: TInt instance bTrue.
+	cstr := expr′′ check: env rtype: TInt instance bTrue.
 	query := HornQuery new.
 	cstr addToQuery: query.
 	CGState current cgInfo cgiKVars do: [ :kVar | kVar addToQuery: query ].

--- a/src/SpriteLang/RType.class.st
+++ b/src/SpriteLang/RType.class.st
@@ -137,6 +137,17 @@ closeType :: [RVar] -> [(F.Symbol, RType)] -> RType -> RType
 	^rvParams generalize
 ]
 
+{ #category : #'α-renaming' }
+RType >> collectαRenames: α [
+	"Create (but not apply!) all neccessary α-renames
+	 and return updated renames. See SpriteAnn >> #uniq2: why
+	 this is needed."
+	
+	^ self subclassResponsibility 	
+	
+
+]
+
 { #category : #polymorphism }
 RType >> dispatchUnify: t1 [
 	"The 'normal' case where we just fall through to unifyLL:."
@@ -514,6 +525,13 @@ unify :: F.SrcSpan -> RType -> RType -> ElabM RType
 	(cf. Elaborate.hs)
 "
 	^t2 dispatchUnify: self
+]
+
+{ #category : #'α-renaming' }
+RType >> uniq2: α [
+	"α-rename all variables. Returns a copy of receiver with all names unique."
+
+	self subclassResponsibility.
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/SpriteLang/RVar.class.st
+++ b/src/SpriteLang/RVar.class.st
@@ -122,3 +122,13 @@ RVar >> tsubstGoP: t′ tVar: a [
 		rvArgs: newRvArgs;
 		yourself
 ]
+
+{ #category : #'α-renaming' }
+RVar >> uniq2: α [
+	| rvName′ | 
+	
+	rvName′ := α at: rvName ifAbsent:[^self].
+	^self class
+		rvName: rvName′ 
+		rvArgs: (rvArgs collect:[:e|e uniq2: α])
+]

--- a/src/SpriteLang/RefVarApp.extension.st
+++ b/src/SpriteLang/RefVarApp.extension.st
@@ -27,3 +27,10 @@ go (H.Var k xs) | k == p ...
 	θ := yts zip: xs with: [ :y_☐ :x | y_☐ key -> x ].
 	^pr substs: θ
 ]
+
+{ #category : #'*SpriteLang' }
+RefVarApp >> uniq2: α [
+	^self class
+		var: (α at: var ifAbsent:[var])
+		args: (args collect:[:arg|α at: arg ifAbsent:[arg]])
+]

--- a/src/SpriteLang/SpriteAnn.class.st
+++ b/src/SpriteLang/SpriteAnn.class.st
@@ -92,3 +92,31 @@ SpriteAnn >> symbol [
 SpriteAnn >> symbol: anObject [
 	symbol := anObject
 ]
+
+{ #category : #'α-renaming' }
+SpriteAnn >> uniq2: α [
+	"α-rename all variables. Returns a copy of receiver with all names unique."
+
+	"Sigh, this is stupid. Ideally, we could do something like
+
+		^self class
+			symbol: symbol
+			rtype: (rtype uniq2: α)
+			metric: (metric uniq2: α)
+	
+	But this won't work, because metric (if any) can refer to function 
+	parameters in rtype and α is immutable.  
+	
+	So, we have to rename them all here and pass down α′ with renames for
+	those.
+	"
+	
+	| α′ |
+	
+	α′	:= rtype collectαRenames: α.
+	^self class
+			symbol: symbol
+			rtype: (rtype uniq2: α′)
+			metric: (metric uniq2: α′)
+	
+]

--- a/src/SpriteLang/SpriteBind.class.st
+++ b/src/SpriteLang/SpriteBind.class.st
@@ -8,6 +8,11 @@ Class {
 }
 
 { #category : #accessing }
+SpriteBind class >> id: id [
+	^self basicNew id: id; yourself
+]
+
+{ #category : #accessing }
 SpriteBind class >> identifier: id [
 	^self basicNew id: id; yourself
 ]
@@ -28,4 +33,9 @@ SpriteBind >> printOn: aStream [
 		nextPutAll: 'Bind "';
 		nextPutAll: id;
 		nextPutAll: '"'
+]
+
+{ #category : #'α-renaming' }
+SpriteBind >> uniq2: α [
+	^self class id: (α at: id ifAbsent:[id])
 ]

--- a/src/SpriteLang/String.extension.st
+++ b/src/SpriteLang/String.extension.st
@@ -43,3 +43,10 @@ rVar :: F.Symbol -> RType
 String >> unifyX: anotherString [ 
 	^self
 ]
+
+{ #category : #'*SpriteLang' }
+String >> uniq [
+	"Return new unique variable name suitable for
+	 α-renaming."
+	^self, '__ß', VariableAlphabet nextJ printString
+]

--- a/src/SpriteLang/TAll.class.st
+++ b/src/SpriteLang/TAll.class.st
@@ -23,6 +23,16 @@ TAll >> bkAll [
 	^ {var},as -> t
 ]
 
+{ #category : #'α-renaming' }
+TAll >> collectαRenames: α [
+	| var′ α′ |
+
+	var′ := α at:var ifAbsent:[var uniq].
+	α′ := α extMap: var to: var′.
+	
+	^α′
+]
+
 { #category : #'as yet unclassified' }
 TAll >> freeTVarsGo [
 	^self shouldBeImplemented "delete a (go t)"
@@ -152,6 +162,17 @@ TAll >> type [
 { #category : #accessing }
 TAll >> type: anObject [
 	type := anObject
+]
+
+{ #category : #'α-renaming' }
+TAll >> uniq2: α [
+	| α′ var′ type′ |
+
+	var′ := α at:var ifAbsent:[var uniq].
+	α′ := α extMap: var to: var′.
+	type′ := type uniq2: α′.
+
+	^self class var: var′ type: type′
 ]
 
 { #category : #accessing }

--- a/src/SpriteLang/TBase.class.st
+++ b/src/SpriteLang/TBase.class.st
@@ -31,6 +31,11 @@ TBase >> collect: aBlock [
 	^TBase b: b r: aBlock ⊛ r
 ]
 
+{ #category : #'α-renaming' }
+TBase >> collectαRenames: α [
+	^α
+]
+
 { #category : #polymorphism }
 TBase >> dispatchUnify: t1 [
 "
@@ -212,6 +217,12 @@ TBase >> unifyLL: t [
 	((t isKindOf: TBase) and: [ t b isKindOf: TVar ]) ifTrue: [ ^t b unifyV: self ].
 	((t isKindOf: TBase) and: [ b = t b ]) ifTrue: [ ^self ].
 	self error: 'Cant unify'
+]
+
+{ #category : #'α-renaming' }
+TBase >> uniq2: α [
+	^self class b: (b uniq2: α) r: (r uniq2: α)
+
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/SpriteLang/TBool.class.st
+++ b/src/SpriteLang/TBool.class.st
@@ -22,3 +22,8 @@ TBool >> baseSort [
 TBool >> printOn: aStream [
 	aStream nextPutAll: 'TBool'
 ]
+
+{ #category : #'α-renaming' }
+TBool >> uniq2: α [
+	"Nothing to do"
+]

--- a/src/SpriteLang/TCon.class.st
+++ b/src/SpriteLang/TCon.class.st
@@ -52,6 +52,18 @@ TCon >> collect: f [
 		r: (r collect: [ :rr | f ⊛ rr ])
 ]
 
+{ #category : #'α-renaming' }
+TCon >> collectαRenames: α [
+	| α′  |
+	
+	α′ := α.
+	ts do:[:e| α′ := e collectαRenames: α′].
+	"TODO: what about ars?"
+		
+	^α′
+
+]
+
 { #category : #'as yet unclassified' }
 TCon >> freeTVarsGo [
 	^Set unionAll: (ts collect: #freeTVarsGo)
@@ -248,6 +260,16 @@ TCon >> unifyLL: tcon2 [
 	(c = tcon2 c) ifFalse: [ self error ].
 	newTs := RType unifys: ts with: tcon2 ts.
 	^TCon c: c ts: newTs ars: #() r: ΛReft new
+]
+
+{ #category : #'α-renaming' }
+TCon >> uniq2: α [
+	^self class
+		c: c
+		ts: (ts collect: [ :each | each uniq2: α])
+		ars: (ars collect: [ :each | each uniq2: α])
+		r: (r collect: [ :each | each uniq2: α])
+
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/SpriteLang/TFun.class.st
+++ b/src/SpriteLang/TFun.class.st
@@ -33,6 +33,17 @@ TFun >> collect: f [
 		t: f ⊛ t
 ]
 
+{ #category : #'α-renaming' }
+TFun >> collectαRenames: α [
+	| x′ α′ α′′ |
+
+	x′ := α at: x ifAbsent:[x uniq].
+	α′ := α extMap: x to: x′.
+	α′′:= t collectαRenames: α′.
+	
+	^α′′
+]
+
 { #category : #'as yet unclassified' }
 TFun >> freeTVarsGo [
 	^s freeTVarsGo union: t freeTVarsGo
@@ -236,6 +247,19 @@ TFun >> unifyLL: tfun2 [
 	t2_ := tfun2 t subsTyM.
 	t_ := t1_ unify: t2_.
 	^TFun x: x_ s: s_ t: t_
+]
+
+{ #category : #'α-renaming' }
+TFun >> uniq2: α [
+	| α′ x′ s′ t′ |
+
+	x′ := α at: x ifAbsent:[x uniq].
+	α′ := α extMap: x to: x′.
+	s′ := s uniq2: α′.
+	t′ := t uniq2: α′.
+
+	^self class x:x′ s:s′ t:t′
+
 ]
 
 { #category : #accessing }

--- a/src/SpriteLang/TInt.class.st
+++ b/src/SpriteLang/TInt.class.st
@@ -22,3 +22,8 @@ TInt >> baseSort [
 TInt >> printOn: aStream [
 	aStream nextPutAll: 'TInt'
 ]
+
+{ #category : #'α-renaming' }
+TInt >> uniq2: α [
+	"Nothing to do"
+]

--- a/src/SpriteLang/TRAll.class.st
+++ b/src/SpriteLang/TRAll.class.st
@@ -33,6 +33,19 @@ TRAll >> collect: f [
 		t: f ⊛ t
 ]
 
+{ #category : #'α-renaming' }
+TRAll >> collectαRenames: α [
+	| rvName rvName′ α′ α′′ |
+	
+	rvName := r rvName.
+	rvName′:= α at: rvName ifAbsent:[rvName uniq].
+	α′ := α extMap: rvName to: rvName′.
+	α′′ := t collectαRenames: α′.
+	
+	^ α′′
+	
+]
+
 { #category : #'as yet unclassified' }
 TRAll >> freeTVarsGo [
 	^r freeTVarsGoP union: t freeTVarsGo
@@ -138,4 +151,18 @@ go (TRAll p t)      = TRAll  (goP p) (go t)
 	^TRAll
 		r: (r tsubstGoP: t′ tVar: a)
 		t: (t tsubstGo: t′ tVar: a)
+]
+
+{ #category : #'α-renaming' }
+TRAll >> uniq2: α [
+	| rvName rvName′ α′ |
+	
+	rvName := r rvName.
+	rvName′:= α at: rvName ifAbsent:[rvName uniq].
+	α′ := α extMap: rvName to: rvName′.
+	
+	^self class 
+		r: (r uniq2: α′) 
+		t: (t uniq2: α′) 
+
 ]

--- a/src/SpriteLang/TVar.class.st
+++ b/src/SpriteLang/TVar.class.st
@@ -77,3 +77,12 @@ TVar >> unifyV: t [
 	symbol nonRigid ifTrue: [ t assign: self.  ^t ].
 	self shouldBeImplemented.
 ]
+
+{ #category : #'α-renaming' }
+TVar >> uniq2: α [
+	| symbol′ |
+
+	symbol′ := α at: symbol ifAbsent:[ ^self ].
+	^self class symbol: symbol′
+
+]

--- a/src/SpriteLang/TerminationMetric.class.st
+++ b/src/SpriteLang/TerminationMetric.class.st
@@ -8,6 +8,11 @@ Class {
 	#category : #SpriteLang
 }
 
+{ #category : #'α-renaming' }
+TerminationMetric >> uniq2: α [
+	^self collect:[:e|e uniq2: α]
+]
+
 { #category : #'as yet unclassified' }
 TerminationMetric >> wfMetric: γ [
 "

--- a/src/SpriteLang/UndefinedObject.extension.st
+++ b/src/SpriteLang/UndefinedObject.extension.st
@@ -4,3 +4,8 @@ Extension { #name : #UndefinedObject }
 UndefinedObject >> refactorAppR: _ [ 
 	^nil
 ]
+
+{ #category : #'*SpriteLang' }
+UndefinedObject >> uniq2: α [
+	^self
+]

--- a/src/SpriteLang/UnknownReft.class.st
+++ b/src/SpriteLang/UnknownReft.class.st
@@ -69,3 +69,9 @@ UnknownReft >> substf: f [
 UnknownReft >> syms [
 	^#()
 ]
+
+{ #category : #'α-renaming' }
+UnknownReft >> uniq2: α [
+	"Nothing to do"
+
+]

--- a/src/SpriteLang/ΛBase.class.st
+++ b/src/SpriteLang/ΛBase.class.st
@@ -38,3 +38,10 @@ RType where r=Reft, here Reft meaning ΛReft.
 ΛBase >> freeTVarsGoB [
 	^Set new
 ]
+
+{ #category : #'α-renaming' }
+ΛBase >> uniq2: α [
+	"α-rename all variables. Returns a copy of receiver with all names unique."
+
+	self subclassResponsibility.
+]

--- a/src/SpriteLang/ΛEApp.class.st
+++ b/src/SpriteLang/ΛEApp.class.st
@@ -103,3 +103,10 @@ cf. Parser.hs
 	cy := y checkImm: Γ rtype: s.
 	^{ ce & cy . t substImm: x imm: y }
 ]
+
+{ #category : #'α-renaming' }
+ΛEApp >> uniq2: α [
+	^self class
+		expr: (expr uniq2: α)
+		imm: (imm uniq2: α)
+]

--- a/src/SpriteLang/ΛExpression.class.st
+++ b/src/SpriteLang/ΛExpression.class.st
@@ -157,6 +157,13 @@ cf. Elaborate.hs
 	^self goSubsTyExpr: su 
 ]
 
+{ #category : #'α-renaming' }
+ΛExpression >> uniq2: α [
+	"α-rename all variables. Returns a copy of receiver with all names unique."
+
+	self subclassResponsibility.
+]
+
 { #category : #'well-formedness' }
 ΛExpression >> wfExpr: γ sort: t [
 "

--- a/src/SpriteLang/ΛReft.class.st
+++ b/src/SpriteLang/ΛReft.class.st
@@ -75,3 +75,10 @@ freshR :: F.SrcSpan -> Env -> F.Sort -> Reft -> CG Reft
 	"instance F.Subable Reft where..."
 	self subclassResponsibility
 ]
+
+{ #category : #'α-renaming' }
+ΛReft >> uniq2: α [
+	"α-rename all variables. Returns a copy of receiver with all names unique."
+
+	self subclassResponsibility.
+]

--- a/src/SpriteLang/αRenames.class.st
+++ b/src/SpriteLang/αRenames.class.st
@@ -1,0 +1,97 @@
+Class {
+	#name : #'αRenames',
+	#superclass : #Object,
+	#instVars : [
+		'key',
+		'value',
+		'rest'
+	],
+	#classVars : [
+		'Sentinel'
+	],
+	#category : #'SpriteLang-Parsing'
+}
+
+{ #category : #'instance creation' }
+αRenames class >> empty [
+	^Sentinel
+]
+
+{ #category : #initialization }
+αRenames class >> initialize [
+	Sentinel := self basicNew
+]
+
+{ #category : #'instance creation' }
+αRenames class >> key: key value: value rest: rest [
+	^self basicNew key: key value: value rest: rest
+]
+
+{ #category : #'instance creation' }
+αRenames class >> new [
+	self shouldNotImplement. "Use #empty or #key:value:rest:"
+]
+
+{ #category : #accessing }
+αRenames >> at: anObject [
+	^self at: anObject ifAbsent:[ KeyNotFound signalFor: anObject ].
+
+]
+
+{ #category : #accessing }
+αRenames >> at: anObject ifAbsent: aBlock [
+	self == Sentinel ifTrue:[
+		^aBlock value
+	].
+
+	key = anObject ifTrue:[
+		^value
+	].
+
+	^rest at: anObject ifAbsent: aBlock
+
+
+]
+
+{ #category : #accessing }
+αRenames >> extMap: original to: unique [
+	"Extend current α-renames with new mapping.
+	 Return new α-renames."
+
+	^self class key: original value: unique rest: self.
+]
+
+{ #category : #GT }
+αRenames >> gtInspectorItemsIn: composite [
+	<gtInspectorPresentationOrder: 0>
+	^ composite fastTable
+		title: 'Renames';
+		display: [
+			| items |
+
+			items := Dictionary new.
+			self keysAndValuesDo: [ :k :v |
+				items at: k ifAbsentPut: v
+			].
+			items associations.
+		];
+		column: 'Key' evaluated: [ :each | GTObjectPrinter asTruncatedTextFrom: each key ];
+		column: 'Value' evaluated: [ :each | GTObjectPrinter asTruncatedTextFrom: each value ];
+		yourself.
+]
+
+{ #category : #initialization }
+αRenames >> key: keyArg value: valueArg rest: restArg [
+	key := keyArg.
+	value := valueArg.
+	rest := restArg
+
+]
+
+{ #category : #enumerating }
+αRenames >> keysAndValuesDo: aBlock [
+	self ~~ Sentinel ifTrue:[
+		aBlock value: key value: value.
+		rest keysAndValuesDo: aBlock
+	]
+]


### PR DESCRIPTION
Yet another attempt to fix #139.

This PR α-renames all variables in a separate step prior elaboration.
It is similar to PR #197 but differ in several ways:

 * perform renaming as a separate step, not as part of [Chk-Lam].
 * renames all lets, not just function parameter binds
 * renames everything in single top-down traversal.
