### PR TITLE
[Sprite] add few missing methods needed by "Tree" view in inspector

### DIFF
--- a/src/SpriteLang/ECon.class.st
+++ b/src/SpriteLang/ECon.class.st
@@ -18,8 +18,18 @@ ECon >> evaluateIn: aBindEnv [
 ]
 
 { #category : #GT }
+ECon >> gtBind [
+	^''
+]
+
+{ #category : #GT }
 ECon >> gtChildren [
-	^{ prim }
+	^#()
+]
+
+{ #category : #GT }
+ECon >> gtExpr [
+	^self
 ]
 
 { #category : #substitution }

--- a/src/SpriteLang/SpriteImm.class.st
+++ b/src/SpriteLang/SpriteImm.class.st
@@ -19,6 +19,11 @@ immExpr :: Imm b -> F.Expr
 	self subclassResponsibility
 ]
 
+{ #category : #testing }
+SpriteImm >> isLet [
+	^false
+]
+
 { #category : #printing }
 SpriteImm >> printOn: aStream [
 	self printStructOn: aStream


### PR DESCRIPTION
Commit 5000538 improved "Tree" view on Sprite AST but few methods were missing in some classes causing inspector to crash on DNU in some cases. This commit add these missing methods.