### PR TITLE
Get rid of MetricExpression class

### DIFF
--- a/src/SpriteLang/MetricExpression.class.st
+++ b/src/SpriteLang/MetricExpression.class.st
@@ -1,6 +1,0 @@
-Class {
-	#name : #MetricExpression,
-	#superclass : #DecidableRefinement,
-	#category : #'SpriteLang-Parsing'
-}
-

--- a/src/SpriteLang/RefinementParser.class.st
+++ b/src/SpriteLang/RefinementParser.class.st
@@ -96,7 +96,7 @@ RefinementParser >> myExprP [
 	 mess.
 "
 	^ self nonBracket plus flatten brackets
-	==> [ :x | MetricExpression text: '(', x, ')' ]
+	==> [ :x | DecidableRefinement text: '(', x, ')' ]
 ]
 
 { #category : #grammar }


### PR DESCRIPTION
Now that metric expressions are no longer special syntactic form [n], but arbitrary Smalltalk, there is nothing left in MetricExpression so there is no purpose to it anymore.