### PR TITLE
[Sprite] improve "Tree" view in inspector

### DIFF
--- a/src/SpriteLang/EFun.class.st
+++ b/src/SpriteLang/EFun.class.st
@@ -77,7 +77,7 @@ EFun >> goSubsTyExpr: su [
 
 { #category : #GT }
 EFun >> gtChildren [
-	^expr gtChildren
+	^ { expr }
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/SpriteLang/EIf.class.st
+++ b/src/SpriteLang/EIf.class.st
@@ -68,6 +68,12 @@ EIf >> goSubsTyExpr: su [
 	^EIf cond: cond trueE: (trueE goSubsTyExpr: su) falseE: (falseE goSubsTyExpr: su)
 ]
 
+{ #category : #GT }
+EIf >> gtChildren [
+	^{cond . trueE . falseE}
+
+]
+
 { #category : #accessing }
 EIf >> trueE [
 	^ trueE

--- a/src/SpriteLang/ELet.class.st
+++ b/src/SpriteLang/ELet.class.st
@@ -65,6 +65,7 @@ ELet >> expr [
 
 { #category : #accessing }
 ELet >> expr: anObject [
+	self assert: self ~~ anObject.
 	expr := anObject
 ]
 
@@ -76,6 +77,16 @@ ELet >> goSubsTyExpr: su [
 ]
 
 { #category : #GT }
+ELet >> gtBind [
+	^decl bind id
+]
+
+{ #category : #GT }
 ELet >> gtChildren [
-	^{decl . expr}
+	^{ decl }
+]
+
+{ #category : #GT }
+ELet >> gtExpr [
+	^decl gtExpr
 ]

--- a/src/SpriteLang/Expr.extension.st
+++ b/src/SpriteLang/Expr.extension.st
@@ -1,6 +1,21 @@
 Extension { #name : #Expr }
 
 { #category : #'*SpriteLang' }
+Expr >> gtBind [
+	^''
+]
+
+{ #category : #'*SpriteLang' }
+Expr >> gtExpr [
+	^self
+]
+
+{ #category : #'*SpriteLang' }
+Expr >> isLet [
+	^false
+]
+
+{ #category : #'*SpriteLang' }
 Expr >> predRType [
 "
 predRType :: F.Pred -> RType

--- a/src/SpriteLang/Prog.class.st
+++ b/src/SpriteLang/Prog.class.st
@@ -43,6 +43,14 @@ Prog >> expr: anObject [
 	expr := anObject
 ]
 
+{ #category : #GT }
+Prog >> gtInspectorExprsIn: composite [
+	<gtInspectorPresentationOrder: 50>
+
+	^(expr gtInspectorTreeIn: composite)
+		title: 'Expressions'
+]
+
 { #category : #accessing }
 Prog >> meas [
 	^ meas

--- a/src/SpriteLang/RType.class.st
+++ b/src/SpriteLang/RType.class.st
@@ -185,8 +185,18 @@ cf. Check.hs
 ]
 
 { #category : #GT }
+RType >> gtBind [
+	^''
+]
+
+{ #category : #GT }
 RType >> gtChildren [
 	^#()
+]
+
+{ #category : #GT }
+RType >> gtExpr [
+	^self
 ]
 
 { #category : #GT }
@@ -237,6 +247,11 @@ isBool t = rTypeSort t == F.boolSort
 cf. Parse.hs
 "
 	^self sort == Bool sort
+]
+
+{ #category : #testing }
+RType >> isLet [
+	^false
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/SpriteLang/SpriteAnn.class.st
+++ b/src/SpriteLang/SpriteAnn.class.st
@@ -56,6 +56,26 @@ SpriteAnn >> goSubsTyExprS: su [
 		metric: metric
 ]
 
+{ #category : #GT }
+SpriteAnn >> gtBind [
+	^''
+]
+
+{ #category : #GT }
+SpriteAnn >> gtChildren [
+	^ metric isNil ifTrue:[{ rtype }] ifFalse:[{rtype . metric }]
+]
+
+{ #category : #GT }
+SpriteAnn >> gtExpr [
+	^self
+]
+
+{ #category : #testing }
+SpriteAnn >> isLet [
+	^false
+]
+
 { #category : #accessing }
 SpriteAnn >> metric [
 	^ metric

--- a/src/SpriteLang/SpriteDecl.class.st
+++ b/src/SpriteLang/SpriteDecl.class.st
@@ -60,8 +60,26 @@ SpriteDecl >> expr: anObject [
 ]
 
 { #category : #GT }
+SpriteDecl >> gtBind [
+	^''
+]
+
+{ #category : #GT }
 SpriteDecl >> gtChildren [ 
+	(expr isKindOf: EAnn) ifTrue:[ ^ { expr ann . expr expr } ].
+	(expr isKindOf: EFun) ifTrue:[ ^ { expr expr } ].
+
 	^{expr}
+]
+
+{ #category : #GT }
+SpriteDecl >> gtExpr [
+	^expr
+]
+
+{ #category : #testing }
+SpriteDecl >> isLet [
+	^false
 ]
 
 { #category : #printing }

--- a/src/SpriteLang/TFun.class.st
+++ b/src/SpriteLang/TFun.class.st
@@ -56,6 +56,11 @@ go (TFun  b s t) = TFun  b (go s) (go t)
 ]
 
 { #category : #GT }
+TFun >> gtBind [
+	^x
+]
+
+{ #category : #GT }
 TFun >> gtChildren [
 	^{ s . t }
 ]

--- a/src/SpriteLang/ΛExpression.class.st
+++ b/src/SpriteLang/ΛExpression.class.st
@@ -81,17 +81,47 @@ elaborate   :: Env -> SrcExpr -> ElbExpr
 ]
 
 { #category : #GT }
+ΛExpression >> gtBind [
+	^''
+]
+
+{ #category : #GT }
 ΛExpression >> gtChildren [
 	^#()
 ]
 
 { #category : #GT }
+ΛExpression >> gtExpr [
+	^self
+]
+
+{ #category : #GT }
 ΛExpression >> gtInspectorTreeIn: composite [
 	<gtInspectorPresentationOrder: 50>
-	^ composite fastTree
+
+	| flatten |
+
+	flatten := [ :children |
+		OrderedCollection streamContents:[:flattened|
+			children do:[:child |
+				| c |
+				c := child.
+				[ c notNil ] whileTrue:[
+					flattened nextPut: c.
+					c := c isLet ifTrue:[c expr] ifFalse:[nil].
+				].
+			]
+		]
+	].
+
+	^ composite fastTreeTable
 		title: 'Tree';
-		children: #gtChildren;
-		display: [ Array with: self ]
+		children: [:expr | flatten value: expr gtChildren  ];
+		display: [ flatten value: { self } ];
+		column: 'Class'evaluated: [ :e | e class name ];
+		column: 'Bind' evaluated: [ :e | e gtBind ];
+		column: 'Expr' evaluated: [ :e | e gtExpr ];
+		yourself.
 ]
 
 { #category : #polymorphism }


### PR DESCRIPTION
This commit improves "Tree" view in inspector in several ways:

 * sequence of `ELet`s is "flattened" and shown is list instead of deeply nested tree
 * it shows multiple columns, most notably "Class" and "Bind" with bound id (or nothing if expression does not bind anything)
 * fixes few DNUs when diving into annotations

I personally find this easier to work with for more complicated, deeply nested programs.