### PR TITLE
[Products] Introduce `Record` and `Cotuple`

### DIFF
--- a/src/Collections-Homogeneous-Tests/RecordTest.class.st
+++ b/src/Collections-Homogeneous-Tests/RecordTest.class.st
@@ -1,0 +1,47 @@
+Class {
+	#name : #RecordTest,
+	#superclass : #TestCase,
+	#category : #'Collections-Homogeneous-Tests'
+}
+
+{ #category : #tests }
+RecordTest >> testAccessingElements [
+	| R r |
+
+	R := Record ofAll: { #x ∷ Integer . #y ∷ Integer }.
+	r := R basicNew.
+
+	self assert: (r at: #x) isNil.
+	self assert: (r at: #y) isNil.
+
+	self should: [ r at: #foo ] raise: KeyNotFound.
+	self should: [ r at: self ] raise: KeyNotFound.
+	self should: [ r at: 1 ] raise: KeyNotFound.
+
+	r at:#x put: 10.
+	r at:#y put: 20.
+
+	self assert: (r at: #x) equals: 10.
+	self assert: (r at: #y) equals: 20.
+
+	self should: [ r at: #foo put: true ] raise: KeyNotFound.
+	self should: [ r at: self put: false] raise: KeyNotFound.
+]
+
+{ #category : #tests }
+RecordTest >> testSubclassing [
+	| R |
+	
+	R := Record empty.
+	self assert: R slots size equals: 0.
+	self should: [ R new ] raise: ShouldNotImplement.
+	self assert: R basicNew class equals: R.
+	
+	R := Record ofAll: { #x ∷ Integer. #y ∷ String }.
+	self assert: R slots size equals: 2.
+	self should: [ R new ] raise: ShouldNotImplement.
+	self assert: R basicNew class equals: R.
+
+	
+
+]

--- a/src/Collections-Homogeneous-Tests/TupleTest.class.st
+++ b/src/Collections-Homogeneous-Tests/TupleTest.class.st
@@ -5,14 +5,37 @@ Class {
 }
 
 { #category : #tests }
+TupleTest >> testAccessingElements [
+	| P p |
+	P := Tuple ofAll: { Integer . Integer }.
+	p := P basicNew.
+
+	self assert: (p at: 1) isNil.
+	self assert: (p at: 2) isNil.
+
+	self should: [ p at: 0 ] raise: SubscriptOutOfBounds.
+	self should: [ p at: 3 ] raise: SubscriptOutOfBounds.
+	self should: [ p at: #xuz ] raise: Error.
+
+	p at: 1 put: 10.
+
+	self assert: (p at: 1) = 10.
+
+	self should: [ p at: 0 put: 0] raise: SubscriptOutOfBounds.
+	self should: [ p at:10 put: 0] raise: SubscriptOutOfBounds.
+]
+
+{ #category : #tests }
 TupleTest >> testSubclassing [
 	| T |
 	
 	T := Tuple empty.
 	self assert: T slots size equals: 0.
+	self should: [ T new ] raise: ShouldNotImplement.
+	self assert: T basicNew class equals: T.
 	
 	T := Tuple ofAll: { Integer. String }.
 	self assert: T slots size equals: 2.
-	
-
+	self should: [ T new ] raise: ShouldNotImplement.
+	self assert: T basicNew class equals: T.
 ]

--- a/src/Collections-Homogeneous/Cotuple.class.st
+++ b/src/Collections-Homogeneous/Cotuple.class.st
@@ -1,0 +1,50 @@
+Class {
+	#name : #Cotuple,
+	#superclass : #Object,
+	#instVars : [
+		'name',
+		'injections'
+	],
+	#category : #'Collections-Homogeneous'
+}
+
+{ #category : #'instance creation' }
+Cotuple class >> named: aName [
+	^self basicNew
+		name: aName;
+		yourself
+]
+
+{ #category : #testing }
+Cotuple >> includes: e [
+	^injections anySatisfy: [ :inj | e isKindOf: inj ]
+]
+
+{ #category : #accessing }
+Cotuple >> injections [
+	^ injections
+]
+
+{ #category : #accessing }
+Cotuple >> injections: anObject [
+	injections := anObject
+]
+
+{ #category : #accessing }
+Cotuple >> name [
+	^ name
+]
+
+{ #category : #accessing }
+Cotuple >> name: anObject [
+	name := anObject
+]
+
+{ #category : #printing }
+Cotuple >> printOn: aStream [
+	aStream nextPutAll: self name.
+	aStream nextPutAll: ' = '.
+	self injections isNil   ifTrue: [ ^aStream nextPut: (Character codePoint: 16r22A5) ].
+	self injections isEmpty ifTrue: [ ^aStream nextPut: (Character codePoint: 16r22A5) ].
+	self injections do: [ :each | each printOn: aStream ] separatedBy: [ aStream nextPutAll: ' | ' ]
+]

--- a/src/Collections-Homogeneous/Record.class.st
+++ b/src/Collections-Homogeneous/Record.class.st
@@ -1,0 +1,83 @@
+Class {
+	#name : #Record,
+	#superclass : #Object,
+	#type : #variable,
+	#category : #'Collections-Homogeneous'
+}
+
+{ #category : #'subclass creation' }
+Record class >> empty [
+	^self ofAll: #()
+]
+
+{ #category : #'instance creation' }
+Record class >> new [
+	"Prohibited. To create an instance of record class to
+	 hold data, use #basicNew. See [1] for explanation.
+
+	[1]: https://github.com/shingarov/MachineArithmetic/pull/188#pullrequestreview-1872166687
+	"
+	self shouldNotImplement.
+]
+
+{ #category : #'subclass creation' }
+Record class >> ofAll: typings [
+	| recordName recordSlots recordClass |
+	
+	recordSlots := typings collect: #asSlot as:Array.
+	recordName := String streamContents:[:s |
+		s nextPutAll: 'Record ofAll: {'.
+		recordSlots do:[:slot | s nextPutAll: slot definitionString ] separatedBy:[s nextPut:$.;space].
+		s nextPut: $}.
+	].
+	[
+	recordClass := self classBuilder
+								name: recordName;								
+								superclass: self;
+								slots: recordSlots;
+								build.
+	] on: InvalidGlobalName do:[:ex|
+		ex resumeUnchecked: nil.
+	].
+	^recordClass
+	
+	"
+	Record ofAll:{ #x ∷ Integer . #y ∷ Integer }
+	"
+	
+]
+
+{ #category : #accessing }
+Record >> at: name [
+	"Return named element of this record."
+
+	| slots |
+
+	slots := self class slots select:#isTypedSlot.
+	slots do:[:slot |
+		slot name = name ifTrue:[
+			^self instVarAt: slot index
+		]
+	].
+	KeyNotFound signalFor: name in: self
+]
+
+{ #category : #accessing }
+Record >> at: name put: value [
+	"Set named element of this record to `value`"
+
+	| slots |
+
+	slots := self class slots select:#isTypedSlot.
+	slots do:[:slot |
+		slot name = name ifTrue:[
+			^self instVarAt: slot index	put: value
+		]
+	].
+	KeyNotFound signalFor: name in: self
+]
+
+{ #category : #testing }
+Record >> isTyped [
+	^true
+]

--- a/src/Collections-Homogeneous/Slot.extension.st
+++ b/src/Collections-Homogeneous/Slot.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Slot }
+
+{ #category : #'*Collections-Homogeneous' }
+Slot >> isTypedSlot [
+	^false
+]

--- a/src/Collections-Homogeneous/Tuple.class.st
+++ b/src/Collections-Homogeneous/Tuple.class.st
@@ -28,19 +28,29 @@ Tuple class >> neoJsonMapping: mapper [
 
 { #category : #'instance creation' }
 Tuple class >> new [
-	"Use #ofAll: or #empty."
-	self shouldNotImplement
+	"Prohibited. To create an instance of tuple class to
+	 hold data, use #basicNew. See [1] for explanation.
+
+	[1]: https://github.com/shingarov/MachineArithmetic/pull/188#pullrequestreview-1872166687
+	"
+	self shouldNotImplement.
 ]
 
 { #category : #'subclass creation' }
 Tuple class >> ofAll: types [
-	| tupleName tupleSlots tupleClass |
-
+	| tupleName |
 	tupleName := 'TypedTuple ofAll: ' , types asArray storeString.
+	^self ofAll: types named: tupleName
+]
+
+{ #category : #'subclass creation' }
+Tuple class >> ofAll: types named: aName [
+	| tupleSlots tupleClass |
+
 	tupleSlots := types withIndexCollect: [:type :index | TypedSlot named: index printString type: type ].
 	[
 	tupleClass := self classBuilder
-								name: tupleName;								
+								name: aName;								
 								superclass: self;
 								slots: tupleSlots;
 								build.
@@ -60,7 +70,75 @@ Tuple class >> slotAssociations [
 	^self slots collect: [ :eachSlot | eachSlot name -> eachSlot type ]
 ]
 
+{ #category : #accessing }
+Tuple class >> value [
+	^self valueWithArguments: { }
+]
+
+{ #category : #accessing }
+Tuple class >> value: arg1 [
+	^self valueWithArguments: { arg1 }
+]
+
+{ #category : #accessing }
+Tuple class >> valueWithArguments: args [
+	| inst |
+	inst := self basicNew.
+	args doWithIndex: [ :arg :j | inst at: j put: arg ].
+	^inst
+]
+
+{ #category : #accessing }
+Tuple >> at: index [
+	"Return index-th element of this tuple"
+	| slots |
+
+	index isInteger ifFalse:[
+		self errorNonIntegerIndex.
+		^nil.
+	].
+
+	slots := self class slots select:#isTypedSlot.
+
+	(index between: 1 and: slots size) ifFalse:[
+		self errorSubscriptBounds: index
+	].
+
+	^self instVarAt: (slots at: index) index.
+
+]
+
+{ #category : #accessing }
+Tuple >> at: index put: value [
+	"Set index-th element of this tuple to value"
+	| slots |
+
+	index isInteger ifFalse:[
+		self errorNonIntegerIndex.
+		^nil.
+	].
+
+	slots := self class slots select:#isTypedSlot.
+
+	(index between: 1 and: slots size) ifFalse:[
+		self errorSubscriptBounds: index
+	].
+
+	^self instVarAt: (slots at: index) index put: value
+
+]
+
+{ #category : #accessing }
+Tuple >> first [
+	^self at: 1
+]
+
 { #category : #testing }
 Tuple >> isTyped [
 	^true
+]
+
+{ #category : #accessing }
+Tuple >> second [
+	^self at: 2
 ]

--- a/src/Collections-Homogeneous/TypedSlot.class.st
+++ b/src/Collections-Homogeneous/TypedSlot.class.st
@@ -30,6 +30,11 @@ TypedSlot >> initialize: anObject [
 	self write: type new to: anObject
 ]
 
+{ #category : #testing }
+TypedSlot >> isTypedSlot [
+	^true
+]
+
 { #category : #printing }
 TypedSlot >> printOn: aStream [
 	"Every subclass that adds state must redefine either this method or #definitionString"


### PR DESCRIPTION
`Record`s have typed elements but unlike `Tuple`s elements are named.

`Tuple` elements are accessed by index whereas `Record` elements are accessed by name.