### PR TITLE
[Z3] Add GaussBvTestTest

### DIFF
--- a/src/Z3-Tests/GaussBvTestTest.class.st
+++ b/src/Z3-Tests/GaussBvTestTest.class.st
@@ -1,0 +1,51 @@
+Class {
+	#name : #GaussBvTestTest,
+	#superclass : #TestCaseWithZ3Context,
+	#instVars : [
+		'xlen'
+	],
+	#category : #'Z3-Tests'
+}
+
+{ #category : #tests }
+GaussBvTestTest >> checkGauss: n [
+	"1+...+n = n*(n+1)/2"
+	self
+		assert: (self sum: n)*2
+		equals: n*(n+1)
+]
+
+{ #category : #'z3 context' }
+GaussBvTestTest >> setUp [
+	xlen := 8
+]
+
+{ #category : #tests }
+GaussBvTestTest >> sum: n [
+	^(1 to: n)
+		inject: (0 toBitVector: xlen)
+		into: [ :acc :thisSummand | (acc+thisSummand) simplify ]
+]
+
+{ #category : #tests }
+GaussBvTestTest >> test10 [
+	"1+...+10 = 55"
+	self checkGauss: 10
+]
+
+{ #category : #tests }
+GaussBvTestTest >> test100 [
+	"1+...+100 = 5050;
+	 this will overflow 8-bit many times but even
+	 this is still ok, because everything is mod 256."
+	self checkGauss: 100
+]
+
+{ #category : #tests }
+GaussBvTestTest >> test20 [
+	"1+...+20 = 210;
+	 this will overflow 8-bit signed into negative
+	 but this doesn't matter because everything is
+	 defined in two's-complement-neutral way."
+	self checkGauss: 20
+]


### PR DESCRIPTION
Anticipating Gauss test in Sprite, we build an intuition for why we should expect BV overflows to not affect the validity of the proof.

(Note the "TestTest" in the class name, symbolizing that we are just testing, not proving).