### PR TITLE
Improve Z3 objects lifecycle support

### DIFF
--- a/src/Refinements/SMTContext.class.st
+++ b/src/Refinements/SMTContext.class.st
@@ -80,7 +80,7 @@ cf. Smt/Interface.hs
 
 { #category : #'SMT interface' }
 SMTContext >> del [
-	z3 del.
+	z3 release.
 	z3 := nil
 ]
 

--- a/src/Refinements/ShallowRefinement.class.st
+++ b/src/Refinements/ShallowRefinement.class.st
@@ -29,7 +29,7 @@ ShallowRefinement >> allElements [
 		elements add: instance.
 		solver assert: m blockerContradictions
 	].
-	solver del.
+	solver release.
 	^elements
 ]
 
@@ -41,7 +41,7 @@ ShallowRefinement >> anyOne [
 	solver assert: (e value: nu).
 	solver check == true ifFalse: [ ^SubscriptOutOfBounds signalFor: 1 ].
 	instance := solver getModel eval: nu completion: true.
-	solver del.
+	solver release.
 	^instance
 ]
 
@@ -113,8 +113,8 @@ ShallowRefinement >> ⊆ [ rhs
 	solver := Z3Solver new.
 	[
 		solver proveValid: (self predicate value: x) ==> (rhs predicate value: x).
-		solver del.
+		solver release.
 		^true
 	] on: NotValid
-	do: [ solver del. ^false ]
+	do: [ solver release. ^false ]
 ]

--- a/src/Z3-FFI-Pharo/Z3Object.class.st
+++ b/src/Z3-FFI-Pharo/Z3Object.class.st
@@ -65,6 +65,17 @@ Z3Object class >> fromExternalAddress: address [
    		yourself.
 ]
 
