### PR TITLE
In #wfExpr, properly use the argument t, not hardcoded ℤ

### DIFF
--- a/src/Refinements/Expr.class.st
+++ b/src/Refinements/Expr.class.st
@@ -457,6 +457,18 @@ Expr >> toHCstr [
 	^self cHead
 ]
 
+{ #category : #'as yet unclassified' }
+Expr >> wfExpr: γ sort: t [
+"
+wfExpr :: F.SrcSpan -> Env -> F.Expr -> F.Sort -> Bool
+"
+	| v |
+	v := self
+		evaluateIn: (EvalEnv ofSorts: γ eSorts)
+		ifUndeclared: [ ^false ]. "expected: we just haven't reached the fixpoint where n is put in γ "
+	^v sort = t
+]
+
 { #category : #'theory symbols' }
 Expr >> without: rhs [
 	^ECst

--- a/src/SpriteLang/MetricExpression.class.st
+++ b/src/SpriteLang/MetricExpression.class.st
@@ -4,15 +4,3 @@ Class {
 	#category : #'SpriteLang-Parsing'
 }
 
-{ #category : #'as yet unclassified' }
-MetricExpression >> wfExpr: γ sort: t [
-"
-wfExpr :: F.SrcSpan -> Env -> F.Expr -> F.Sort -> Bool
-"
-	| v |
-	v := self
-		evaluateIn: (EvalEnv ofSorts: γ eSorts)
-		ifUndeclared: [ ^false ]. "expected: we just haven't reached the fixpoint where n is put in γ "
-	^v sort = Int sort
-
-]


### PR DESCRIPTION
Also, when the termination metric gets arithmetically manipulated, it means #wfExpr can be sent to any Expr, so this method properly belongs in Expr (as it does in upstream).