### PR TITLE
Move `PPParser`'s utility extensions to class side

### DIFF
--- a/src/PreSmalltalks-Parser/PPParser.extension.st
+++ b/src/PreSmalltalks-Parser/PPParser.extension.st
@@ -31,7 +31,7 @@ PPParser >> commaSeparated [
 ]
 
 { #category : #'*PreSmalltalks-Parser' }
-PPParser >> nonBracket [
+PPParser class >> nonBracket [
 	^(PPPredicateObjectParser
 		on: (PPCharSetPredicate on: [ :ch | ch ~~ $[ and: ch ~~ $] ])
 		message: 'Nonparenthesis expected')
@@ -39,7 +39,7 @@ PPParser >> nonBracket [
 ]
 
 { #category : #'*PreSmalltalks-Parser' }
-PPParser >> nonParen [
+PPParser class >> nonParen [
 	^(PPPredicateObjectParser
 		on: (PPCharSetPredicate on: [ :ch | ch ~~ $( and: ch ~~ $) ])
 		message: 'Nonparenthesis expected')

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -21,7 +21,6 @@ Class {
 		'kappa',
 		'predAnd',
 		'decidablePred',
-		'nonParen',
 		'matchedParen',
 		'cstrPred',
 		'funcSort',
@@ -178,7 +177,7 @@ NNFParser >> kappaApp [
 
 { #category : #'grammar - util' }
 NNFParser >> matchedParen [
-	^(nonParen / matchedParen parens) plus flatten
+	^(PPParser nonParen / matchedParen parens) plus flatten
 ]
 
 { #category : #grammar }

--- a/src/SpriteLang/RefinementParser.class.st
+++ b/src/SpriteLang/RefinementParser.class.st
@@ -38,7 +38,7 @@ RefinementParser >> aRefArg [
 
 { #category : #grammar }
 RefinementParser >> aRefBody [
-	^ self nonBracket plus flatten brackets
+	^ PPParser nonBracket plus flatten brackets
 	==> [ :x | DecidableRefinement text: x ]
 ]
 
@@ -77,7 +77,7 @@ RefinementParser >> identifier [
 
 { #category : #grammar }
 RefinementParser >> matchedParen [
-	^(self nonParen / matchedParen parens) plus flatten
+	^(PPParser nonParen / matchedParen parens) plus flatten
 ]
 
 { #category : #grammar }
@@ -95,7 +95,7 @@ RefinementParser >> myExprP [
 	 Actually it's even worse, trying to pull-in generic 'expr' results in major
 	 mess.
 "
-	^ self nonBracket plus flatten brackets
+	^ PPParser nonBracket plus flatten brackets
 	==> [ :x | DecidableRefinement text: '(', x, ')' ]
 ]
 


### PR DESCRIPTION
Here we call "utility" those methods that do not reference self.