### PR TITLE
Move `RefinementExpressionParser` up to `Refinements-Parsing`

### DIFF
--- a/src/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
+++ b/src/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
@@ -74,9 +74,15 @@ BaselineOfMachineArithmetic >> baseline: spec [
 					spec requires: 'Z3'.
 					spec requires: 'MathNotation'];
 
+				package: #'PetitSmalltalk' with:
+					[
+					spec requires: 'PetitParser'.
+					spec repository: 'github://shingarov/PetitParser:ULD'];
+
 				package: #'Refinements-Parsing' with:
 					[
 					spec requires: 'PetitParser'.
+					spec requires: 'PetitSmalltalk'.
 					spec requires: 'Refinements'];
 
 				package: #'Refinements-Tests' with:
@@ -85,15 +91,9 @@ BaselineOfMachineArithmetic >> baseline: spec [
 				package: #'Refinements-Doodles' with:
 					[spec requires: 'Refinements-Parsing'];
 
-				package: #'PetitSmalltalk' with:
-					[
-					spec requires: 'PetitParser'.
-					spec repository: 'github://shingarov/PetitParser:ULD'];
-
 				package: #'SpriteLang' with:
 					[
-					spec requires: 'PetitSmalltalk'.
-					spec requires: 'Refinements'];
+					spec requires: 'Refinements-Parsing'];
 
 				package: #'SpriteLang-Tests' with:
 					[spec requires: 'SpriteLang'].

--- a/src/Refinements-Parsing/RefinementExpressionParser.class.st
+++ b/src/Refinements-Parsing/RefinementExpressionParser.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'binaryChar'
 	],
-	#category : #'SpriteLang-Parsing'
+	#category : #'Refinements-Parsing'
 }
 
 { #category : #primitives }


### PR DESCRIPTION
PR#179, "Use full smalltalk parser when parsing refinement expression", replaces Smalltalk-in-Sprite-via-ad-hoc-hackery by delegating the job to PetitSmalltalk.  This commit moves RefinementExpressionParser up the package-dependency chain so that the NNF parser (the parser for the `liquid-fixpoint/tests/horn/pos/*.smt2` tests) can also benefit from it. No actual changes to `NNFParser` are included in this commit; we are simply setting the stage here.