### PR TITLE
[PreSmalltalks] Move Git directory discovery best practice to MA

### DIFF
--- a/src/PreSmalltalks-Pharo/Class.extension.st
+++ b/src/PreSmalltalks-Pharo/Class.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Class }
+
+{ #category : #'*PreSmalltalks-Pharo' }
+Class >> definingGitDirectory [
+	^IceRepository gitDirectoryDefiningClass: self
+]

--- a/src/PreSmalltalks-Pharo/IceRepository.extension.st
+++ b/src/PreSmalltalks-Pharo/IceRepository.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #IceRepository }
+
+{ #category : #'*PreSmalltalks-Pharo' }
+IceRepository class >> gitDirectoryDefiningClass: aClass [
+	| packageName definingRepo |
+	packageName := aClass package name.
+	definingRepo := self registry
+		detect:[ :each | each loadedPackages contains: [ :icep | icep name = packageName ] ]
+		ifNone:[ NotFound signalFor: aClass ].
+	^definingRepo location "which is a FileReference"
+]

--- a/src/PreSmalltalks-Tests/VersionControlTest.class.st
+++ b/src/PreSmalltalks-Tests/VersionControlTest.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #VersionControlTest,
+	#superclass : #TestCase,
+	#category : #'PreSmalltalks-Tests'
+}
+
+{ #category : #tests }
+VersionControlTest >> testRepoDirectory [
+	| aFileReference |
+	aFileReference := VersionControlTest definingGitDirectory.
+	self assert: aFileReference isDirectory.
+	self assert: aFileReference exists.
+]


### PR DESCRIPTION
AcProcessorDescriptions>>baseDirectoryGuess in Pharo-ArchC establishes a best-practice pattern for how to locate resources (such as a PDL model) relative to Git repo.
This commit pulls the Pharo half of that pattern to PreSmalltalks, so that downstream projects don't have to engage in silly guesses how it should be done.