### PR TITLE
Add class `Query`

### DIFF
--- a/src/PreSmalltalks-Pharo/Query.class.st
+++ b/src/PreSmalltalks-Pharo/Query.class.st
@@ -1,0 +1,57 @@
+Class {
+	#name : #Query,
+	#superclass : #Notification,
+	#category : #'PreSmalltalks-Pharo'
+}
+
+{ #category : #answering }
+Query class >> answer: value do: block [
+	"Evaluate `block` answering `value` to queries made within the block.
+	 Returns the value of `block`.
+
+	 See `Query class >> #query`"
+
+	^block on: self do: [:q | q resume: value ]
+
+
+	"
+	Query answer: 'kitty' do:[
+		Transcript show: 'Hello ' , Query query , '!'; cr.
+	]
+	"
+]
+
+{ #category : #asking }
+Query class >> query [
+	"Raise the query. Return the answer or default value.
+
+	 See `Query class >> #answer:do:` and `Query >> #defaultResumeValue`"
+
+	^self signal
+
+
+	"
+	Query answer: 'world' do:[
+		Transcript show: 'Hello ' , Query query , '!'; cr.
+		1
+	]
+	"
+]
+
+{ #category : #accessing }
+Query >> defaultAction [
+	"The default action taken if the exception is signaled."
+
+	^self defaultResumeValue
+]
+
+{ #category : #accessing }
+Query >> defaultResumeValue [
+	"Default answer to this query. This value is used if nobody
+	 provided 'better' answer using `#answer:do:`.
+
+   By default an error is raised. Subclasses may override this
+   to provide a suitable default."
+
+	self error: 'No suitable default answer!'
+]

--- a/src/PreSmalltalks-Tests/QueryTest.class.st
+++ b/src/PreSmalltalks-Tests/QueryTest.class.st
@@ -1,0 +1,47 @@
+Class {
+	#name : #QueryTest,
+	#superclass : #TestCase,
+	#category : #'PreSmalltalks-Tests'
+}
+
+{ #category : #tests }
+QueryTest >> testBasic [
+	| answer reply |
+
+	answer := Object new.
+
+	TestQuery answer: answer do:[
+		reply := TestQuery query.
+	].
+
+	self assert: answer == reply
+]
+
+{ #category : #tests }
+QueryTest >> testDefaultAnswer [
+	| answer |
+
+
+	answer := TestQuery query.
+
+	self assert: answer equals: TestQuery basicNew defaultResumeValue
+
+]
+
+{ #category : #tests }
+QueryTest >> testNested [
+	| outer inner reply |
+
+	outer := Object new.
+	inner := Object new.
+
+	TestQuery answer: outer do:[
+		reply := TestQuery query.
+
+		TestQuery answer: inner do:[
+			reply := TestQuery query.
+		]
+	].
+
+	self assert: inner == reply
+]

--- a/src/PreSmalltalks-Tests/TestQuery.class.st
+++ b/src/PreSmalltalks-Tests/TestQuery.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #TestQuery,
+	#superclass : #Query,
+	#category : #'PreSmalltalks-Tests'
+}
+
+{ #category : #accessing }
+TestQuery >> defaultResumeValue [
+	^ 'default resume value'
+
+]


### PR DESCRIPTION
This commit adds class `Query` implementing "query pattern". The API was chosen to be compatible with Smalltalk/X counterpart [1].

[1]: https://jan.vrany.io/hg/stx-libbasic/file/tip/Query.st