### PR TITLE
[Z3] Refactor #inThisEnvoronment

### DIFF
--- a/src/PreSmalltalks/Context.extension.st
+++ b/src/PreSmalltalks/Context.extension.st
@@ -10,3 +10,10 @@ Context class >> readState: marker [
 	launchContext isNil ifTrue: [ ^self error: 'No state context: ', marker ].
 	^launchContext tempNamed: #s
 ]
+
+{ #category : #'*PreSmalltalks' }
+Context >> toDictionary [
+	^(Dictionary newFromAssociations: (self tempNames collect: [ :t | t -> (self tempNamed: t) ]))
+		at: 'self' put: self receiver;
+		yourself
+]

--- a/src/Z3/Z3Node.class.st
+++ b/src/Z3/Z3Node.class.st
@@ -205,14 +205,7 @@ Z3Node >> inEnvironment: aDictionary [
 
 { #category : #'term rewriting' }
 Z3Node >> inThisEnvironment [
-	| senderContext senderEnvironment |
-	senderContext := thisContext sender.
-	senderEnvironment := Dictionary new: senderContext size + 1"self".
-	senderContext tempNames withIndexDo:[:n :i |
-		senderEnvironment at: n put: (senderContext at: i)
-	].
-	senderEnvironment at: 'self' put: senderContext receiver.
-	^ self inEnvironment: senderEnvironment
+	^ self inEnvironment: thisContext sender toDictionary
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
It would be much preferable to get rid of the #toDictionary; In Cardano–Tartaglia we want to make Context and Dictionary interchangeable in terms of environment lookup API. However, due to Issue 287, lookup doesn't really work, so we will revisit this when 287 is resolved.