+{ #category : #'initialization & release' }
+Z3Object >> delete [
+    "Delete (deallocate) underlaying Z3 resource.
+
+     Private, do not call directly, use #release
+     instead."
+
+    self subclassResponsibility
+
+]
+
 { #category : #utilities }
 Z3Object >> ensureValidZ3AST [
 	"This method is no-op if the object appears to be valid
@@ -109,12 +120,21 @@ Z3Object >> externalArrayFrom: anArray [
 		
 ]
 
-{ #category : #initialization }
+{ #category : #finalization }
+Z3Object >> finalize [
+	(self isNull or: [ self isPoisoned ]) ifTrue: [
+        "Invalid or already released."
+        ^ self
+    ].
+	self delete
+]
+
+{ #category : #'initialization & release' }
 Z3Object >> initialize [
 	self error:'Should not be sent nor overidden. Use `#initializeWithAddress:` instead'
 ]
 
-{ #category : #initialization }
+{ #category : #'initialization & release' }
 Z3Object >> initializeWithAddress: address [
 	self setHandle: address
 ]
@@ -145,10 +165,31 @@ Z3Object >> poison [
 	self setHandle: ExternalAddress newPoison 
 ]
 
-{ #category : #initialization }
-Z3Object >> release [
-    "Release the object. Once released, receiver is no longer
-     usable. This method must be idempotent."
-    self poison.
+{ #category : #finalization }
+Z3Object >> registerForFinalization [
+	self finalizationRegistry add: self.
+]
 
+{ #category : #'initialization & release' }
+Z3Object >> release [
+    "Release underlaying Z3 resource.
+
+     Subclasses normally do not need to override this method (except in
+     special cases). However, receiver must override #delete (unless it
+     overrides #release, of course).
+
+     This method must be idempotent.
+    "
+    (self isNull or: [ self isPoisoned ]) ifTrue: [
+        "Invalid or already released."
+        ^ self
+    ].
+    self unregisterForFinalization.
+    self delete.
+    self poison.
+]
+
+{ #category : #finalization }
+Z3Object >> unregisterForFinalization [
+	self finalizationRegistry remove: self ifAbsent: []
 ]

--- a/src/Z3-FFI-Pharo/Z3Object.class.st
+++ b/src/Z3-FFI-Pharo/Z3Object.class.st
@@ -110,6 +110,11 @@ Z3Object >> externalArrayFrom: anArray [
 ]
 
 { #category : #initialization }
+Z3Object >> initialize [
+	self error:'Should not be sent nor overidden. Use `#initializeWithAddress:` instead'
+]
+
+{ #category : #initialization }
 Z3Object >> initializeWithAddress: address [
 	self setHandle: address
 ]
@@ -138,4 +143,12 @@ Z3Object >> poison [
 	 no longer be used. This is to help debugging use-after-free bugs."
 	
 	self setHandle: ExternalAddress newPoison 
+]
+
+{ #category : #initialization }
+Z3Object >> release [
+    "Release the object. Once released, receiver is no longer
+     usable. This method must be idempotent."
+    self poison.
+
 ]

--- a/src/Z3-FFI-SmalltalkX/Z3Object.class.st
+++ b/src/Z3-FFI-SmalltalkX/Z3Object.class.st
@@ -88,6 +88,16 @@ Z3Object class >> initialize [
 
 ]
 
+{ #category : #'initialization & release' }
+Z3Object >> delete [
+	"Delete (deallocate) underlaying Z3 resource.
+
+	 Private, do not call directly, use #release
+	 instead."
+
+	self subclassResponsibility
+]
+
 { #category : #utilities }
 Z3Object >> ensureValidZ3AST [
 	"This method is no-op if the object appears to be valid
@@ -152,9 +162,20 @@ Z3Object >> poison [
 	self setAddress: ExternalAddress newPoison 
 ]
 
-{ #category : #initialization }
+{ #category : #'initialization & release' }
 Z3Object >> release [
-	"Release the object. Once released, receiver is no longer
-	 usable. This method must be idempotent."
+	"Release underlaying Z3 resource.
+
+	 Subclasses normally do not need to override this method (except in
+	 special cases). However, receiver must override #delete (unless it
+	 overrides #release, of course).
+
+	 This method must be idempotent.
+	"
+	(self isNull or: [ self isPoisoned ]) ifTrue: [
+		"Invalid or already released."
+		^ self
+	].
+	self delete.
 	self poison.
 ]

--- a/src/Z3-FFI-SmalltalkX/Z3Object.class.st
+++ b/src/Z3-FFI-SmalltalkX/Z3Object.class.st
@@ -154,6 +154,7 @@ Z3Object >> poison [
 
 { #category : #initialization }
 Z3Object >> release [
+	"Release the object. Once released, receiver is no longer
+	 usable. This method must be idempotent."
 	self poison.
-
 ]

--- a/src/Z3-Tests/BitRelevanceTest.class.st
+++ b/src/Z3-Tests/BitRelevanceTest.class.st
@@ -22,7 +22,7 @@ BitRelevanceTest >> test1KStores [
 	thm := ((A arraySelect: k) eq: (Int value: 0)) ==>
 		((k copyFrom: 0 to: 0) eq: 0).
 	s proveValid: thm.
-	s del
+	s release
 ]
 
 { #category : #tests }
@@ -45,7 +45,7 @@ BitRelevanceTest >> test1KStoresExceptOne [
 		((k copyFrom: 0 to: 0) eq: 0).
 	[s proveValid: thm] on: NotValid do: [ :ex |
 		self assert: (ex counterexample constantsASTs at: 'k') value equals: 101.
-		s del.
+		s release.
 		^self ].
 	self assert: false
 ]

--- a/src/Z3-Tests/BoolSymbolTest.class.st
+++ b/src/Z3-Tests/BoolSymbolTest.class.st
@@ -11,7 +11,7 @@ BoolSymbolTest >> setUp [
 
 { #category : #running }
 BoolSymbolTest >> tearDown [
-	Z3Context current del
+	Z3Context current release
 ]
 
 { #category : #tests }

--- a/src/Z3-Tests/ContextlessZ3Test.class.st
+++ b/src/Z3-Tests/ContextlessZ3Test.class.st
@@ -44,7 +44,7 @@ ContextlessZ3Test >> testSimpleExample [
 	ctx := Z3Context fromDefault.
 	self assert: ctx class equals: Z3Context.
 	self deny: ctx isNull.
-	ctx del.
+	ctx release.
 ]
 
 { #category : #tests }
@@ -66,8 +66,8 @@ ContextlessZ3Test >> testTwoContexts [
 	self deny: ctx1 getHandle asInteger = ctx2 getHandle asInteger.
 	x := ctx1 mkBoolVar: 'x'.
 	y := ctx2 mkBoolVar: 'y'.
-	ctx1 del.
+	ctx1 release.
 	"ctx2 can still be used"
 	self assert: y astToString equals: 'y'.
-	ctx2 del
+	ctx2 release
 ]

--- a/src/Z3-Tests/FixpointTest.class.st
+++ b/src/Z3-Tests/FixpointTest.class.st
@@ -17,7 +17,7 @@ FixpointTest >> setUp [
 
 { #category : #'z3 context' }
 FixpointTest >> tearDown [
-	fp del.
+	fp release.
 	super tearDown.
 ]
 

--- a/src/Z3-Tests/GaussBvTestTest.class.st
+++ b/src/Z3-Tests/GaussBvTestTest.class.st
@@ -79,7 +79,7 @@ GaussBvTestTest >> testUnderflowSigned [
 	s := Z3Solver new.
 	s assert: (n-1 < n) not.
 	counterexamples := s allSolutions.
-	s del.
+	s release.
 	self assert: counterexamples size = 1.
 	self assert: (counterexamples first constants at: 'n') equals: 16r80
 	
@@ -94,7 +94,7 @@ GaussBvTestTest >> testUnderflowUnsigned [
 	s := Z3Solver new.
 	s assert: (n-1 <+ n) not.
 	counterexamples := s allSolutions.
-	s del.
+	s release.
 	self assert: counterexamples size = 1.
 	self assert: (counterexamples first constants at: 'n') equals: 0
 	

--- a/src/Z3-Tests/IntSymbolTest.class.st
+++ b/src/Z3-Tests/IntSymbolTest.class.st
@@ -11,7 +11,7 @@ IntSymbolTest >> setUp [
 
 { #category : #running }
 IntSymbolTest >> tearDown [
-	Z3Context current del
+	Z3Context current release
 ]
 
 { #category : #tests }
@@ -54,7 +54,7 @@ IntSymbolTest >> testImplication [
 	
 	solver := Z3Solver new.
 	solver proveValid: thm.
-	solver del.
+	solver release.
 ]
 
 { #category : #tests }
@@ -70,7 +70,7 @@ IntSymbolTest >> testImplicationQuantified [
 	rhs := (y<=v & fxy exists: {v.y.}) forall: x.
 	solver := Z3Solver new.
 	solver proveValid: lhs ==> rhs.
-	solver del.
+	solver release.
 ]
 
 { #category : #tests }

--- a/src/Z3-Tests/IntValueTest.class.st
+++ b/src/Z3-Tests/IntValueTest.class.st
@@ -14,7 +14,7 @@ IntValueTest >> setUp [
 
 { #category : #running }
 IntValueTest >> tearDown [
-	Z3Context current del
+	Z3Context current release
 ]
 
 { #category : #'tests - arithmetic' }

--- a/src/Z3-Tests/NQueensTest.class.st
+++ b/src/Z3-Tests/NQueensTest.class.st
@@ -69,8 +69,8 @@ NQueensTest >> solveNaive: n [
 
 { #category : #running }
 NQueensTest >> tearDown [
-	solver del.
-	Z3Context current del
+	solver release.
+	Z3Context current release
 ]
 
 { #category : #tests }

--- a/src/Z3-Tests/SimpleBitVectorTest.class.st
+++ b/src/Z3-Tests/SimpleBitVectorTest.class.st
@@ -86,7 +86,7 @@ SimpleBitVectorTest >> testProveStrengthReductionBV [
 	thm := x+x eq: 2*x.
 	solver := Z3Solver new.
 	solver proveValid: thm.
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -97,7 +97,7 @@ SimpleBitVectorTest >> testProveStrengthReductionBV3 [
 	thm := x+x+x eq: x*3.
 	solver := Z3Solver new.
 	solver proveValid: thm.
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -107,7 +107,7 @@ SimpleBitVectorTest >> testProveStrengthReductionInt [
 	thm := x+x eq: x*2.
 	solver := Z3Solver new.
 	solver proveValid: thm.
-	solver del
+	solver release
 ]
 
 { #category : #tests }

--- a/src/Z3-Tests/SimpleZ3Test.class.st
+++ b/src/Z3-Tests/SimpleZ3Test.class.st
@@ -27,7 +27,7 @@ SimpleZ3Test >> shapesBV: mod [
 	
 	hasOtherSolutions := solver check.
 	model := hasOtherSolutions ifTrue: [ solver getModel constants ] ifFalse: [ nil ].
-	solver del.
+	solver release.
 	^model
 ]
 
@@ -40,7 +40,7 @@ SimpleZ3Test >> test0lt1 [
 	one := Z3AST numeral: '1' ofSort: bvSort.
 	thm := zero <= one.
 	solver prove: thm isValid: true.
-	solver del.
+	solver release.
 ]
 
 { #category : #tests }
@@ -119,7 +119,7 @@ SimpleZ3Test >> testArrayUpdate [
 	updatedV := newArray arraySelect: i.
 	solver := Z3Solver new.
 	solver proveValid: (updatedV eq: v).
-	solver del.
+	solver release.
 	
 	"all other elements sit where they were"
 	j := Int const: 'j'.
@@ -128,7 +128,7 @@ SimpleZ3Test >> testArrayUpdate [
 		(i eq: j) not 
 		==>
 		((newArray arraySelect: j) eq: (a arraySelect: j)).
-	solver del
+	solver release
 	
 	
 
@@ -171,7 +171,7 @@ SimpleZ3Test >> testBitvectorCounterexample [
 	model := solver getModel.
 	"Just check that it gives us *some* counter example"
 	self assert: (model toString beginsWith: 'x -> #').
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -238,7 +238,7 @@ SimpleZ3Test >> testEvenOdd [
 	x := 'x' toInt.
 	solver := Z3Solver new.
 	solver proveValid: x even ==> (x+1) odd.
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -248,7 +248,7 @@ SimpleZ3Test >> testForAll [
 	x := 'x' toInt.
 	prop := (a+x eq: x) forall: x.
 	solver := Z3Solver new.
-	[solver proveValid: prop] on: NotValid do: [ :ex | self deny: (ex counterexample constantsASTs at: 'a') value = 0. ^solver del ].
+	[solver proveValid: prop] on: NotValid do: [ :ex | self deny: (ex counterexample constantsASTs at: 'a') value = 0. ^solver release ].
 	self error
 ]
 
@@ -289,7 +289,7 @@ SimpleZ3Test >> testFunctionality [
 	fml := (x eq: y) ==> ((f value: x) eq: (f value: y)).
 	solver := Z3Solver new.
 	solver proveValid: fml.
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -351,7 +351,7 @@ SimpleZ3Test >> testIsValid [
 	x := 'x' toInt.
 	solver := Z3Solver new.
 	self assert: (solver isValid: x even | x odd).
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -403,7 +403,7 @@ SimpleZ3Test >> testMixedTheories [
 		).
 	solver := Z3Solver new.
 	solver proveValid: fml.
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -438,7 +438,7 @@ SimpleZ3Test >> testProveNotValid [
 	thm := p.
 	counterexample := solver proveNotValid: thm.
 	self assert: (counterexample constants at: 'p') equals: Bool false.
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -449,7 +449,7 @@ SimpleZ3Test >> testProveNotValidFail [
 	thm := p | p not.
 	self should: [ solver proveNotValid: thm ]
 		raise: NotInvalid.
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -496,7 +496,7 @@ SimpleZ3Test >> testSMT2_b [
 	solutions := solver allSolutions collect: [ :eachSolution |
 		(eachSolution eval: ('a' toBitVector: 8) completion: false) value ].
 	self assert: solutions asSet equals: (16r10 to: 16rf0) asSet.
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -557,7 +557,7 @@ SimpleZ3Test >> testSendMoreMoney [
 	model := solver getModel constants.
 	self assert: (model at: 'y')         equals: 2.   
 	self assert: (model at: 'd')         equals: 7.
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -585,7 +585,7 @@ SimpleZ3Test >> testShapesN [
 	self assert: solver check.
 	model := solver getModel constants.
 	self assert: (model at: '?')         equals: 20.  
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -631,7 +631,7 @@ SimpleZ3Test >> testSmallExample [
 	one := m at: x.
 	self assert: one isInt.
 	self assert: one value = 1.
-	s del
+	s release
 ]
 
 { #category : #tests }
@@ -652,7 +652,7 @@ SimpleZ3Test >> testSplitNoOverlap [
 	m := solver getModel constantsASTs.
 	self assert: (m at: 'x') equals: 16r1234.
 	self assert: (m at: 'y') equals: 16r5678.
-	solver del
+	solver release
 ]
 
 { #category : #tests }

--- a/src/Z3-Tests/TestCaseWithZ3Context.class.st
+++ b/src/Z3-Tests/TestCaseWithZ3Context.class.st
@@ -11,5 +11,5 @@ TestCaseWithZ3Context >> setUp [
 
 { #category : #'z3 context' }
 TestCaseWithZ3Context >> tearDown [
-	Z3Context current del
+	Z3Context current release
 ]

--- a/src/Z3-Tests/YurichevBookTest.class.st
+++ b/src/Z3-Tests/YurichevBookTest.class.st
@@ -104,7 +104,7 @@ YurichevBookTest >> testDogCatMouse [
 	"TODO: Use readable selectors (~=?) after merging 'equality'"
 	s assert: (dogs eq: 3) not | (cats eq: 41) not | (mice eq: 56) not.
 	self deny: s check.
-	s del
+	s release
 ]
 
 { #category : #tests }
@@ -133,7 +133,7 @@ YurichevBookTest >> testXKCD287_int [
 	s assert: (f <= 10); assert: (f >= 0).
 
 	solutions := s allSolutions.
-	s del.
+	s release.
 	self assert: solutions size equals: 2.
 	
 	"One solution with a=7, and the other one."

--- a/src/Z3-Tests/Z3CAPITest.class.st
+++ b/src/Z3-Tests/Z3CAPITest.class.st
@@ -23,7 +23,7 @@ Z3CAPITest >> exampleArray2: n [
 	solver := Z3Solver on: arraySort ctx.
 	solver assert: distinct.
 	sat := solver check.
-	solver del.
+	solver release.
 	^sat
 ]
 
@@ -57,7 +57,7 @@ Z3CAPITest >> testArray1 [
 	
 	s := Z3Solver new.
 	s proveValid: thm.
-	s del
+	s release
 ]
 
 { #category : #tests }
@@ -119,7 +119,7 @@ Z3CAPITest >> testBitvector1 [
 	thm := x <= ten iff: x - ten <= zero.
 	counterexample := solver proveNotValid: thm.
 	self assert: (counterexample constants includesKey: 'x').
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -130,7 +130,7 @@ Z3CAPITest >> testBitvector1a [
 	x := 'x' toBitVector: 32.
 	thm := x <= 10 iff: x - 10 <= 0.
 	solver proveNotValid: thm.
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -162,7 +162,7 @@ Z3CAPITest >> testDemorgan [
 	"The negated conjecture was unsatisfiable, hence the conjecture is valid"
 	self deny: sat.
 	
-	solver del
+	solver release
 
 ]
 
@@ -191,7 +191,7 @@ Z3CAPITest >> testEnum [
 	fruity := fruit mkConst: 'fruity'.
 	solver := Z3Solver new.
 	solver proveValid: (Bool or: { fruity===apple. fruity===banana. fruity===orange. }).
-	solver del.
+	solver release.
 
 ]
 
@@ -225,8 +225,8 @@ Z3CAPITest >> testEval [
 	Transcript cr.
 	
 	"m decRef."
-	solver del.
-	ctx del
+	solver release.
+	ctx release
 	
 ]
 
@@ -302,7 +302,7 @@ Z3CAPITest >> testFindModel2 [
 	self assert: sat.
 	model := solver getModel.
 	Transcript cr; show: model toString. "x->3, y->4"
-	solver del
+	solver release
 ]
 
 { #category : #tests }
@@ -340,7 +340,7 @@ Z3CAPITest >> testNumeral [
 	n1 := real_sort numeralFrom: '-1/3'.
 	n2 := real_sort numeralFrom: '-0.33333333333333333333333333333333333333333333333333'.
 	s proveValid: (n1 eq: n2) not.
-	s del
+	s release
 ]
 
 { #category : #tests }
@@ -368,7 +368,7 @@ Z3CAPITest >> testProve1 [
 	ggx := g value: gx.
 	self flag: #TODO.  "I don't understand why the below fails to prove a counterexample"
 	"solver proveNotValid: (ggx eq: gy)."
-	solver del.
+	solver release.
 ]
 
 { #category : #tests }
@@ -419,8 +419,8 @@ Z3CAPITest >> testPushPop [
 	self assert: s check == true.
 	"s getModel inspect."
 	
-	s del.
-	ctx del 
+	s release.
+	ctx release
 ]
 
 { #category : #tests }
@@ -530,6 +530,6 @@ Z3CAPITest >> testUnsatCore [
 	self assert: result == false.
 	self assert: solver unsatCore size equals: 2.
 	"solver proof." "TODO"
-	solver del
+	solver release
 	
 ]

--- a/src/Z3-Tests/Z3FactorialTest.class.st
+++ b/src/Z3-Tests/Z3FactorialTest.class.st
@@ -75,5 +75,5 @@ Z3FactorialTest >> testInvertFactorial [
 	solver check.
 	x := solver getModel eval: x completion: true.
 	self assert: x equals: 5.
-	solver del
+	solver release
 ]

--- a/src/Z3-Tests/Z3SetTest.class.st
+++ b/src/Z3-Tests/Z3SetTest.class.st
@@ -45,7 +45,7 @@ Z3SetTest >> testSetAdd [
 		on: NotValid 
 		do: [ :ex |
 			"but the model doesn't contain an interesting x"
-			^solver del
+			^solver release
 	].
 	self assert: false
 ]
@@ -102,7 +102,7 @@ Z3SetTest >> testSetIU2 [
 	solver := Z3Solver new.
 	solver proveValid: (((onetwo union: threefour) includes: 'x') exists: 'x' toInt).
 	solver proveValid: (((onetwo union: threefour) includes: 'x') exists: 'x' toInt) not.
-	solver del
+	solver release
 ]
 
 { #category : #tests }

--- a/src/Z3/Bool.class.st
+++ b/src/Z3/Bool.class.st
@@ -89,7 +89,7 @@ Bool >> findCounterexample [
 	| solver answer |
 	solver := Z3Solver new.
 	answer := solver findCounterexample: self.
-	solver del.
+	solver release.
 	^answer
 	
 ]

--- a/src/Z3/Z3AST.class.st
+++ b/src/Z3/Z3AST.class.st
@@ -198,6 +198,20 @@ Z3AST >> printString [
 
 ]
 
+{ #category : #'initialization & release' }
+Z3AST >> release [
+	"MachineArithmetic does not use ref-counted ASTs, instead
+	 AST lifetime is bound to its context.
+	 Therefore here we merely invalidate the Smalltalk object
+	 so it cannot be used anymore.
+
+	 This may change once (if at all) we switch to ref-counted
+	 ASTs."
+
+	self poison.
+	ctx := nil.
+]
+
 { #category : #'refinement typing' }
 Z3AST >> singletonExpr: v [ 
 	^nil

--- a/src/Z3/Z3ArraySort.class.st
+++ b/src/Z3/Z3ArraySort.class.st
@@ -12,7 +12,7 @@ Z3ArraySort >> anyOne [
 	solver assert: ((a arraySelect: self domain anyOne) === self range anyOne).
 	solver check.
 	element := solver getModel eval: a completion: false.
-	solver del.
+	solver release.
 	^element
 	
 ]

--- a/src/Z3/Z3Config.class.st
+++ b/src/Z3/Z3Config.class.st
@@ -9,3 +9,8 @@ Z3Config class >> default [
 	^ Z3 mk_config 
 
 ]
+
+{ #category : #'initialization & release' }
+Z3Config >> delete [
+	Z3 del_config: self.
+]

--- a/src/Z3/Z3Constructor.class.st
+++ b/src/Z3/Z3Constructor.class.st
@@ -3,3 +3,8 @@ Class {
 	#superclass : #Z3ContextedObject,
 	#category : #'Z3-Core'
 }
+
+{ #category : #'initialization & release' }
+Z3Constructor >> delete [
+	Z3 del_constructor: ctx _: self
+]

--- a/src/Z3/Z3ConstructorList.class.st
+++ b/src/Z3/Z3ConstructorList.class.st
@@ -3,3 +3,8 @@ Class {
 	#superclass : #Z3ContextedObject,
 	#category : #'Z3-Core'
 }
+
+{ #category : #'initialization & release' }
+Z3ConstructorList >> delete [
+	Z3 del_constructor_list: ctx _: self
+]

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -232,3 +232,12 @@ Z3Context >> parseSmtlib2String: aString [
 	^ Z3 parse_smtlib2_string: self _: aString _: 0 _: #() _: #() _: 0 _: #() _: #()
 
 ]
+
+{ #category : #'initialization & release' }
+Z3Context >> release [
+	"In case #release sent to current global context, we have to flush it first
+	 before releasing it to make sure no subsequent code will use it."
+
+	Global == self ifTrue:[Global := nil].
+	super release.
+]

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -47,19 +47,6 @@ Z3Context class >> z3fullVersion [
 	^LibZ3 getFullVersion 
 ]
 
-{ #category : #'as yet unclassified' }
-Z3Context >> del [
-	"In case #del is sent to current global context, we have to flush it first 
-	 before we `z3_del_context()` to make sure no subsequent code will use it. 
-
-	 This is not fool-proof as there still may be instances that uses it, but still 
-	 this helps to stabilize tests. We need ref-counting..."
-
-	Global == self ifTrue:[Global := nil].
-	self delete.
-	self poison
-]
-
 { #category : #'initialization & release' }
 Z3Context >> delete [
 	Z3 del_context: self.

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -56,9 +56,13 @@ Z3Context >> del [
 	 this helps to stabilize tests. We need ref-counting..."
 
 	Global == self ifTrue:[Global := nil].
-	Z3 del_context: self.
+	self delete.
 	self poison
+]
 
+{ #category : #'initialization & release' }
+Z3Context >> delete [
+	Z3 del_context: self.
 ]
 
 { #category : #'error handling' }
@@ -75,7 +79,7 @@ Z3Context >> errorCheck [
 
 ]
 
-{ #category : #initialization }
+{ #category : #'initialization & release' }
 Z3Context >> initializeWithAddress: anExternalAddress [
 	super initializeWithAddress: anExternalAddress.
 	asts := WeakValueDictionary new.

--- a/src/Z3/Z3Fixedpoint.class.st
+++ b/src/Z3/Z3Fixedpoint.class.st
@@ -7,7 +7,7 @@ https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.648.9876&rep=rep1&type
 "
 Class {
 	#name : #Z3Fixedpoint,
-	#superclass : #Z3ContextedObject,
+	#superclass : #Z3ReferenceCountedObject,
 	#instVars : [
 		'vars'
 	],
@@ -85,7 +85,6 @@ Z3Fixedpoint >> incRef [
 { #category : #initialization }
 Z3Fixedpoint >> initializeWithAddress: anExternalAddress context: aZ3Context [
 	super initializeWithAddress: anExternalAddress context: aZ3Context.
-	Z3 fixedpoint_inc_ref: ctx _: self.
 	vars := OrderedCollection new.
 ]
 

--- a/src/Z3/Z3Fixedpoint.class.st
+++ b/src/Z3/Z3Fixedpoint.class.st
@@ -43,11 +43,6 @@ Z3Fixedpoint >> declareVar: x [
 ]
 
 { #category : #API }
-Z3Fixedpoint >> del [
-	self decRef
-]
-
-{ #category : #API }
 Z3Fixedpoint >> fact: head [ 
 	self fact: head named: nil
 ]

--- a/src/Z3/Z3Model.class.st
+++ b/src/Z3/Z3Model.class.st
@@ -85,12 +85,6 @@ Z3Model >> decls [
 ]
 
 { #category : #'as yet unclassified' }
-Z3Model >> del [
-	self release
-
-]
-
-{ #category : #'as yet unclassified' }
 Z3Model >> displayFunctionInterpretations [
 	self shouldBeImplemented 
 ]

--- a/src/Z3/Z3ReferenceCountedObject.class.st
+++ b/src/Z3/Z3ReferenceCountedObject.class.st
@@ -10,22 +10,19 @@ Z3ReferenceCountedObject >> decRef [
 
 ]
 
+{ #category : #'initialization & release' }
+Z3ReferenceCountedObject >> delete [
+	self decRef
+]
+
 { #category : #'ref-counting' }
 Z3ReferenceCountedObject >> incRef [
 	self subclassResponsibility
 
 ]
 
-{ #category : #initialization }
+{ #category : #'initialization & release' }
 Z3ReferenceCountedObject >> initializeWithAddress: anExternalAddress context: aZ3Context [
 	super initializeWithAddress: anExternalAddress context: aZ3Context.
 	self incRef.
-
-]
-
-{ #category : #initialization }
-Z3ReferenceCountedObject >> release [
-	self decRef.
-	super release
-
 ]

--- a/src/Z3/Z3Solver.class.st
+++ b/src/Z3/Z3Solver.class.st
@@ -14,7 +14,7 @@ Z3Solver class >> isValid: thm [
 	| solver answer |
 	solver := self new.
 	answer := solver isValid: thm.
-	solver del.
+	solver release.
 	^answer
 ]
 

--- a/src/Z3/Z3Solver.class.st
+++ b/src/Z3/Z3Solver.class.st
@@ -131,12 +131,6 @@ Z3Solver >> decRef [
 
 ]
 
-{ #category : #asserting }
-Z3Solver >> del [
-	self release.
-
-]
-
 { #category : #printing }
 Z3Solver >> dimacs [
 	"Answer a textual representation of the receiver in DIMACS format."

--- a/src/Z3/Z3Symbol.class.st
+++ b/src/Z3/Z3Symbol.class.st
@@ -118,6 +118,17 @@ Z3Symbol >> printOn: aStream [
 		ifFalse: [ self getInt printOn: aStream ]
 ]
 
+{ #category : #'initialization & release' }
+Z3Symbol >> release [
+	"The lifecycle of Z3 symbols seems to be bound to its context -
+	 there is no z3_del_symbol() nor are Z3 symbols ref-counted.
+	 Therefore here we merely invalidate the Smalltalk object
+	 so it cannot be used anymore."
+
+	self poison.
+	ctx := nil.
+]
+
 { #category : #accessing }
 Z3Symbol >> s [
 	^ s


### PR DESCRIPTION
This commit tries to improve Z3 object livecycle support, in particular adds systematic
support for disposing of an object once no longer used. 

With these changes, users are supposed to call `#release` on any kind of Z3 object (except on ASTs) once
the object is no longer needed. For "contexted" objects, that is, for objects whose life is bound to their
context, it is user responsiblity to call `#release` first on dependent object and then on the context. 

For reference-counted objects (solvers, models, ...) uses should not call `incRef` and `decRef` manually, 
reference counts are automatically increased when object is instantiated in Smalltalk and decremented when `#release`d.