### PR TITLE
[PLE] Create DecidableRefinements when parsing NNF 'define'

### DIFF
--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -91,7 +91,7 @@ NNFParser >> define [
 	==> [ :x | Equation
 					mkEquation: x second
 					args: x third
-					expr: x seventh
+					expr: (DecidableRefinement text: x seventh)
 					sort: x fifth ]
 ]
 


### PR DESCRIPTION
This fix belongs in the pure-z3 branch, not in reflect*, because it is in the "plumbing connecting Refinements and PLE" introduced in 629ab