### PR TITLE
Implement any-length BitVectors

### DIFF
--- a/src/SpriteLang-Tests/L4PosTest.class.st
+++ b/src/SpriteLang-Tests/L4PosTest.class.st
@@ -107,3 +107,23 @@ let check1 = (y) => {
 };
 '
 ]
+
+{ #category : #'tests-safety' }
+L4PosTest >> test_idPoly [
+	self processString: '
+⟦val id : ''a => ''a⟧
+let id = (x) => { x };
+
+⟦val check1 : x:int => int⟧
+let check1 = (y) => {
+  let res  = id(y);
+  res
+};
+
+⟦val check2 : bool => bool⟧
+let check2 = (y) => {
+  let res  = id(y);
+  res
+};
+'
+]

--- a/src/SpriteLang-Tests/L5PosTest.class.st
+++ b/src/SpriteLang-Tests/L5PosTest.class.st
@@ -311,6 +311,21 @@ let rec app = (xs, ys) => {
 ]
 
 { #category : #'tests-safety' }
+L5PosTest >> test_nested [
+	self processString: '
+⟦val fourtyTwo : int⟧
+let fourtyTwo = 42;
+
+⟦val main : int => int⟧
+let main = (x) => {
+  ⟦val a : int⟧
+  let a = 42;
+  a
+};
+'
+]
+
+{ #category : #'tests-safety' }
 L5PosTest >> test_nil00 [
 	self processString: '
 ⟦measure len : list(''a) => int⟧
@@ -398,6 +413,23 @@ let rec mkOList = (lo, hi) => {
     ONil
   }
 };
+'
+]
+
+{ #category : #'tests-simple' }
+L5PosTest >> test_polyId [
+	self processString: '
+⟦val id : ''a => ''a⟧
+let id = (x) => { x };
+
+⟦val idd : ''b => ''b⟧
+let idd = (x) => { id(x) };
+
+⟦val mainZ : int => int⟧
+let mainZ = (x) => { idd(x) };
+
+⟦val mainB : bool => bool⟧
+let mainB = (x) => { idd(x) };
 '
 ]
 

--- a/src/SpriteLang-Tests/TBitVectorTest.class.st
+++ b/src/SpriteLang-Tests/TBitVectorTest.class.st
@@ -133,6 +133,75 @@ TBitVectorTest >> test_09p [
 ]
 
 { #category : #tests }
+TBitVectorTest >> test_10n [
+	self proveUnsafe: '
+		    ⟦val xminusx : bv8 => bv8[v|v===0] ⟧
+		    let xminusx = (x) => {
+					bvadd8(x,x)
+			  };
+		'
+]
+
+{ #category : #tests }
+TBitVectorTest >> test_10p [
+	self proveSafe: '
+		    ⟦val xminusx : bv8 => bv8[v|v===0] ⟧
+		    let xminusx = (x) => {
+					bvsub8(x,x)
+			  };
+		'
+]
+
+{ #category : #tests }
+TBitVectorTest >> test_11p [
+	self proveSafe: '
+		    ⟦reflect xminusx : bv8 => bv8⟧
+		    let xminusx = (x) => {
+					bvsub8(x,x)
+			  };
+			
+		    ⟦val main : bv8 => bv8[v|v===0]⟧
+		    let main = (x) => {
+					xminusx(x)
+			  };
+			
+			
+		'
+]
+
+{ #category : #tests }
+TBitVectorTest >> test_ID [
+	self proveSafe: '
+		    ⟦reflect xminusx : bv8 => bv8⟧
+		    let xminusx = (x) => {
+					bvsub8(x,x)
+			  };
+			
+		    ⟦val main : bv8 => bv8[v|v===0]⟧
+		    let main = (x) => {
+					xminusx(x)
+			  };
+			
+			
+		'
+]
+
+{ #category : #tests }
+TBitVectorTest >> test_narrow [
+	self proveSafe: '
+⟦val id : bv32 => bv32⟧
+let id = (x) => {
+   x
+};
+
+⟦val main : bv32 => bv? ⟧
+let main = (xx) => {
+   id(xx)
+};
+'
+]
+
+{ #category : #tests }
 TBitVectorTest >> test_sum_Gauss_BVn [
 	self proveUnsafe: '
 [--check-termination]
@@ -186,6 +255,22 @@ let rec thm_sum = (n) => {
     let n1 = bvsub8(n,bv8(1));
     thm_sum(n1)
   }
+};
+'
+]
+
+{ #category : #tests }
+TBitVectorTest >> test_widen [
+	self proveSafe: '
+⟦val id : bv? => bv?⟧
+let id = (x) => {
+   x
+};
+
+⟦val check1 : bv32 => bv32 ⟧
+let check1 = (y) => {
+  let res  = id(y);
+  res
 };
 '
 ]

--- a/src/SpriteLang/BvSub.class.st
+++ b/src/SpriteLang/BvSub.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #BvSub,
+	#superclass : #Dictionary,
+	#category : #SpriteLang
+}
+
+{ #category : #'as yet unclassified' }
+BvSub >> subsTy: su [ 
+	^self collect: [ :t | t subsTy: su ]
+]
+
+{ #category : #'as yet unclassified' }
+BvSub >> updBvSub: a rtype: t [ 
+	^(t subsBv1: a x: self) copy at: a symbol put: t; yourself
+]

--- a/src/SpriteLang/ElabState.class.st
+++ b/src/SpriteLang/ElabState.class.st
@@ -7,7 +7,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'eSub',
-		'eNum'
+		'eNum',
+		'bvSub'
 	],
 	#classVars : [
 		'current'
@@ -43,6 +44,14 @@ ElabState >> eSub [
 ]
 
 { #category : #'as yet unclassified' }
+ElabState >> freshBvId [
+	| answer |
+	answer := 'bv' intSymbol: eNum.
+	eNum := eNum + 1.
+	^answer
+]
+
+{ #category : #'as yet unclassified' }
 ElabState >> freshTVar [
 	| answer |
 	answer := eNum nonRigidTV.
@@ -54,6 +63,7 @@ ElabState >> freshTVar [
 ElabState >> initS0 [
 	eSub := TvSub new.
 	eNum := 0.
+	bvSub := BvSub new.
 	^self
 ]
 
@@ -62,6 +72,11 @@ ElabState >> runStateT: act [
 	| v |
 	v := act value.
 	^{ eSub . v }
+]
+
+{ #category : #'as yet unclassified' }
+ElabState >> updBvSub: a rtype: t [
+	^bvSub := bvSub updBvSub: a rtype: t
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/SpriteLang/PAnyBV.class.st
+++ b/src/SpriteLang/PAnyBV.class.st
@@ -1,0 +1,25 @@
+Class {
+	#name : #PAnyBV,
+	#superclass : #'ΛPrim',
+	#instVars : [
+		'v'
+	],
+	#category : #SpriteLang
+}
+
+{ #category : #'instance creation' }
+PAnyBV class >> with: anInteger [ 
+	^self basicNew
+		v: anInteger;
+		yourself
+]
+
+{ #category : #accessing }
+PAnyBV >> v [
+	^ v
+]
+
+{ #category : #initialization }
+PAnyBV >> v: anInteger [
+	v := anInteger
+]

--- a/src/SpriteLang/RType.class.st
+++ b/src/SpriteLang/RType.class.st
@@ -54,6 +54,14 @@ RType class >> unifysNonEmpty: coll1 with: coll2 [
 
 ]
 
+{ #category : #'as yet unclassified' }
+RType >> ==> codomain [
+	^TFun
+		x: '_'
+		s: self
+		t: codomain
+]
+
 { #category : #polymorphism }
 RType >> assign: tVar [
 	ElabState current updSub: tVar rtype: self

--- a/src/SpriteLang/RType.class.st
+++ b/src/SpriteLang/RType.class.st
@@ -458,6 +458,11 @@ rTypeSort :: RType -> F.Sort
 	self subclassResponsibility
 ]
 
+{ #category : #'as yet unclassified' }
+RType >> singBvSub: a [ 
+	^BvSub newFromAssociations: {a symbol -> self}
+]
+
 { #category : #polymorphism }
 RType >> singTvSub: a [ 
 	^TvSub newFromAssociations: {a symbol -> self}

--- a/src/SpriteLang/RefinementParser.class.st
+++ b/src/SpriteLang/RefinementParser.class.st
@@ -209,15 +209,16 @@ RefinementParser >> tbase [
 
 { #category : #grammar }
 RefinementParser >> tbitvectors [
-	| parsers |
-
+	| parsers anyBvParser |
 	parsers := TBitVector lengths reverse collect:
-						[ :len | ('bv' , len printString) asParser ==> [:ignored | TBitVector instance: len ] ].
-	^PPChoiceParser withAll: parsers.
+						[ :len | ('bv' , len printString) asParser ==> [ :_ | TBitVector instance: len ] ].
+	anyBvParser := 'bv?' asParser ==> [ :_ | TAnyBV basicNew ].
+	^PPChoiceParser withAll: parsers, {anyBvParser}.
 
 
 	"
 	RTypeParser new tbase parse:'bv8'
+	RTypeParser new tbase parse:'bv?'
 	"
 ]
 

--- a/src/SpriteLang/TAll.class.st
+++ b/src/SpriteLang/TAll.class.st
@@ -8,9 +8,17 @@ Class {
 	#category : #SpriteLang
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
+TAll class >> new [
+	^self shouldNotImplement
+]
+
+{ #category : #'instance creation' }
 TAll class >> var: v type: t [
-	^self basicNew var: v; type: t; yourself
+	^self basicNew
+		var: v;
+		type: t;
+		yourself
 ]
 
 { #category : #SMT }

--- a/src/SpriteLang/TAnyBV.class.st
+++ b/src/SpriteLang/TAnyBV.class.st
@@ -1,0 +1,89 @@
+Class {
+	#name : #TAnyBV,
+	#superclass : #'ΛBase',
+	#instVars : [
+		'symbol'
+	],
+	#category : #SpriteLang
+}
+
+{ #category : #'instance creation' }
+TAnyBV class >> fresh [
+	^self basicNew
+		obtainFreshSymbol;
+		yourself
+]
+
+{ #category : #'instance creation' }
+TAnyBV class >> symbol: s [
+	^self basicNew
+		symbol: s;
+		yourself
+]
+
+{ #category : #comparing }
+TAnyBV >> = another [
+	another class == self class ifFalse: [ ^false ].
+	^symbol = another symbol
+]
+
+{ #category : #'refinement typing' }
+TAnyBV >> baseSort [
+	^Z3Sort uninterpretedSortNamed: 'ANYBV'
+]
+
+{ #category : #comparing }
+TAnyBV >> hash [
+	^symbol hash
+]
+
+{ #category : #'as yet unclassified' }
+TAnyBV >> obtainFreshSymbol [
+	symbol := ElabState current freshBvId
+]
+
+{ #category : #printing }
+TAnyBV >> printOn: aStream [
+	aStream nextPutAll: 'TAnyBV['.
+	symbol isNil ifFalse: [ aStream nextPutAll: symbol ].
+	aStream nextPutAll: ']'.
+		
+]
+
+{ #category : #'as yet unclassified' }
+TAnyBV >> symbol [
+	^symbol
+]
+
+{ #category : #'as yet unclassified' }
+TAnyBV >> symbol: s [
+	symbol := s
+]
+
+{ #category : #'as yet unclassified' }
+TAnyBV >> unifyBV: t [
+	"t is an RType"
+	(t isKindOf: TBase) ifFalse: [ self shouldBeImplemented ].
+	(t b isKindOf: TBitVector) ifTrue: [ t assignBV: self. self halt. ^t ].
+	(t b isKindOf: TAnyBV) ifFalse: [ Incompatible signal ].
+	
+	"AnyBV vs AnyBV; there are 4 cases"
+	symbol isNil
+		ifTrue:  [
+			t b symbol isNil
+				ifTrue:  [ ^self shouldBeImplemented ]
+				ifFalse: [ ^self shouldBeImplemented ]
+		] ifFalse: [
+			t b symbol isNil
+				ifTrue:  [ | t′ |
+					t′ := TBase b: (TAnyBV symbol: symbol) r: t r.
+					t′ assignBV: t b.
+					^t′
+				] ifFalse: [ ^self shouldBeImplemented ]
+		]
+]
+
+{ #category : #'α-renaming' }
+TAnyBV >> uniq2: α [
+	"Nothing to do"
+]

--- a/src/SpriteLang/TBase.class.st
+++ b/src/SpriteLang/TBase.class.st
@@ -14,6 +14,11 @@ TBase class >> b: b r: r [
 		b: b; r: r; yourself
 ]
 
+{ #category : #'as yet unclassified' }
+TBase >> assignBV: aTAnyBV [
+	ElabState current updBvSub: aTAnyBV rtype: self
+]
+
 { #category : #accessing }
 TBase >> b [
 	^ b
@@ -45,6 +50,10 @@ unify l t (TBase (TVar a) _) =
 See L5 test_tail01 for an example going through this path.
 "
 	(b isKindOf: TVar) ifTrue: [ ^b unifyV: t1 ].
+
+	(b isKindOf: TAnyBV) ifTrue: [ ^b unifyBV: t1 ].
+	((t1 isKindOf: TBase) and: [t1 b isKindOf: TAnyBV]) ifTrue: [ ^t1 b unifyBV: self ].
+
 	^super dispatchUnify: t1
 ]
 
@@ -68,6 +77,13 @@ TBase >> goRefresh [
 { #category : #GT }
 TBase >> gtChildren [
 	^#()
+]
+
+{ #category : #polymorphism }
+TBase >> instantiateGo: ts n: n [
+	"This special-case for AnyBV exists only in Smalltalk."
+	(b isKindOf: TAnyBV) ifTrue: [ ^{ ts reversed . n . TBase b: TAnyBV fresh r: r } ].
+	^super instantiateGo: ts n: n
 ]
 
 { #category : #testing }
@@ -214,6 +230,7 @@ TBase >> tsubstGo: t tVar: a [
 { #category : #polymorphism }
 TBase >> unifyLL: t [
 	(b isKindOf: TVar) ifTrue: [ ^b unifyV: t ].
+	(b isKindOf: TAnyBV) ifTrue: [ ^b unifyBV: t ].
 	((t isKindOf: TBase) and: [ t b isKindOf: TVar ]) ifTrue: [ ^t b unifyV: self ].
 	((t isKindOf: TBase) and: [ b = t b ]) ifTrue: [ ^self ].
 	self error: 'Cant unify'

--- a/src/SpriteLang/ΛBase.class.st
+++ b/src/SpriteLang/ΛBase.class.st
@@ -25,6 +25,18 @@ RType where r=Reft, here Reft meaning ΛReft.
 ]
 
 { #category : #'refinement typing' }
+ΛBase >> bUnknown [
+"
+bTrue :: Base -> RType
+bTrue b = TBase b mempty
+
+Here TBase parametrizes over r, but the result needs to be
+RType where r=Reft, here Reft meaning ΛReft.
+"
+	^TBase b: self r: UnknownReft new
+]
+
+{ #category : #'refinement typing' }
 ΛBase >> baseSort [
 	self subclassResponsibility 
 ]

--- a/src/SpriteLang/ΛκParser.class.st
+++ b/src/SpriteLang/ΛκParser.class.st
@@ -157,15 +157,18 @@ Class {
 
 { #category : #accessing }
 ΛκParser >> immBV [
-	| parsers |
+	| parsers anyBvParser |
 	parsers := TBitVector lengths reverse collect:
 						[ :len | (('bv' , len printString) asParser , $( asParser trim , natural , $) asParser trim)
 											==> [:x | ECon prim: (PBitVector length: len value: x third) ] ].
-	^PPChoiceParser withAll: parsers.
+	anyBvParser := (('bv?') asParser , $( asParser trim , natural , $) asParser trim)
+											==> [:x | ECon prim: (PAnyBV with: x third) ].
+	^PPChoiceParser withAll: parsers, {anyBvParser}.
 
 	"
 	ΛκParser new immBV parse:'bv8(127)'
 	ΛκParser new immBV parse:'bv32(1)'
+	ΛκParser new immBV parse:'bv?(42)'
 	"
 ]
 

--- a/src/Z3-Tests/UndefinedElementTest.class.st
+++ b/src/Z3-Tests/UndefinedElementTest.class.st
@@ -1,0 +1,33 @@
+Class {
+	#name : #UndefinedElementTest,
+	#superclass : #TestCase,
+	#category : #'Z3-Tests'
+}
+
+{ #category : #tests }
+UndefinedElementTest >> testDifferentLengthBitVector [
+	| BV32 BV64 e₁ e₂ |
+	BV32 := BitVector///32.
+	BV64 := BitVector///64.
+	e₁ := BV32 undefinedElement.
+	e₂ := BV64 undefinedElement.
+	self deny: e₁ equals: e₂
+]
+
+{ #category : #tests }
+UndefinedElementTest >> testSameBitVector [
+	| BV32 e₁ e₂ |
+	BV32 := BitVector///32.
+	e₁ := BV32 undefinedElement.
+	e₂ := BV32 undefinedElement.
+	self assert: e₁ == e₂
+]
+
+{ #category : #tests }
+UndefinedElementTest >> testZZ [
+	| Z e₁ e₂ |
+	Z := Int sort.
+	e₁ := Z undefinedElement.
+	e₂ := Z undefinedElement.
+	self assert: e₁ == e₂
+]

--- a/src/Z3/UndefinedElement.class.st
+++ b/src/Z3/UndefinedElement.class.st
@@ -1,0 +1,39 @@
+"
+Given a type A, my unique instance is the element of A+𝟙 coming along the injection from 𝟙.
+"
+Class {
+	#name : #UndefinedElement,
+	#superclass : #Object,
+	#instVars : [
+		'type'
+	],
+	#classInstVars : [
+		'Types'
+	],
+	#category : #Z3
+}
+
+{ #category : #'class initialization' }
+UndefinedElement class >> initialize [
+	Types := Dictionary new
+]
+
+{ #category : #'instance creation' }
+UndefinedElement class >> of: aType [
+	^Types
+		at: aType
+		ifAbsentPut: [
+			self basicNew
+				type: aType;
+				yourself ]
+]
+
+{ #category : #accessing }
+UndefinedElement >> type [
+	^ type
+]
+
+{ #category : #accessing }
+UndefinedElement >> type: anObject [
+	type := anObject
+]

--- a/src/Z3/Z3Sort.class.st
+++ b/src/Z3/Z3Sort.class.st
@@ -169,3 +169,8 @@ Z3Sort >> raisedTo: B [
 Z3Sort >> sort_reft: knownDatatypes [ 
 	^{self . 0}
 ]
+
+{ #category : #'type theory' }
+Z3Sort >> undefinedElement [
+	^UndefinedElement of: self
+]


### PR DESCRIPTION
This PR attempts to address #334.  The idea is to have a pre-sort standing somewhere between actual bitvector sorts (of known length) and type variables.  At Sprite-level elaboration, unification will "assign" concrete lengths to them (similar to how concrete sorts are assigned to type variables), so the VC level does not see them at all (in other words, the whole concept just does not exist in Fixpoint).