### PR TITLE
[Z3] Add `Z3BitVectorSort>>#uminVal`, `#umaxVal`, `#sminVal`, `#smaxVal`

### DIFF
--- a/src/Z3-Tests/BVTest.class.st
+++ b/src/Z3-Tests/BVTest.class.st
@@ -98,6 +98,45 @@ BVTest >> testCoerceSignedRemainder [
 		equals: 1
 ]
 
+{ #category : #limits }
+BVTest >> testLimits32 [
+	| sort |
+
+	sort := Z3Sort bv: 32.
+
+	self assert: sort uminVal equals: 0.
+	self assert: sort umaxVal equals: 16rFFFFFFFF.
+
+	self assert: sort sminVal equals:-16r80000000.
+	self assert: sort smaxVal equals: 16r7FFFFFFF.
+]
+
+{ #category : #limits }
+BVTest >> testLimits5 [
+	| sort |
+
+	sort := Z3Sort bv: 5.
+
+	self assert: sort uminVal equals: 0.
+	self assert: sort umaxVal equals: 31.
+
+	self assert: sort sminVal equals:-16.
+	self assert: sort smaxVal equals: 15
+]
+
+{ #category : #limits }
+BVTest >> testLimits8 [
+	| sort |
+
+	sort := Z3Sort bv: 8.
+
+	self assert: sort uminVal equals: 0.
+	self assert: sort umaxVal equals: 255.
+
+	self assert: sort sminVal equals: -128.
+	self assert: sort smaxVal equals:  127
+]
+
 { #category : #rewriting }
 BVTest >> testThisEnvironment [
 	self doTestThisEnvironment: 2r1111

--- a/src/Z3/Z3BitVectorSort.class.st
+++ b/src/Z3/Z3BitVectorSort.class.st
@@ -1,6 +1,11 @@
 Class {
 	#name : #Z3BitVectorSort,
 	#superclass : #Z3Sort,
+	#instVars : [
+		'smin',
+		'smax',
+		'umax'
+	],
 	#category : #'Z3-Core'
 }
 
@@ -12,6 +17,19 @@ Z3BitVectorSort >> anyOne [
 { #category : #'type theory' }
 Z3BitVectorSort >> cast: value [
 	^ value toBitVector: self length
+]
+
+{ #category : #initialization }
+Z3BitVectorSort >> initializeWithAddress: anExternalAddress context: aZ3Context [
+	| len |
+
+	super initializeWithAddress: anExternalAddress context: aZ3Context.
+
+	len := self length.
+
+	umax := (1 << len) - 1.
+	smin := (1 << (len - 1)) negated.
+	smax := umax + smin.
 ]
 
 { #category : #accessing }
@@ -31,4 +49,24 @@ Z3BitVectorSort >> nodeClass [
 Z3BitVectorSort >> printString [
 	^ 'Z3Sort bv:',self length printString
 
+]
+
+{ #category : #'accessing - limits' }
+Z3BitVectorSort >> smaxVal [
+	^ smax
+]
+
+{ #category : #'accessing - limits' }
+Z3BitVectorSort >> sminVal [
+	^ smin
+]
+
+{ #category : #'accessing - limits' }
+Z3BitVectorSort >> umaxVal [
+	^ umax
+]
+
+{ #category : #'accessing - limits' }
+Z3BitVectorSort >> uminVal [
+	^ 0
 ]


### PR DESCRIPTION
This commit adds methods return minimum and maximum values of bitvector of given size - both when interpreted as unsigned and signed values.