### PR TITLE
Use `g∘f` for "g after f" and `f⋅g` for "f before g"

### DIFF
--- a/src/CardanoTartaglia-Tests/FormulaCoercionTest.class.st
+++ b/src/CardanoTartaglia-Tests/FormulaCoercionTest.class.st
@@ -11,7 +11,7 @@ FormulaCoercionTest >> fx [
 	| f x |
 	f := Cosa named: 'f'.
 	x := DummyArg named: 'x'.
-	^f value: x "or x∘f also works"
+	^f value: x "or x⋅f also works"
 	
 ]
 

--- a/src/MathNotation-Pharo/RBScanner.extension.st
+++ b/src/MathNotation-Pharo/RBScanner.extension.st
@@ -69,6 +69,9 @@ RBScanner >> isUnicodeMathOperator: aCharacter [
 		16rD7  " × "
 		16rF7  " ÷ "
 		
+		"From General Punctuation block"
+		16r2022" • "
+
 		"From 'Arrows' block"
 		16r21F4" ⇴ "
 		
@@ -92,6 +95,7 @@ RBScanner >> isUnicodeMathOperator: aCharacter [
 		16r229B" ⊛ "
 		16r22B2" ⊲ "
 		16r22B3" ⊳ "
+		16r22C5" ⋅ "
 		
 		"From 'Supplemental Mathematical Operators' block"
 		16r2A30" ⨰ "

--- a/src/MathNotation/BlockClosure.extension.st
+++ b/src/MathNotation/BlockClosure.extension.st
@@ -1,9 +1,9 @@
 Extension { #name : #BlockClosure }
 
 { #category : #'*MathNotation' }
-BlockClosure >> ∘ [ thenBlock
+BlockClosure >> ⋅ [ thenBlock
 	"Answer the block that is the composition of self, then thenBlock.
-	 I.e. f∘g means f, then g.
+	 I.e. f⋅g means f, then g.
 	 In other words: 'thenBlock after self'. "
 	^[ :x | thenBlock value: (self value: x) ]
 ]

--- a/src/MathNotation/Object.extension.st
+++ b/src/MathNotation/Object.extension.st
@@ -12,11 +12,9 @@ Object >> ∉ [ aCollection
 
 { #category : #'*MathNotation' }
 Object >> ∘ [ f
-	"Compose 'self before f', in the left-to-right order
-	 like in P.M.Cohn's 'Universal Algebra' and opposite 
-	 to the 'self after f' right-to-left order in most
-	 modern category-theory books."
-	^f value: self
+	"Compose 'self after f' in dextrosinistral order,
+	 following the notation in most modern category-theory books."
+	^f ⋅ self
 ]
 
 { #category : #'*MathNotation' }
@@ -27,6 +25,13 @@ Object >> ≅ [ anObject
 { #category : #'*MathNotation' }
 Object >> ⊛ [ Fa
 	^Fa collect: self
+]
+
+{ #category : #'*MathNotation' }
+Object >> ⋅ [ f
+	"Compose 'self before f' in sinistrodextral order
+	 (like in P.M.Cohn's 'Universal Algebra')."
+	^f value: self
 ]
 
 { #category : #'*MathNotation' }

--- a/src/Refinements/Alts.class.st
+++ b/src/Refinements/Alts.class.st
@@ -19,7 +19,7 @@ Alts class >> xs: xs [
 
 { #category : #'case switching' }
 Alts >> ifFound: foundBlock alts: altsBlock [
-	^xs∘altsBlock
+	^xs⋅altsBlock
 ]
 
 { #category : #accessing }

--- a/src/Refinements/Env.class.st
+++ b/src/Refinements/Env.class.st
@@ -7,7 +7,7 @@ Class {
 
 { #category : #'as yet unclassified' }
 Env >> checkSym: x [
-	^x∘self
+	^x⋅self
 		ifFound: #instantiate
 		alts: #error
 ]

--- a/src/Refinements/Found.class.st
+++ b/src/Refinements/Found.class.st
@@ -19,7 +19,7 @@ Found class >> x: x [
 
 { #category : #'case switching' }
 Found >> ifFound: foundBlock alts: altsBlock [
-	^x∘foundBlock
+	^x⋅foundBlock
 ]
 
 { #category : #accessing }

--- a/src/Refinements/Reft.class.st
+++ b/src/Refinements/Reft.class.st
@@ -117,7 +117,7 @@ mapPredReft :: (Expr -> Expr) -> Reft -> Reft
 mapPredReft f (Reft (v, p)) = Reft (v, f p)
 cf. Refinements.hs
 "
-	^Reft symbol: symbol expr: expr∘f
+	^Reft symbol: symbol expr: expr⋅f
 ]
 
 { #category : #Semigroup }

--- a/src/Refinements/ShallowRefinement.class.st
+++ b/src/Refinements/ShallowRefinement.class.st
@@ -62,7 +62,7 @@ ShallowRefinement >> includes: x [
 	 We can't really do much here meaningfully,
 	 because many things can reasonably cast to many other things.
 	 For example, 'a' casts to the integer symbolic constant a."
-	^x∘e
+	^x⋅e
 ]
 
 { #category : #accessing }

--- a/src/SpriteLang-Tests/BoolGaloisConnectionTest.class.st
+++ b/src/SpriteLang-Tests/BoolGaloisConnectionTest.class.st
@@ -16,8 +16,8 @@ In this case we have a pair of functions, b2i and i2b:
 
 These are inverses of each other:
 
-  i2b ∘ b2i = Id(𝔹)
-  b2i ∘ i2b = Id({0,1})
+  i2b ⋅ b2i = Id(𝔹)
+  b2i ⋅ i2b = Id({0,1})
 
 In Kernighan and Ritchie's ""C"" language, booleans are represented in an
 almost, but not quite the same way:
@@ -43,11 +43,11 @@ construct b2i and i2b similar to above:
 
 These are no longer inverse: although
 
-  i2b ∘ b2i = Id(𝔹),
+  i2b ⋅ b2i = Id(𝔹),
 
 it breaks in the other direction:
 
-  b2i ∘ i2b ≠ Id(ℤ)
+  b2i ⋅ i2b ≠ Id(ℤ)
 
 because i2b is not injective: it ""loses information"" by ""squishing"" all
 nonzero ints together into one point:

--- a/src/SpriteLang-Tests/L5NegTest.class.st
+++ b/src/SpriteLang-Tests/L5NegTest.class.st
@@ -16,8 +16,8 @@ L5NegTest >> test_SplitToOr00 [
 ⟦measure encoding: instruction => int⟧
 
 type instruction =
-  | A => [v| v∘encoding === 0 ]
-  | B => [v| v∘encoding === 1 ]
+  | A => [v| v⋅encoding === 0 ]
+  | B => [v| v⋅encoding === 1 ]
   ;
 
 ⟦val cassert : bool[b|b] => int⟧
@@ -56,11 +56,11 @@ L5NegTest >> test_SplitToOr01 [
 ⟦measure encoding : instruction => int⟧
 
 type instruction =
-  | A => [v| v∘encoding === 0 ]
-  | B => [v| v∘encoding === 1 ]
+  | A => [v| v⋅encoding === 0 ]
+  | B => [v| v⋅encoding === 1 ]
   ;
 
-⟦val encode: insn:instruction=>int[v | insn∘encoding === v ]⟧
+⟦val encode: insn:instruction=>int[v | insn⋅encoding === v ]⟧
 let encode = (insn) => {
   switch (insn) {
     | A => 0
@@ -76,11 +76,11 @@ L5NegTest >> test_append00 [
 ⟦measure len : list(''a) => int⟧
 
 type list(''a) =
-  | Nil                        => [v| v∘len === 0 ]
-  | Cons (x:''a, xs:list(''a)) => [v| v∘len === (xs∘len + 1) ]
+  | Nil                        => [v| v⋅len === 0 ]
+  | Cons (x:''a, xs:list(''a)) => [v| v⋅len === (xs⋅len + 1) ]
   ;
 
-⟦val append : xs:list(''a) => ys:list(''a) => list(''a)[v| v∘len === ((xs∘len) + (ys∘len)) ]⟧
+⟦val append : xs:list(''a) => ys:list(''a) => list(''a)[v| v⋅len === ((xs⋅len) + (ys⋅len)) ]⟧
 let rec append = (xs, ys) => {
   switch (xs) {
     | Nil        => ys
@@ -96,11 +96,11 @@ L5NegTest >> test_cons00 [
 ⟦measure len : list(''a) => int⟧
 
 type list(''a) =
-  | Nil                        => [v| v∘len === 0 ]
-  | Cons (x:''a, xs:list(''a)) => [v| v∘len === (xs∘len + 1) ]
+  | Nil                        => [v| v⋅len === 0 ]
+  | Cons (x:''a, xs:list(''a)) => [v| v⋅len === (xs⋅len + 1) ]
   ;
 
-⟦val singleton : ''a => list(''a)[v| v∘len === 10 ]⟧
+⟦val singleton : ''a => list(''a)[v| v⋅len === 10 ]⟧
 let singleton = (x) => {
   let t = Nil;
   Cons(x, t)
@@ -166,11 +166,11 @@ L5NegTest >> test_nil00 [
 ⟦measure len : list(''a) => int⟧
 
 type list(''a) =
-  | Nil                        => [v| v∘len === 0 ]
-  | Cons (x:''a, xs:list(''a)) => [v| v∘len === (xs∘len + 1) ]
+  | Nil                        => [v| v⋅len === 0 ]
+  | Cons (x:''a, xs:list(''a)) => [v| v⋅len === (xs⋅len + 1) ]
   ;
 
-⟦val singleton : ''a => list(''a)[v|v∘len === 1]⟧
+⟦val singleton : ''a => list(''a)[v|v⋅len === 1]⟧
 let singleton = (x) => {
   let t = Nil;
   t

--- a/src/SpriteLang-Tests/L5PosTest.class.st
+++ b/src/SpriteLang-Tests/L5PosTest.class.st
@@ -16,8 +16,8 @@ L5PosTest >> test_SplitToOr00 [
 ⟦measure encoding: instruction => int⟧
 
 type instruction =
-  | A => [v| v ∘ encoding === 0 ]
-  | B => [v| v ∘ encoding === 1 ]
+  | A => [v| v ⋅ encoding === 0 ]
+  | B => [v| v ⋅ encoding === 1 ]
   ;
 
 ⟦val cassert : bool[b|b] => int⟧
@@ -56,11 +56,11 @@ L5PosTest >> test_SplitToOr01 [
 ⟦measure encoding : instruction => int⟧
 
 type instruction =
-  | A => [v| v ∘ encoding === 0 ]
-  | B => [v| v ∘ encoding === 1 ]
+  | A => [v| v ⋅ encoding === 0 ]
+  | B => [v| v ⋅ encoding === 1 ]
   ;
 
-⟦val encode: insn:instruction=>int[v | insn ∘ encoding === v ]⟧
+⟦val encode: insn:instruction=>int[v | insn ⋅ encoding === v ]⟧
 let encode = (insn) => {
   switch (insn) {
     | A => 0
@@ -76,11 +76,11 @@ L5PosTest >> test_append00 [
 ⟦measure len : list(''a) => int⟧
 
 type list(''a) =
-  | Nil => [v| v∘len === 0 ]
-  | Cons (x:''a, xs:list(''a)) => [v| v∘len === (xs∘len + 1) ]
+  | Nil => [v| v⋅len === 0 ]
+  | Cons (x:''a, xs:list(''a)) => [v| v⋅len === (xs⋅len + 1) ]
   ;
 
-⟦val append : xs:list(''a) => ys:list(''a) => list(''a)[v| v∘len === ((xs∘len) + (ys∘len)) ]⟧
+⟦val append : xs:list(''a) => ys:list(''a) => list(''a)[v| v⋅len === ((xs⋅len) + (ys⋅len)) ]⟧
 let rec append = (xs, ys) => {
   switch (xs) {
     | Nil        => ys
@@ -97,10 +97,10 @@ L5PosTest >> test_appendInt [
 ⟦measure len : list(''a) => int⟧
 
 type list(''a) =
-  | Nil => [v| v∘len === 0 ]
-  | Cons (x:''a, xs:list(''a)) => [v| v∘len === (xs∘len + 1) ]
+  | Nil => [v| v⋅len === 0 ]
+  | Cons (x:''a, xs:list(''a)) => [v| v⋅len === (xs⋅len + 1) ]
   ;
-⟦val append : xs:list(int) => ys:list(int) => list(int)[v| v∘len === ((xs∘len) + (ys∘len)) ]⟧
+⟦val append : xs:list(int) => ys:list(int) => list(int)[v| v⋅len === ((xs⋅len) + (ys⋅len)) ]⟧
 let rec append = (xs, ys) => {
   switch (xs) {
     | Nil        => ys
@@ -117,11 +117,11 @@ L5PosTest >> test_cons00 [
 ⟦measure len : list(''a) => int⟧
 
 type list(''a) =
-  | Nil                      => [v| v∘len === 0 ]
-  | Cons (x:''a, xs:list(''a)) => [v| v∘len === (xs∘len + 1) ]
+  | Nil                      => [v| v⋅len === 0 ]
+  | Cons (x:''a, xs:list(''a)) => [v| v⋅len === (xs⋅len + 1) ]
   ;
 
-⟦val singleton : ''a => list(''a)[v| v∘len === 1 ]⟧
+⟦val singleton : ''a => list(''a)[v| v⋅len === 1 ]⟧
 let singleton = (x) => {
   let t = Nil;
   Cons(x, t)
@@ -184,11 +184,11 @@ L5PosTest >> test_head01 [
 ⟦measure len : list(''a) => int⟧
 
 type list(''a) =
-  | Nil                        => [v| v∘len === 0 ]
-  | Cons (x:''a, xs:list(''a)) => [v| v∘len === (xs∘len + 1) ]
+  | Nil                        => [v| v⋅len === 0 ]
+  | Cons (x:''a, xs:list(''a)) => [v| v⋅len === (xs⋅len + 1) ]
   ;
 
-⟦val head : list(''a)[v|v∘len > 0] => ''a⟧
+⟦val head : list(''a)[v|v⋅len > 0] => ''a⟧
 let head = (xs) => {
   switch(xs){
     | Cons(h, t) => h
@@ -196,7 +196,7 @@ let head = (xs) => {
   }
 };
 
-⟦val singleton : ''a => list(''a)[v|v∘len === 1]⟧
+⟦val singleton : ''a => list(''a)[v|v⋅len === 1]⟧
 let singleton = (x) => {
   let t = Nil;
   Cons(x, t)
@@ -216,12 +216,12 @@ L5PosTest >> test_isort00 [
 ⟦measure len : list(''a) => int⟧
 
 type list(''a) =
-  | Nil                        => [v| v∘len === 0 ]
-  | Cons (x:''a, xs:list(''a)) => [v| v∘len === (xs∘len + 1) ]
+  | Nil                        => [v| v⋅len === 0 ]
+  | Cons (x:''a, xs:list(''a)) => [v| v⋅len === (xs⋅len + 1) ]
   ;
 
 
-⟦val insert : x:''a => ys:list(''a) => list(''a)[v| v∘len === (ys∘len + 1) ]⟧
+⟦val insert : x:''a => ys:list(''a) => list(''a)[v| v⋅len === (ys⋅len + 1) ]⟧
 let rec insert = (x, ys) => {
   switch (ys) {
     | Nil           => let t = Nil;
@@ -237,7 +237,7 @@ let rec insert = (x, ys) => {
   }
 };
 
-⟦val isort : xs:list(''a) => list(''a)[v| v∘len === (xs∘len) ]⟧
+⟦val isort : xs:list(''a) => list(''a)[v| v⋅len === (xs⋅len) ]⟧
 let rec isort = (xs) => {
   switch (xs){
     | Nil         => Nil
@@ -316,11 +316,11 @@ L5PosTest >> test_nil00 [
 ⟦measure len : list(''a) => int⟧
 
 type list(''a) =
-  | Nil                        => [v| v∘len === 0 ]
-  | Cons (x:''a, xs:list(''a)) => [v| v∘len === (xs∘len + 1) ]
+  | Nil                        => [v| v⋅len === 0 ]
+  | Cons (x:''a, xs:list(''a)) => [v| v⋅len === (xs⋅len + 1) ]
   ;
 
-⟦val singleton : ''a => list(''a)[v| v∘len === 0 ]⟧
+⟦val singleton : ''a => list(''a)[v| v⋅len === 0 ]⟧
 let singleton = (x) => {
   let t = Nil;
   t
@@ -407,11 +407,11 @@ L5PosTest >> test_tail01 [
 ⟦measure len : list(''a) => int⟧
 
 type list(''a) =
-  | Nil                        => [v| v∘len === 0 ]
-  | Cons (x:''a, xs:list(''a)) => [v| v∘len === (xs∘len + 1) ]
+  | Nil                        => [v| v⋅len === 0 ]
+  | Cons (x:''a, xs:list(''a)) => [v| v⋅len === (xs⋅len + 1) ]
   ;
 
-⟦val tail: zs:list(''a)[v|v∘len > 0] => list(''a)[v| v∘len === (zs∘len - 1) ]⟧
+⟦val tail: zs:list(''a)[v|v⋅len > 0] => list(''a)[v| v⋅len === (zs⋅len - 1) ]⟧
 let tail = (zs) => {
   switch(zs){
     | Cons(h, t) => t


### PR DESCRIPTION
Both Leandro and Luciano (and myself) are in consensus that going against the grain with `#∘` causes too much unwarranted confusion.