### PR TITLE
Replace non-standard name for monadic bind

### DIFF
--- a/src/PLE/ICtx.class.st
+++ b/src/PLE/ICtx.class.st
@@ -159,7 +159,7 @@ Cf. PLE.hs
 	rhs := eRhs" unElab??".
 	es  := binds collect: #expr" unElab??".
 	econsts := Dictionary newFromAssociations: (ienv ieKnowl findConstants: es).
-	cands := {rhs},es collectAndCat: [ :eachExpr | ienv ieKnowl makeCandidates: eachExpr in: self ].
+	cands := {rhs},es >>= [ :eachExpr | ienv ieKnowl makeCandidates: eachExpr in: self ].
 	initEqs := #(). "BOGUS but still ok today"
 	ctxEqs := "... initEqs, sims, icEquals ctx, ..."
 		bs "select: [ :eachBind |

--- a/src/PLE/Knowledge.class.st
+++ b/src/PLE/Knowledge.class.st
@@ -47,7 +47,7 @@ knowledge :: Config -> SMT.Context -> SInfo a -> Knowledge
 "
 	| sims |
 	sims := si ae aenvSimpl ", ...next line".
-	#() "none in ple42 example" collectAndCat: #reWriteDDecl "BOGUS".
+	#() "none in ple42 example" >>= #reWriteDDecl "BOGUS".
 	"in the ple42 example, no sims anyway."
 	
 	^self basicNew

