### PR TITLE
[PreSmalltalks] Introduce `TypingJudgement`

### DIFF
--- a/src/MathNotation-Pharo/RBScanner.extension.st
+++ b/src/MathNotation-Pharo/RBScanner.extension.st
@@ -17,6 +17,14 @@ RBScanner >> classify: aCharacter [
 ]
 
 { #category : #'*MathNotation-Pharo' }
+RBScanner >> initializeClassificationTable [
+	"Initializer for case we need RBScanner only to classify
+	 characters. In that case, there's no need to initialize
+	 other variables as in #on:"
+	classificationTable := self class classificationTable.
+]
+
+{ #category : #'*MathNotation-Pharo' }
 RBScanner >> isBinary [
 	characterType = #binary
 		ifTrue: [ [ characterType = #binary ] whileTrue: [ self step ].
@@ -81,6 +89,7 @@ RBScanner >> isUnicodeMathOperator: aCharacter [
 		16r2218" ∘ "
 		16r2229" ∩ "
 		16r222A" ∪ "
+		16r2237" ∷ "
 		16r2243" ≃ "
 		16r2245" ≅ "
 		16r225B" ≛ "
@@ -99,7 +108,7 @@ RBScanner >> isUnicodeMathOperator: aCharacter [
 		
 		"From 'Supplemental Mathematical Operators' block"
 		16r2A30" ⨰ "
-		
+
 	)	includes: aCharacter asInteger
 ]
 

--- a/src/MathNotation/Object.extension.st
+++ b/src/MathNotation/Object.extension.st
@@ -18,6 +18,19 @@ Object >> ∘ [ f
 ]
 
 { #category : #'*MathNotation' }
+Object >> ∷ [ type
+	^TypingJudgement term: self hasType: type
+
+	"
+	| a |
+
+	a := 1.
+	a ∷ Int
+	"
+
+]
+
+{ #category : #'*MathNotation' }
 Object >> ≅ [ anObject
 	^self = anObject
 ]

--- a/src/MathNotation/TypingJudgement.extension.st
+++ b/src/MathNotation/TypingJudgement.extension.st
@@ -1,0 +1,41 @@
+Extension { #name : #TypingJudgement }
+
+{ #category : #'*MathNotation' }
+TypingJudgement >> isSelfEvaluating [
+	^term isSelfEvaluating and:[type isSelfEvaluating]
+]
+
+{ #category : #'*MathNotation' }
+TypingJudgement >> printOn: aStream [
+	self storeOn: aStream
+]
+
+{ #category : #'*MathNotation' }
+TypingJudgement >> storeOn: aStream [
+	| scanner termString typeString |
+
+	"Try to put parenthesis around term and type
+	 when needed.
+	"
+	scanner := RBScanner new initializeClassificationTable.
+
+	termString := term printString.
+	(termString anySatisfy:[:char | | charCls | (charCls := scanner classify: char) ~~ #alphabetic and:[ charCls ~~ #digit ]]) ifTrue:[
+		aStream nextPut:$(.
+		term printOn: aStream.
+		aStream nextPut:$).
+	] ifFalse:[
+		term printOn: aStream
+	].
+
+	aStream nextPutAll: ' ∷ '.
+
+	typeString := type printString.
+	(typeString anySatisfy:[:char | | charCls | (charCls := scanner classify: char) ~~ #alphabetic and:[ charCls ~~ #digit ]]) ifTrue:[
+		aStream nextPut:$(.
+		type printOn: aStream.
+		aStream nextPut:$).
+	] ifFalse:[
+		type printOn: aStream
+	].
+]

--- a/src/PreSmalltalks/TypingJudgement.class.st
+++ b/src/PreSmalltalks/TypingJudgement.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : #TypingJudgement,
+	#superclass : #Object,
+	#instVars : [
+		'term',
+		'type'
+	],
+	#category : #PreSmalltalks
+}
+
+{ #category : #'instance creation' }
+TypingJudgement class >> term: term hasType: type [
+	^self new term: term type: type
+]
+
+{ #category : #accessing }
+TypingJudgement >> term [
+	^ term
+]
+
+{ #category : #initialization }
+TypingJudgement >> term: termArg type: typeArg [
+	term := termArg.
+	type := typeArg.
+
+]
+
+{ #category : #accessing }
+TypingJudgement >> type [
+	^ type
+]


### PR DESCRIPTION
This commit introduces a `TypingJudgement` (for now) a simple object holding a term and its type. It also introduces a "math notation" to create typing judgements:

    obj ∷ type