### PR TITLE
Implement 'define' NNF syntax

### DIFF
--- a/src/Refinements-Doodles/NNFParserTest.class.st
+++ b/src/Refinements-Doodles/NNFParserTest.class.st
@@ -69,6 +69,15 @@ NNFParserTest >> testConstraintWithVarAppHypothesis [
 ]
 
 { #category : #tests }
+NNFParserTest >> testDefine [
+	| horn eqn |
+	horn := self parse: '(define adder(x : int, y : int) : int = { x + y })'.
+	self assert: horn qEqns size equals: 1.
+	eqn := horn qEqns first.
+	self assert: eqn eqName equals: 'adder'
+]
+
+{ #category : #tests }
 NNFParserTest >> testFixpoint [
 	self parse: '
 (fixpoint "--eliminate=horn")

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -26,7 +26,8 @@ Class {
 		'cstrPred',
 		'upperId',
 		'funcSort',
-		'sortArg'
+		'sortArg',
+		'define'
 	],
 	#category : #'Refinements-Parsing'
 }
@@ -74,6 +75,24 @@ NNFParser >> cstrPred [
 NNFParser >> decidablePred [
 	^matchedParen
 	==> [ :x | HReft expr: (DecidableRefinement text: x) ]
+]
+
+{ #category : #grammar }
+NNFParser >> define [
+	"Function definition equations (PLE).
+	 Cf. top-level Parse.hs"
+	^'define' asParser trim,
+	tok trim, "name"
+	(tok trim, $: asParser trim, sort ==> [ :eachArg | eachArg first -> eachArg last ]) commaList trim,
+	$: asParser trim,
+	sort,
+	'=' asParser trim,
+	(RefinementExpressionParser new braces ==> [ :seq | seq formattedCode ])
+	==> [ :x | Equation
+					mkEquation: x second
+					args: x third
+					expr: x seventh
+					sort: x fifth ]
 ]
 
 { #category : #grammar }
@@ -211,7 +230,7 @@ NNFParser >> symSort [
 
 { #category : #grammar }
 NNFParser >> thing [
-	^(constraint / var / qualif / constant / fixpoint "define match data") parens
+	^(constraint / var / qualif / constant / fixpoint / define "match data") parens
 ]
 
 { #category : #'grammar - util' }


### PR DESCRIPTION
Cf. `defineP` in `liquid-fixpoint/src/Language/Fixpoint/Parse.hs`. At this point, we instantiate `Equation` but don't do anything with it: this is simply plumbing connecting Refinements to PLE.