--- a/src/PLE/Z3Node.extension.st
+++ b/src/PLE/Z3Node.extension.st
@@ -72,8 +72,8 @@ Z3Node >> notGuardedApps [
   -- type application, or quantifier.
 notGuardedApps :: Expr -> [Expr]
 "
-	self isPAnd   ifTrue: [ ^self args collectAndCat: #notGuardedApps ].
-	self isPOr    ifTrue: [ ^self args collectAndCat: #notGuardedApps ].
+	self isPAnd   ifTrue: [ ^self args >>= #notGuardedApps ].
+	self isPOr    ifTrue: [ ^self args >>= #notGuardedApps ].
 	self isPNot   ifTrue: [ ^self args first notGuardedApps ].
 	self isPAtom  ifTrue: [ ^self args first notGuardedApps, self args second notGuardedApps ].
 	self isPIff   ifTrue: [ ^self args first notGuardedApps, self args second notGuardedApps ].

--- a/src/PreSmalltalks-Applicative/Collection.extension.st
+++ b/src/PreSmalltalks-Applicative/Collection.extension.st
@@ -4,7 +4,7 @@ Extension { #name : #Collection }
 Collection >> <*> a [
 	"Cf. McBride-Paterson, 'Applicative programming with effects':
 	 https://www.staff.city.ac.uk/~ross/papers/Applicative.pdf"
-	^self collectAndCat: [ :f | a collect: f ]
+	^self >>= [ :f | a collect: f ]
 ]
 
 { #category : #'*PreSmalltalks-Applicative' }

--- a/src/PreSmalltalks-Substitutions/Collection.extension.st
+++ b/src/PreSmalltalks-Substitutions/Collection.extension.st
@@ -25,5 +25,5 @@ Collection >> substf: f [
 Collection >> syms [
 	"instance Subable a => Subable [a] where
 	   syms   = concatMap syms"
-	^self collectAndCat: #syms
+	^self >>= #syms
 ]

--- a/src/PreSmalltalks-Tests/MonadTest.class.st
+++ b/src/PreSmalltalks-Tests/MonadTest.class.st
@@ -1,23 +1,23 @@
 Class {
-	#name : #CollectAndCatTest,
+	#name : #MonadTest,
 	#superclass : #TestCase,
 	#category : #'PreSmalltalks-Tests'
 }
 
-{ #category : #tests }
-CollectAndCatTest >> test1 [
+{ #category : #'tests-bind' }
+MonadTest >> testBind1 [
 	| ω result |
 	ω := 1000000000000000000000000000000000000000000000000000000000.
 	result := { 1 to: ω.  10 to: ω.  100 to: ω.  1000 to: ω. }
 	 "{ 1 to: ∞.  10 to: ∞.  100 to: ∞.  1000 to: ∞. }"
-			collectAndCat: [ :a | a copyFrom: 1 to: 3 ].
+			>>= [ :a | a copyFrom: 1 to: 3 ].
 	self assert: result equals: #(1 2 3 10 11 12 100 101 102 1000 1001 1002)
 ]
 
-{ #category : #tests }
-CollectAndCatTest >> test2 [
+{ #category : #'tests-bind' }
+MonadTest >> testBind2 [
 	| f result |
 	f := [ :to | 1 to: to ].
-	result := #(1 3 5) collectAndCat: f.
+	result := #(1 3 5) >>= f.
 	self assert: result equals: #(1 1 2 3 1 2 3 4 5)
 ]

--- a/src/PreSmalltalks/Collection.extension.st
+++ b/src/PreSmalltalks/Collection.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #Collection }
 
 { #category : #'*PreSmalltalks' }
+Collection >> >>= aBlock [
+	^(self collect: aBlock) inject: self species new into: [ :x :y | x, y ]
+]
+
+{ #category : #'*PreSmalltalks' }
 Collection >> colject: thisValue into: binaryBlock [
 	"This method behaves like a combination of #collect: and #inject:into:.
 	It applies binaryBlock to each element of the receiver, passing an accumulating parameter
@@ -11,21 +16,6 @@ Collection >> colject: thisValue into: binaryBlock [
 	blockResult := binaryBlock value: thisValue value: self first.
 	rest := self allButFirst colject: blockResult key into: binaryBlock.
 	^rest key -> ( (self species with: blockResult value), rest value)
-]
-
-{ #category : #'*PreSmalltalks' }
-Collection >> collectAndCat: aBlock [
-	"Evaluate aBlock with each of the receiver's elements,
-	 assuming aBlock will return a collection each time,
-	 and concatenate the resulting lists.
-	
-	Cf. Data.Foldable.concatMap in Haskell.  Where this becomes interesting
-	is with infinite lists, e.g.:
-	  { 1 to: ∞.  10 to: ∞.  100 to: ∞.  1000 to: ∞. }
-			collectAndCat: [ :a | a copyFrom: 1 to: 3 ]
-	(viz. the test)."
-	
-	^(self collect: aBlock) inject: self species new into: [ :x :y | x, y ]
 ]
 
 { #category : #'*PreSmalltalks' }

--- a/src/Refinements/BindEnv.class.st
+++ b/src/Refinements/BindEnv.class.st
@@ -120,7 +120,7 @@ BindEnv >> envCs: anIBindEnv [
 { #category : #'as yet unclassified' }
 BindEnv >> envKVars: c [
 	"Answer a collection of kvar names."
-	^(c clhs: self) collectAndCat: [ :ass |
+	^(c clhs: self) >>= [ :ass |
 		| sr |
 		sr := ass value.
 		sr sr_reft expr kvarsExpr ]

--- a/src/Refinements/ConstraintGraph.class.st
+++ b/src/Refinements/ConstraintGraph.class.st
@@ -41,7 +41,7 @@ ConstraintGraph class >> cSuccM: es [
 	iWrites := (es select:  [ :e | e key isCstr and: [e value isKVar]] thenCollect: [ :anEdge | anEdge key id -> anEdge value kvar ]) groupAssociations.
 	kReads :=  (es select:  [ :e | e key isKVar and: [e value isCstr]] thenCollect: [ :anEdge | anEdge key kvar -> anEdge value id ]) groupAssociations.
 	kRdBy := [ :k | kReads at: k ifAbsent: [Set new] ].
-	^iWrites collect: [ :kvs | (kvs collectAndCat: kRdBy) asSet asArray sorted ]
+	^iWrites collect: [ :kvs | (kvs >>= kRdBy) asSet asArray sorted ]
 ]
 
 { #category : #'instance creation' }

--- a/src/Refinements/CstrAnd.class.st
+++ b/src/Refinements/CstrAnd.class.st
@@ -114,7 +114,7 @@ CstrAnd >> rename: x to: y [
 
 { #category : #logic }
 CstrAnd >> sol1: k [
-	^self conjuncts collectAndCat: [ :c | c sol1: k ]
+	^self conjuncts >>= [ :c | c sol1: k ]
 ]
 
 { #category : #logic }

--- a/src/Refinements/HCstr.class.st
+++ b/src/Refinements/HCstr.class.st
@@ -63,7 +63,7 @@ boundKvars :: Cstr a -> S.Set F.Symbol
 HCstr >> demorgan: x t: t kvars: kvars preds: preds bss: bss [
 	| suki su cubeSols |
 	"first compute the Subst; bss isn't needed for this"
-	suki := kvars collectAndCat: [ :k_xs |
+	suki := kvars >>= [ :k_xs |
 			| k xs |
 			k := k_xs key.
 			xs := k_xs value.

--- a/src/Refinements/HPredAnd.class.st
+++ b/src/Refinements/HPredAnd.class.st
@@ -133,5 +133,5 @@ HPredAnd >> substf: f [
 
 { #category : #'F.Subable' }
 HPredAnd >> syms [
-	^ps collectAndCat: #syms
+	^ps >>= #syms
 ]

--- a/src/Refinements/HornInfo.class.st
+++ b/src/Refinements/HornInfo.class.st
@@ -323,7 +323,7 @@ HornInfo >> kvEdges [
 		(ks collect: [ :k | (KVarVertex kvar: k)->(DKVarVertex kvar: k) ]),
 		(ks collect: [ :k | (DKVarVertex kvar: k)->(DKVarVertex kvar: k) ]).
 	^selfes,
-	(cs collectAndCat: [ :c | (c edges: bs) asArray ])
+	(cs >>= [ :c | (c edges: bs) asArray ])
 	"BOGUS!!! ebindEdges!!!!!" "++ concatMap (ebindEdges ebs bs) cs)"
 ]
 
@@ -342,7 +342,7 @@ HornInfo >> kvReadBy [
 HornInfo >> kvSucc [
 	| rdBy |
 	rdBy := self kvReadBy.
-	^self kvWriteBy collect: [ :ks | ks asSet collectAndCat: [ :k | rdBy at: k ifAbsent: [Set new] ] ]
+	^self kvWriteBy collect: [ :ks | ks asSet >>= [ :k | rdBy at: k ifAbsent: [Set new] ] ]
 ]
 
 { #category : #'as yet unclassified' }
@@ -410,7 +410,7 @@ HornInfo >> sliceKVars: sl [
 	| union cs |
 	union := sl kVarCs asSet union: sl concCs asSet.
 	cs := union collect: [ :anId | cm at: anId ].
-	^(cs collectAndCat: [ :c | bs subcKVars: c ]) asSet
+	^(cs >>= [ :c | bs subcKVars: c ]) asSet
 ]
 
 { #category : #sanitizing }

--- a/src/Refinements/LabeledGraph.extension.st
+++ b/src/Refinements/LabeledGraph.extension.st
@@ -23,7 +23,7 @@ LabeledGraph >> elimK: kV [
 	| cs cis kis es1 |
 	cs := self immediateSuccessorsOf: kV.
 	cis := self immediatePredecessorsOf: kV.
-	kis := cis collectAndCat: [ :x | self immediatePredecessorsOf: x ].
+	kis := cis >>= [ :x | self immediatePredecessorsOf: x ].
 	es1 := (kis reject: #isCstr) ⊗ (cs select: #isCstr).
 	^(self addLinks: es1) delNodes: (cis add: kV; yourself)
 ]

--- a/src/Refinements/PAnd.class.st
+++ b/src/Refinements/PAnd.class.st
@@ -39,7 +39,7 @@ PAnd >> children [
 
 { #category : #accessing }
 PAnd >> conjuncts [
-	^conjuncts collectAndCat: #conjuncts
+	^conjuncts >>= #conjuncts
 ]
 
 { #category : #accessing }
@@ -95,7 +95,7 @@ PAnd >> isTautoPred [
 
 { #category : #'term rewriting' }
 PAnd >> kvarsExpr [
-	^((conjuncts collect: #kvarsExpr) collectAndCat: #asArray) asSet asArray
+	^((conjuncts collect: #kvarsExpr) >>= #asArray) asSet asArray
 ]
 
 { #category : #printing }

--- a/src/Refinements/QCluster.class.st
+++ b/src/Refinements/QCluster.class.st
@@ -57,7 +57,7 @@ cf. Solution.hs
 	^(su0_i0_qs0′s collectTriplesAndCat: [ :su0 :i0 :qs0 |
 		| what |
 		what := tyss matchP: senv is: { { i0 . qs0 } } qualParams: (qps collect: [ :eachQP | eachQP applyQPP: su0 ]).
-		(what collectAndCat: [ :ixs |
+		(what >>= [ :ixs |
 			| yss |
 			yss := QCluster instSymbol: tyss is: ixs reversed allButFirst.
 			yss size.
@@ -98,10 +98,10 @@ instK :: Bool -> F.SEnv F.Sort -> F.Symbol -> F.Sort -> QCluster    -> Sol.QBind
 cf. Solver/Solution.hs
 "
 	| eQuals |
-	eQuals := self associations collectAndCat: [ :sig_qs |
+	eQuals := self associations >>= [ :sig_qs |
 		| sig qs xss | sig := sig_qs key. qs := sig_qs value.
 		xss := QCluster instKSig: ho _: env _: v _: t _: sig.
-		xss collectAndCat: [ :xs | qs collect: [ :q | q eQual: xs ] ] ].
+		xss >>= [ :xs | qs collect: [ :q | q eQual: xs ] ] ].
 	^QBind fromEQuals: eQuals asSet
 	
 ]

--- a/src/Refinements/SInfo.class.st
+++ b/src/Refinements/SInfo.class.st
@@ -70,7 +70,7 @@ cutSInfo :: SInfo a -> KIndex -> S.HashSet KVar -> SInfo a
 "
 	| cs cm′ ws′ |
 	ws′ := ws associationsSelect: [ :k__ | cKs includes: k__ key ].
-	cs := (cKs collectAndCat: [ :k | (kI at: k ifAbsent: Set new) asArray ]) asSet.
+	cs := (cKs >>= [ :k | (kI at: k ifAbsent: Set new) asArray ]) asSet.
 	cm′ := cm associationsSelect: [ :i_c |
 		| i c |
 		i := i_c key.
@@ -238,7 +238,7 @@ SInfo >> kIndex [
 	"
 	| iCs b |
 	iCs := cm associations.
-	b := iCs collectAndCat: [ :ass |
+	b := iCs >>= [ :ass |
 		| i c rkvars |
 		i := ass key.
 		c := ass value.

--- a/src/Refinements/SimpC.class.st
+++ b/src/Refinements/SimpC.class.st
@@ -119,7 +119,7 @@ subcKSubs :: Fixpoint a => [(F.Symbol, F.SortedReft)] -> F.SimpC a -> [KSub]
 type KSub = (Maybe F.Symbol, F.KVar, F.Subst)
 "
 	| l r |
-	l := xsrs asArray collectAndCat: [ :xsr |
+	l := xsrs asArray >>= [ :xsr |
 		| sr rs |
 		sr := xsr value.
 		rs := sr sr_reft pkvarConjuncts.

--- a/src/Refinements/Solution.class.st
+++ b/src/Refinements/Solution.class.st
@@ -291,7 +291,7 @@ Solution >> rhsCands: c [
 "Sol.Solution -> F.SimpC a -> ([F.KVar], Sol.Cand (F.KVar, Sol.EQual))"
 	| ks kqs |
 	ks := c crhs predKs.
-	kqs := ks asArray collectAndCat: [ :k_su |
+	kqs := ks asArray >>= [ :k_su |
 		| k su |
 		k := k_su key.
 		su := k_su value.

--- a/src/SpriteLang/Expr.extension.st
+++ b/src/SpriteLang/Expr.extension.st
@@ -40,16 +40,6 @@ predRType p = TBase TBool (known $ F.predReft p)
 ]
 
 { #category : #'*SpriteLang' }
-Expr >> wfMetric: γ [ 
-	| v |
-	v := self
-		evaluateIn: (EvalEnv ofSorts: γ eSorts)
-		ifUndeclared: [ ^false ]. "expected: we just haven't reached the fixpoint where n is put in γ "
-	(v isKindOf: UnknownEVar) ifTrue: [ ^false ]. "BOGUS: what about non-atoms?"
-	^v sort canBeTerminationMetric
-]
-
-{ #category : #'*SpriteLang' }
 Expr >> uniq2: α [
 	"α-rename all variables. Returns a copy of receiver with all names unique."
 
@@ -60,6 +50,16 @@ Expr >> uniq2: α [
 		self′ := self′ rename: orig to: uniq.
 	].
 	^ self′
+]
+
+{ #category : #'*SpriteLang' }
+Expr >> wfMetric: γ [ 
+	| v |
+	v := self
+		evaluateIn: (EvalEnv ofSorts: γ eSorts)
+		ifUndeclared: [ ^false ]. "expected: we just haven't reached the fixpoint where n is put in γ "
+	(v isKindOf: UnknownEVar) ifTrue: [ ^false ]. "BOGUS: what about non-atoms?"
+	^v sort canBeTerminationMetric
 ]
 
 { #category : #'*SpriteLang' }

--- a/src/SpriteLang/HPred.extension.st
+++ b/src/SpriteLang/HPred.extension.st
@@ -16,7 +16,7 @@ cf. Types.hs
 "
 	| flat |
 	flat := self flatten.
-	(flat isKindOf: HPredAnd) ifTrue: [ ^flat ps collectAndCat: #predExprsGo ].
+	(flat isKindOf: HPredAnd) ifTrue: [ ^flat ps >>= #predExprsGo ].
 	^flat predExprsGo
 ]
 

--- a/src/SpriteLang/HPredAnd.extension.st
+++ b/src/SpriteLang/HPredAnd.extension.st
@@ -11,7 +11,7 @@ HPredAnd >> smash [
 "
 smash (H.PAnd ps) = concatMap smash ps
 "
-	^ps collectAndCat: #smash
+	^ps >>= #smash
 ]
 
 { #category : #'*SpriteLang' }

--- a/src/SpriteLang/RVar.class.st
+++ b/src/SpriteLang/RVar.class.st
@@ -27,7 +27,7 @@ RVar class >> rvName: rvName rvArgs: rvArgs [
 
 { #category : #'as yet unclassified' }
 RVar >> freeTVarsGoP [
-	^(rvArgs collectAndCat: #freeTVars) asSet
+	^(rvArgs >>= #freeTVars) asSet
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/SpriteLang/TCon.class.st
+++ b/src/SpriteLang/TCon.class.st
@@ -228,7 +228,7 @@ TCon >> substf: f [
 { #category : #'F.Subable' }
 TCon >> syms [
 	"syms (TCon _ ts r)   = concatMap F.syms ts ++ F.syms r"
-	^(ts collectAndCat: #syms), r syms
+	^(ts >>= #syms), r syms
 ]
 
 { #category : #accessing }

--- a/src/SpriteLang/ΓContext.class.st
+++ b/src/SpriteLang/ΓContext.class.st
@@ -26,7 +26,7 @@ Class {
 empEnv :: [(F.Symbol, F.Sort)] -> [SrcData] -> Env
 "
 	| prelSigs env₀ |
-	prelSigs := RType prelude, (typs collectAndCat: #dataSigs).
+	prelSigs := RType prelude, (typs >>= #dataSigs).
 	env₀ := 	self basicNew
 		eBinds: SEnv new;
 		eSize: 0;


### PR DESCRIPTION
The selector `#collectAndCat:` is sheer inverse vandalism. It is not met in any book or programming language, while the concept has been standard for decades, as well as the name for it (bind) and mathematical notation (μ::T²→T).

The proper for this method, would not make sense for this half-assed implementation; we shall give it when we transition to Smalltalk-25 Collections.