### PR TITLE
Classify Z3 nodes from Liquid-Fixpoint's perspective

### DIFF
--- a/src/Z3-Tests/LFxClassificationTest.class.st
+++ b/src/Z3-Tests/LFxClassificationTest.class.st
@@ -1,0 +1,85 @@
+Class {
+	#name : #LFxClassificationTest,
+	#superclass : #TestCase,
+	#category : #'Z3-Tests'
+}
+
+{ #category : #tests }
+LFxClassificationTest >> testIsEBin [
+	| x y |
+	x := 'x' toInt.
+	y := 'y' toInt.
+
+	self assert: (x+y)  isEBin.
+	self assert: (x-y)  isEBin.
+	self assert: (x*y)  isEBin.
+	self assert: (x/y)  isEBin.
+	self assert: (x\\y) isEBin.
+	
+	self deny:   'x' toInt  isEBin.
+	self deny:   'A' toBool isEBin.
+	self deny:   Bool false isEBin.
+
+]
+
+{ #category : #tests }
+LFxClassificationTest >> testIsECon [
+	self assert:  1  toInt  isECon.
+	self assert: (42 toBitVector: 32) isECon.
+	self deny:   'x' toInt  isECon.
+	self deny:   'A' toBool isECon.
+	self assert: Bool true  isECon.
+	self assert: Bool false isECon.
+
+]
+
+{ #category : #tests }
+LFxClassificationTest >> testIsEIte [
+	self assert: ('b' toBool ifThen: 1 toInt else: 2 toInt) isEIte
+]
+
+{ #category : #tests }
+LFxClassificationTest >> testIsEVar [
+	self assert: 'x' toInt isEVar.
+	self deny:    1  toInt isEVar.
+]
+
+{ #category : #tests }
+LFxClassificationTest >> testIsPAExist [
+	self assert: (  'a' toInt < 0 exists: 'x' toInt  )  isPExist.
+	self deny:   (  'a' toInt < 0                    )  isPExist.
+	self deny:   (  'a' toInt < 0 forall: 'x' toInt  )  isPExist.
+]
+
+{ #category : #tests }
+LFxClassificationTest >> testIsPAll [
+	self assert: (  'a' toInt < 0 forall: 'x' toInt  )  isPAll.
+	self deny:   (  'a' toInt < 0                    )  isPAll.
+	self deny:   (  'a' toInt < 0 exists: 'x' toInt  )  isPAll.
+]
+
+{ #category : #tests }
+LFxClassificationTest >> testIsPAnd [
+	self assert: ('x' toInt < 0 & Bool true) isPAnd
+]
+
+{ #category : #tests }
+LFxClassificationTest >> testIsPAtom [
+	self assert: ('x' toInt < 0) isPAtom
+]
+
+{ #category : #tests }
+LFxClassificationTest >> testIsPIff [
+	self assert: ('A' toBool iff: 'B' toBool) isPIff.
+	self deny:   ('x' toInt  ===  'y' toInt)  isPIff
+]
+
+{ #category : #tests }
+LFxClassificationTest >> testIsPImp [
+	self assert: ('A' toBool ==> 'B' toBool) isPImp
+]
+
+{ #category : #tests }
+LFxClassificationTest >> testIsPNot [
+	self assert: ('x' toInt < 0) not isPNot
+]

--- a/src/Z3/BitVector.class.st
+++ b/src/Z3/BitVector.class.st
@@ -233,6 +233,11 @@ BitVector >> isBitVector [
 	^true
 ]
 
+{ #category : #'fx expr classification' }
+BitVector >> isEBin [
+	self shouldBeImplemented
+]
+
 { #category : #accessing }
 BitVector >> length [
 	"Return length in bits"

--- a/src/Z3/Bool.class.st
+++ b/src/Z3/Bool.class.st
@@ -107,6 +107,50 @@ Bool >> isBool [
 
 ]
 
+{ #category : #'fx expr classification' }
+Bool >> isECon [
+	^self = Bool true or: [ self = Bool false ]
+]
+
+{ #category : #'fx expr classification' }
+Bool >> isPAnd [
+	self isApp ifFalse: [ ^false ].
+	^self functorName = 'and'
+]
+
+{ #category : #'fx expr classification' }
+Bool >> isPAtom [
+	self isApp ifFalse: [ ^false ].
+	self functorName = 'not' ifTrue: [ self shouldBeImplemented ].
+	self arity = 2 ifFalse: [ ^false ].
+	^#('=' '>' '>=' '<' '<=') includes: self functorName
+]
+
+{ #category : #'fx expr classification' }
+Bool >> isPIff [
+	self isApp ifFalse: [ ^false ].
+	self functorName = '=' ifFalse: [ ^false ].
+	^self args allSatisfy: #isBool 
+]
+
+{ #category : #'fx expr classification' }
+Bool >> isPImp [
+	self isApp ifFalse: [ ^false ].
+	^self functorName = '=>'
+]
+
+{ #category : #'fx expr classification' }
+Bool >> isPNot [
+	self isApp ifFalse: [ ^false ].
+	^self functorName = 'not'
+]
+
+{ #category : #'fx expr classification' }
+Bool >> isPOr [
+	self isApp ifFalse: [ ^false ].
+	^self functorName = 'or'
+]
+
 { #category : #testing }
 Bool >> isShortExpr [
 	^ self == Bool true

--- a/src/Z3/Z3Node.class.st
+++ b/src/Z3/Z3Node.class.st
@@ -223,6 +223,35 @@ Z3Node >> isConstantNamed: v [
 			and: [ self functorName = v ]
 ]
 
+{ #category : #'fx expr classification' }
+Z3Node >> isEBin [
+	"Answer whether Fixpoint would consider this node a EBin."
+	self isApp ifFalse: [ ^false ].
+	self arity = 2 ifFalse: [ ^false ].
+	^#('+' '-' '*' 'div' 'mod') includes: self functorName
+]
+
+{ #category : #'fx expr classification' }
+Z3Node >> isECon [
+	"Answer whether Fixpoint would consider this node a ECon."
+	^self kind = NUMERAL_AST
+]
+
+{ #category : #'fx expr classification' }
+Z3Node >> isEIte [
+	"Answer whether Fixpoint would consider this node a EIte."
+	self isApp ifFalse: [ ^false ].
+	self functorName = 'if' ifFalse: [ ^false ].
+	self arity = 3 ifFalse: [ ^false ].
+	^self args first isBool
+]
+
+{ #category : #'fx expr classification' }
+Z3Node >> isEVar [
+	"Answer whether Fixpoint would consider this node a EVar."
+	^self isConstant
+]
+
 { #category : #testing }
 Z3Node >> isLeaf [
 	^ self isConstant or: [ self isNumeral or: [ self isVar ]]
@@ -245,6 +274,57 @@ Z3Node >> isNamedConstant [
 { #category : #testing }
 Z3Node >> isNode [
 	^true
+]
+
+{ #category : #'fx expr classification' }
+Z3Node >> isPAll [
+	"Answer whether Fixpoint would consider this node a PAll."
+	^false
+]
+
+{ #category : #'fx expr classification' }
+Z3Node >> isPAnd [
+	"Answer whether Fixpoint would consider this node a PAnd."
+	^false
+]
+
+{ #category : #'fx expr classification' }
+Z3Node >> isPAtom [
+	"Answer whether Fixpoint would consider this node a PAtom.
+	 A PAtom is (Brel e₁ ₂), where Brel = Eq | Ne | Gt | Ge | Lt | Le | Ueq | Une.
+	 In Z3 we don't have some of that, let's postpone deciding what to do there;
+	 it should never happen if callers check for isPNot first."
+	^false
+]
+
+{ #category : #'fx expr classification' }
+Z3Node >> isPExist [
+	"Answer whether Fixpoint would consider this node a PExist."
+	^false
+]
+
+{ #category : #'fx expr classification' }
+Z3Node >> isPIff [
+	"Answer whether Fixpoint would consider this node a PIff."
+	^false
+]
+
+{ #category : #'fx expr classification' }
+Z3Node >> isPImp [
+	"Answer whether Fixpoint would consider this node a PImp."
+	^false
+]
+
+{ #category : #'fx expr classification' }
+Z3Node >> isPNot [
+	"Answer whether Fixpoint would consider this node a PNot."
+	^false
+]
+
+{ #category : #'fx expr classification' }
+Z3Node >> isPOr [
+	"Answer whether Fixpoint would consider this node a POr."
+	^false
 ]
 
 { #category : #testing }

--- a/src/Z3/Z3QuantifierNode.class.st
+++ b/src/Z3/Z3QuantifierNode.class.st
@@ -64,3 +64,14 @@ Z3QuantifierNode >> isForAll [
 Z3QuantifierNode >> isLambda [
 	^Z3 is_lambda: ctx _: self
 ]
+
+{ #category : #'fx expr classification' }
+Z3QuantifierNode >> isPAll [
+	^self isForAll
+]
+
+{ #category : #'fx expr classification' }
+Z3QuantifierNode >> isPExist [
+	"Answer whether Fixpoint would consider this node a PExist."
+	^self isExists
+]


### PR DESCRIPTION
In upstream PLE, Turchin driving is dispatched over ELam/EIte/EApp etc. At the point when PLE is triggered, in Smalltalk it's already too late, because the F.Exprs have already become Z3 ASTs.  In this commit, we classify Z3 ASTs into something over which fastEval can be dispatched.

The space this code lives in, is somewhat brain-damaged; the problem comes from a defect in the particular substrate dialect of Smalltalk-80 (for example, in ENVY you can still have method categorization even for methods in "extensions"; but in Pharo you have "star-categories" so placing these methods in "*Refinements" would lump them with everything else).  So we group them in the "fx expr classification" category even though they are a concept foreign to Z3.