### PR TITLE
Fix `PAtomEq>>evaluateIn:`

### DIFF
--- a/src/Refinements/PAtomEq.class.st
+++ b/src/Refinements/PAtomEq.class.st
@@ -30,8 +30,8 @@ PAtomEq >> accept: aVisitor [
 ]
 
 { #category : #'term rewriting' }
-PAtomEq >> evaluateIn: aBindEnv [ 
-	^(aBindEnv evaluate: x) === (aBindEnv evaluate: y)
+PAtomEq >> evaluateIn: aBindEnv [
+	^(x evaluateIn: aBindEnv) === (y evaluateIn: aBindEnv)
 ]
 
 { #category : #comparing }


### PR DESCRIPTION
This commit evaluates lhs and rhs of `PAtomEq` using (their) `#evaluateIn:` rather than going through `EvalEnv >> evaluate:`. The latter did not really work for anything by `EVar` and unnecessarily called down to Smalltalk compiler.