### PR TITLE
Allow to notate `TypedSlot` using `term ∷ type` notation

### DIFF
--- a/src/Collections-Homogeneous/TypingJudgement.extension.st
+++ b/src/Collections-Homogeneous/TypingJudgement.extension.st
@@ -1,0 +1,10 @@
+Extension { #name : #TypingJudgement }
+
+{ #category : #'*Collections-Homogeneous' }
+TypingJudgement >> asSlot [
+	term isString ifFalse:[
+		self error:'term must be a string or symbol'.
+		^nil.
+	].
+	^TypedSlot named: term asSymbol type: type
+]

--- a/src/MathNotation/TypedSlot.extension.st
+++ b/src/MathNotation/TypedSlot.extension.st
@@ -1,0 +1,25 @@
+Extension { #name : #TypedSlot }
+
+{ #category : #'*MathNotation' }
+TypedSlot >> definitionString [
+	| scanner typeString |
+
+	"Try to put parenthesis around term and type
+	 when needed.
+	"
+	scanner := RBScanner new initializeClassificationTable.
+
+	^String streamContents: [ :aStream|
+		name storeOn: aStream.
+		aStream nextPutAll: ' ∷ '.
+
+		typeString := type printString.
+		(typeString anySatisfy:[:char | | charCls | (charCls := scanner classify: char) ~~ #alphabetic and:[ charCls ~~ #digit ]]) ifTrue:[
+			aStream nextPut:$(.
+			type printOn: aStream.
+			aStream nextPut:$).
+		] ifFalse:[
+			type printOn: aStream
+		].
+	]
+]


### PR DESCRIPTION
This together with `TypingJudgement >> asSlot` allows to use `term ∷ type` notation when defining typed instance variables and elements of future class `Record`.