### PR TITLE
Generalize Symbol evaluation to aid origami programming

### DIFF
--- a/src/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
+++ b/src/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
@@ -10,6 +10,7 @@ BaselineOfMachineArithmetic >> baseline: spec [
 	spec
 		for: #common
 		do: [
+			spec postLoadDoIt: #'postLoad'.
 			spec baseline: 'PetitParser' with: [
 				spec loads: 'Core'.
 				spec loads: 'Analyzer'.
@@ -123,4 +124,9 @@ BaselineOfMachineArithmetic >> baseline: spec [
 				[ spec requires: 'DepthFirstSearch' ].
 		].
 
+]
+
+{ #category : #baselines }
+BaselineOfMachineArithmetic >> postLoad [
+	( Symbol >> #value: ) removeFromSystem
 ]

--- a/src/PreSmalltalks-Pharo/Object.extension.st
+++ b/src/PreSmalltalks-Pharo/Object.extension.st
@@ -67,3 +67,23 @@ Object >> primPerform: selector withArguments: argArray inSuperclass: lookupClas
 		ifFalse: [ ^ self error: 'Undefined behavior on wrong arity' ].	
 	self primitiveFailed
 ]
+
+{ #category : #'*PreSmalltalks-Pharo' }
+Object >> value: arg [
+	^self valueWithArguments: { arg }
+]
+
+{ #category : #'*PreSmalltalks-Pharo' }
+Object >> value: arg1 value: arg2 [
+	^self valueWithArguments: { arg1. arg2 }
+]
+
+{ #category : #'*PreSmalltalks-Pharo' }
+Object >> value: arg1 value: arg2 value: arg3 [
+	^self valueWithArguments: { arg1. arg2. arg3 }
+]
+
+{ #category : #'*PreSmalltalks-Pharo' }
+Object >> value: arg1 value: arg2 value: arg3 value: arg4 [
+	^self valueWithArguments: { arg1. arg2. arg3. arg4 }
+]

--- a/src/PreSmalltalks-Pharo/Symbol.extension.st
+++ b/src/PreSmalltalks-Pharo/Symbol.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #Symbol }
+
+{ #category : #'*PreSmalltalks-Pharo' }
+Symbol >> valueWithArguments: args [
+	args isEmpty ifTrue: [
+		"If there is no object to serve as the receiver,
+		 then this is like Object>>value, i.e. Lawvere's
+		 'generalized element' (terminal stage of definition)."
+		^self
+	].
+	^args first perform: self withArguments: args allButFirst
+]

--- a/src/PreSmalltalks-Tests/FoldlIsInjectTest.class.st
+++ b/src/PreSmalltalks-Tests/FoldlIsInjectTest.class.st
@@ -38,3 +38,17 @@ FoldlIsInjectTest >> test4 [
 FoldlIsInjectTest >> test5 [
 	self assert: ({1 . 2 . 3} inject: 4 into: [ :x :y | 2*x + y ]) equals: 43
 ]
+
+{ #category : #tests }
+FoldlIsInjectTest >> testFactorial0 [
+	self
+		assert: 0 factorialHylomorphically
+		equals: 1
+]
+
+{ #category : #tests }
+FoldlIsInjectTest >> testFactorial5 [
+	self
+		assert: 5 factorialHylomorphically
+		equals: 120
+]

--- a/src/PreSmalltalks-Tests/Integer.extension.st
+++ b/src/PreSmalltalks-Tests/Integer.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #Integer }
+
+{ #category : #'*PreSmalltalks-Tests' }
+Integer >> factorialHylomorphically [
+	self < 0 ifTrue: [self error: 'Not valid for negative integers'].
+	^(1 to: self) "anamorphism: unfold scalar to an inductive datatype"
+		inject: 1 into: #* "catamorphism: fold inductive datatype to scalar"
+]

--- a/src/Refinements/EVar.class.st
+++ b/src/Refinements/EVar.class.st
@@ -193,26 +193,6 @@ EVar >> uniq1: α [
 ]
 
 { #category : #'function application' }
-EVar >> value: arg1 [
-	^self valueWithArguments: {arg1}
-]
-
-{ #category : #'function application' }
-EVar >> value: arg1 value: arg2 [
-	^self valueWithArguments: {arg1.arg2}
-]
-
-{ #category : #'function application' }
-EVar >> value: arg1 value: arg2 value: arg3 [
-	^self valueWithArguments: {arg1.arg2.arg3}
-]
-
-{ #category : #'function application' }
-EVar >> value: arg1 value: arg2 value: arg3 value: arg4 [
-	^self valueWithArguments: {arg1.arg2.arg3.arg4}
-]
-
-{ #category : #'function application' }
 EVar >> valueWithArguments: args [
 	^args inject: self into: [ :acc :thisArg | EApp expr: acc imm: thisArg ]
 ]

--- a/src/Refinements/HVar.class.st
+++ b/src/Refinements/HVar.class.st
@@ -121,26 +121,6 @@ HVar >> value [
 ]
 
 { #category : #'function application' }
-HVar >> value: arg [
-	^self valueWithArguments: {arg}
-]
-
-{ #category : #'function application' }
-HVar >> value: arg1 value: arg2 [
-	^self valueWithArguments: {arg1. arg2}
-]
-
-{ #category : #'function application' }
-HVar >> value: arg1 value: arg2 value: arg3 [
-	^self valueWithArguments: {arg1. arg2. arg3}
-]
-
-{ #category : #'function application' }
-HVar >> value: arg1 value: arg2 value: arg3 value: arg4 [
-	^self valueWithArguments: {arg1. arg2. arg3. arg4}
-]
-
-{ #category : #'function application' }
 HVar >> valueWithArguments: args [
 	"Create a Smalltalk-side representation of the receiver
 	 to args, without creating an actual Z3 APP_AST node.

--- a/src/Refinements/NaturalTransformation.class.st
+++ b/src/Refinements/NaturalTransformation.class.st
@@ -117,26 +117,6 @@ NaturalTransformation >> printOn: aStream [
 ]
 
 { #category : #evaluating }
-NaturalTransformation >> value: arg1 [
-	^self valueWithArguments: {arg1}
-]
-
-{ #category : #evaluating }
-NaturalTransformation >> value: arg1 value: arg2 [
-	^self valueWithArguments: {arg1.arg2}
-]
-
-{ #category : #evaluating }
-NaturalTransformation >> value: arg1 value: arg2 value: arg3 [
-	^self valueWithArguments: {arg1.arg2.arg3}
-]
-
-{ #category : #evaluating }
-NaturalTransformation >> value: arg1 value: arg2 value: arg3 value: arg4 [
-	^self valueWithArguments: {arg1.arg2.arg3.arg4}
-]
-
-{ #category : #evaluating }
 NaturalTransformation >> valueWithArguments: args [
 	| D thisComponent C f |
 	D := args collect: #sort.


### PR DESCRIPTION
This PR improves auto-currying of `#perform:` so that BMF-like transformations can be written in a reasonably concise notation.  In particular, we are now able to use higher-arity selectors as arguments to `#collect:`, `#inject:into:` etc.

See pp. 41 et seq in:
Jeremy Gibbons, Oege de Moor.  The Fun of Programming.  (Palgrave Macmillan, 2003).

