### PR TITLE
Add context query

### DIFF
--- a/src/Z3-Tests/BoolSymbolTest.class.st
+++ b/src/Z3-Tests/BoolSymbolTest.class.st
@@ -1,18 +1,8 @@
 Class {
 	#name : #BoolSymbolTest,
-	#superclass : #TestCase,
+	#superclass : #TestCaseWithZ3Context,
 	#category : #'Z3-Tests'
 }
-
-{ #category : #running }
-BoolSymbolTest >> setUp [
-	Z3Context createGlobalContext 
-]
-
-{ #category : #running }
-BoolSymbolTest >> tearDown [
-	Z3Context current release
-]
 
 { #category : #tests }
 BoolSymbolTest >> testBasicCreation [

--- a/src/Z3-Tests/ContextlessZ3Test.class.st
+++ b/src/Z3-Tests/ContextlessZ3Test.class.st
@@ -51,7 +51,7 @@ ContextlessZ3Test >> testSimpleExample [
 ContextlessZ3Test >> testSymbolFromString [
 	| ctx sym |
 	ctx := Z3Context fromDefault.
-	sym := Z3Symbol from: 123 on: ctx.
+	sym := ctx mkSymbol: 123.
 	self deny:   sym isStringSymbol.
 	self assert:   sym isIntSymbol.
 ]

--- a/src/Z3-Tests/ContextlessZ3Test.class.st
+++ b/src/Z3-Tests/ContextlessZ3Test.class.st
@@ -71,3 +71,42 @@ ContextlessZ3Test >> testTwoContexts [
 	self assert: y astToString equals: 'y'.
 	ctx2 release
 ]
+
+{ #category : #tests }
+ContextlessZ3Test >> testTwoContexts2 [
+	"Several logical contexts can be used simultaneously."
+
+	| global ctx1 ctx2 x y |
+
+	global := Z3Context current.
+	ctx1 := Z3Context fromDefault.
+	ctx2 := Z3Context fromDefault.
+	self deny: ctx1 getHandle asInteger = ctx2 getHandle asInteger.
+
+	Z3ContextQuery answer: ctx1 do: [
+		self assert: global ~~ ctx1.
+		self assert: Z3Context current == ctx1.
+		x := 'x' toBool.
+	].
+	self assert: Z3Context current == global.
+	global ensureValidZ3Object.
+	self assert: global ~~ ctx1.
+	self assert: x ctx == ctx1.
+
+	Z3ContextQuery answer: ctx2 do: [
+		self assert: global ~~ ctx2.
+		self assert: Z3Context current == ctx2.
+		y := 'y' toBool.
+	].
+	self assert: Z3Context current == global.
+	global ensureValidZ3Object.
+	self assert: global ~~ ctx2.
+	self assert: y ctx == ctx2.
+
+	ctx1 release.
+	"ctx2 can still be used"
+	self assert: y astToString equals: 'y'.
+	ctx2 release.
+
+	global ensureValidZ3Object.
+]

--- a/src/Z3-Tests/IntSymbolTest.class.st
+++ b/src/Z3-Tests/IntSymbolTest.class.st
@@ -1,18 +1,8 @@
 Class {
 	#name : #IntSymbolTest,
-	#superclass : #TestCase,
+	#superclass : #TestCaseWithZ3Context,
 	#category : #'Z3-Tests'
 }
-
-{ #category : #running }
-IntSymbolTest >> setUp [
-	Z3Context createGlobalContext 
-]
-
-{ #category : #running }
-IntSymbolTest >> tearDown [
-	Z3Context current release
-]
 
 { #category : #tests }
 IntSymbolTest >> testAdd0 [

--- a/src/Z3-Tests/IntValueTest.class.st
+++ b/src/Z3-Tests/IntValueTest.class.st
@@ -3,19 +3,9 @@ Tests for the most basic fuctionality of concrete BitVectors.
 "
 Class {
 	#name : #IntValueTest,
-	#superclass : #TestCase,
+	#superclass : #TestCaseWithZ3Context,
 	#category : #'Z3-Tests'
 }
-
-{ #category : #running }
-IntValueTest >> setUp [
-	Z3Context createGlobalContext 
-]
-
-{ #category : #running }
-IntValueTest >> tearDown [
-	Z3Context current release
-]
 
 { #category : #'tests - arithmetic' }
 IntValueTest >> testAdd8 [

--- a/src/Z3-Tests/NQueensTest.class.st
+++ b/src/Z3-Tests/NQueensTest.class.st
@@ -4,7 +4,7 @@ This is a very very far cry from CLP(FD) ff-labeling.
 "
 Class {
 	#name : #NQueensTest,
-	#superclass : #TestCase,
+	#superclass : #TestCaseWithZ3Context,
 	#instVars : [
 		'solver'
 	],
@@ -13,7 +13,7 @@ Class {
 
 { #category : #running }
 NQueensTest >> setUp [
-	Z3Context createGlobalContext.
+	super setUp.
 	solver := Z3Solver new
 ]
 
@@ -70,7 +70,7 @@ NQueensTest >> solveNaive: n [
 { #category : #running }
 NQueensTest >> tearDown [
 	solver release.
-	Z3Context current release
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/Z3-Tests/SimpleZ3Test.class.st
+++ b/src/Z3-Tests/SimpleZ3Test.class.st
@@ -219,6 +219,14 @@ SimpleZ3Test >> testBoundVar [
 ]
 
 { #category : #tests }
+SimpleZ3Test >> testContext [
+	| ctx |
+
+	ctx := Z3Context current.
+	self assert: ctx ~~ Z3Context global.
+]
+
+{ #category : #tests }
 SimpleZ3Test >> testCreateArray [
 	| a |
 	a := Z3Sort int --> Z3Sort bool.

--- a/src/Z3-Tests/TestCaseWithZ3Context.class.st
+++ b/src/Z3-Tests/TestCaseWithZ3Context.class.st
@@ -1,15 +1,34 @@
+"
+TestCaseWithZ3Context is a abstract testcase superclass ensuring that each
+test is run in a separate `Z3Context`, leaving the default 'global' context
+intact.
+
+There's no real to make Z3 tests a subclass of `TestCaseWithZ3Context`, tests
+should pass even when subclassing SUnit's `TestCase` directly (in which case,
+a default ""global"" `Z3Context` will be used).
+
+`TestCaseWithZ3Context` is used merely to make sure the codebase works
+correctly when using custom `Z3Context` provided via query.
+
+"
 Class {
 	#name : #TestCaseWithZ3Context,
 	#superclass : #TestCase,
 	#category : #'Z3-Tests'
 }
 
-{ #category : #'z3 context' }
-TestCaseWithZ3Context >> setUp [
-	Z3Context createGlobalContext 
-]
+{ #category : #private }
+TestCaseWithZ3Context >> runCase [
+	| ctx |
 
-{ #category : #'z3 context' }
-TestCaseWithZ3Context >> tearDown [
-	Z3Context current release
+	ctx := Z3Context fromDefault.
+	"Z3Context createGlobalContext."
+	[
+		Z3ContextQuery answer: ctx do: [
+			super runCase
+		].
+	] ensure: [
+		ctx release.
+		"Z3Context current release."
+	].
 ]

--- a/src/Z3-Tests/Z3CAPITest.class.st
+++ b/src/Z3-Tests/Z3CAPITest.class.st
@@ -20,7 +20,7 @@ Z3CAPITest >> exampleArray2: n [
 		Z3AST mkConst: s ofSort: arraySort ].
 	
 	distinct := arraySort ctx mkDistinct: arrays.
-	solver := Z3Solver on: arraySort ctx.
+	solver := arraySort ctx mkSolver.
 	solver assert: distinct.
 	sat := solver check.
 	solver release.
@@ -214,7 +214,7 @@ Z3CAPITest >> testEval [
 	y := ctx mkIntVar: 'y'.
 	two := ctx mkInt: 2.
 	
-	solver := Z3Solver on: ctx.
+	solver := ctx mkSolver.
 	solver assert: x < y.
 	solver assert: x > two.
 	solver check.
@@ -227,7 +227,6 @@ Z3CAPITest >> testEval [
 	"m decRef."
 	solver release.
 	ctx release
-	
 ]
 
 { #category : #tests }
@@ -377,7 +376,7 @@ Z3CAPITest >> testPushPop [
    This example also demonstrates how big numbers can be created in Z3."
 	| ctx s brazilion int_sort x y  big_number three |
 	ctx := Z3Context fromDefault.
-	s := Z3Solver on: ctx.
+	s := ctx mkSolver.
 	
 	"create a big number"
 	int_sort := Z3Sort intSortOn: ctx.

--- a/src/Z3-Tests/Z3CAPITest.class.st
+++ b/src/Z3-Tests/Z3CAPITest.class.st
@@ -379,7 +379,7 @@ Z3CAPITest >> testPushPop [
 	s := ctx mkSolver.
 	
 	"create a big number"
-	int_sort := Z3Sort intSortOn: ctx.
+	int_sort := ctx mkIntSort.
 	brazilion := '1000000000000000000000000000000000000000000000000000000'.
 	big_number := int_sort numeralFrom: brazilion.
 	self assert: big_number astToString equals: brazilion.

--- a/src/Z3/Bool.class.st
+++ b/src/Z3/Bool.class.st
@@ -6,9 +6,12 @@ Class {
 
 { #category : #'multi-arity ops' }
 Bool class >> and: aCollection [
-	self assert: (aCollection allSatisfy: [ :e | e isBool ]).
-	^ Z3 mk_and: Z3Context current _: aCollection size _: aCollection
+	| ctx |
 
+	self assert: (aCollection allSatisfy: [ :e | e isBool ]).
+
+	ctx := aCollection isEmpty ifTrue: [ Z3Context current ] ifFalse: [ aCollection anyOne ctx ].
+	^ Z3 mk_and: ctx _: aCollection size _: aCollection
 ]
 
 { #category : #'instance creation' }
@@ -18,9 +21,12 @@ Bool class >> false [
 
 { #category : #'multi-arity ops' }
 Bool class >> or: aCollection [
-	self assert: (aCollection allSatisfy: [ :e | e isBool ]).
-	^ Z3 mk_or: Z3Context current _: aCollection size _: aCollection
+	| ctx |
 
+	self assert: (aCollection allSatisfy: [ :e | e isBool ]).
+
+	ctx := aCollection isEmpty ifTrue: [ Z3Context current ] ifFalse: [ aCollection anyOne ctx ].
+	^ Z3 mk_or: ctx _: aCollection size _: aCollection
 ]
 
 { #category : #sorting }

--- a/src/Z3/Z3AST.class.st
+++ b/src/Z3/Z3AST.class.st
@@ -55,7 +55,7 @@ Z3AST class >> numeral: aString ofSort: ty [
 { #category : #'particular sort creation' }
 Z3AST class >> var: varName ofSort: ty [
 	| sym |
-	sym := Z3Symbol from: varName on: ty ctx.
+	sym := ty ctx mkSymbol: varName.
 	^self mkConst: sym ofSort: ty
 ]
 

--- a/src/Z3/Z3ASTVector.class.st
+++ b/src/Z3/Z3ASTVector.class.st
@@ -6,14 +6,7 @@ Class {
 
 { #category : #'instance creation' }
 Z3ASTVector class >> parseSmtlib2String: aString [
-	^self parseSmtlib2String: aString in: Z3Context current
-]
-
-{ #category : #'instance creation' }
-Z3ASTVector class >> parseSmtlib2String: aString in: ctx [
-	| instance |
-	instance := ctx parseSmtlib2String: aString.
-	^instance
+	^ Z3Context current parseSmtlib2String: aString
 ]
 
 { #category : #solving }

--- a/src/Z3/Z3ASTVector.class.st
+++ b/src/Z3/Z3ASTVector.class.st
@@ -13,7 +13,6 @@ Z3ASTVector class >> parseSmtlib2String: aString [
 Z3ASTVector class >> parseSmtlib2String: aString in: ctx [
 	| instance |
 	instance := ctx parseSmtlib2String: aString.
-	instance incRef.
 	^instance
 ]
 

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -226,8 +226,23 @@ Z3Context >> mkPattern: terms [
 ]
 
 { #category : #'as yet unclassified' }
+Z3Context >> mkSymbol [
+	"The empty symbol (a special symbol in Z3).
+	 By analogy with other monoids such as String, Array etc,
+	 we use the selector #new for 'the monoidal unit',
+	 even though Z3Symbol is not a monoid."
+	^ self mkSymbol: String new
+]
+
+{ #category : #'as yet unclassified' }
 Z3Context >> mkSymbol: stringOrInteger [
-	^Z3Symbol from: stringOrInteger on: self
+	stringOrInteger isInteger ifTrue: [
+		^ Z3 mk_int_symbol: self _: stringOrInteger
+	].
+	stringOrInteger isString ifTrue: [
+		^ Z3 mk_string_symbol: self _: stringOrInteger
+	].
+	^ self error: 'Unsupported value type'
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -13,13 +13,6 @@ Class {
 	#category : #'Z3-Core'
 }
 
-{ #category : #private }
-Z3Context class >> createGlobalContext [
-	"OBSOLETE, DO NOT USE. Kept temporarily for compatibility with tests. Will be removed."
-
-	Global := nil
-]
-
 { #category : #accessing }
 Z3Context class >> current [
 	"Answer the current Z3 context to use. By default, this

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -152,7 +152,7 @@ Z3Context >> mkBoolSort [
 { #category : #'as yet unclassified' }
 Z3Context >> mkBoolVar: name [
 	| ty |
-	ty := Z3Sort boolSortOn: self.
+	ty := self mkBoolSort.
 	^self mkVar: name ofSort: ty
 ]
 
@@ -219,8 +219,8 @@ Z3Context >> mkForAll: patterns weight: w numQuantifiedVars: nVars types: types 
 Z3Context >> mkInt: anInteger [
 	"Create a Z3 integer node using a C int."
 	| ty |
-	ty := Z3Sort intSortOn: self.
-	^ty mkInt: anInteger 
+	ty := self mkIntSort.
+	^ty mkInt: anInteger
 ]
 
 { #category : #'as yet unclassified' }
@@ -231,7 +231,7 @@ Z3Context >> mkIntSort [
 { #category : #'as yet unclassified' }
 Z3Context >> mkIntVar: name [
 	| ty |
-	ty := Z3Sort intSortOn: self.
+	ty := self mkIntSort.
 	^self mkVar: name ofSort: ty
 ]
 

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -13,15 +13,26 @@ Class {
 	#category : #'Z3-Core'
 }
 
-{ #category : #'global context' }
+{ #category : #private }
 Z3Context class >> createGlobalContext [
-	Global := self fromDefault
+	"OBSOLETE, DO NOT USE. Kept temporarily for compatibility with tests. Will be removed."
+
+	Global := nil
 ]
 
-{ #category : #'global context' }
+{ #category : #accessing }
 Z3Context class >> current [
-	"TODO: local contexts"
-	^self global
+	"Answer the current Z3 context to use. By default, this
+	 is the 'global' context, but users may specify their own
+	 for particular computation using `Z3ContextQuery`:
+
+		 customContext := Z3Context from: ...
+		 Z3ContextQuery answer: customContext do: [
+			...some computation with custom context...
+		 ].
+	"
+
+	^ Z3ContextQuery query
 ]
 
 { #category : #'instance creation' }
@@ -46,10 +57,14 @@ Z3Context class >> fromDefault [
 	^self from: Z3Config default
 ]
 
-{ #category : #'global context' }
+{ #category : #private }
 Z3Context class >> global [
-	Global isNil ifTrue: [ self createGlobalContext ].
-	Global isNull ifTrue: [ self createGlobalContext ]. "see PR#76"
+	"Return the global context. Do not use this directly,
+	 always ask for context using `Z3Context current`"
+
+	(Global isNil "Global context has not yet been created"
+		or: [ Global isNull ]) "Or it is invalid (null) such as after an image restart"
+			ifTrue:[ Global := self fromDefault ].
 	^Global
 ]
 

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -145,10 +145,20 @@ Z3Context >> internAST: class address: address kind: kind sort: sort [
 ]
 
 { #category : #'as yet unclassified' }
+Z3Context >> mkBoolSort [
+	^Z3 mk_bool_sort: self
+]
+
+{ #category : #'as yet unclassified' }
 Z3Context >> mkBoolVar: name [
 	| ty |
 	ty := Z3Sort boolSortOn: self.
 	^self mkVar: name ofSort: ty
+]
+
+{ #category : #'as yet unclassified' }
+Z3Context >> mkBvSort: length [
+	^ Z3 mk_bv_sort: self _: length
 ]
 
 { #category : #'as yet unclassified' }
@@ -214,6 +224,11 @@ Z3Context >> mkInt: anInteger [
 ]
 
 { #category : #'as yet unclassified' }
+Z3Context >> mkIntSort [
+	^Z3 mk_int_sort: self
+]
+
+{ #category : #'as yet unclassified' }
 Z3Context >> mkIntVar: name [
 	| ty |
 	ty := Z3Sort intSortOn: self.
@@ -223,6 +238,11 @@ Z3Context >> mkIntVar: name [
 { #category : #'as yet unclassified' }
 Z3Context >> mkPattern: terms [
 	^Z3 mk_pattern: self _: terms size _: terms
+]
+
+{ #category : #'as yet unclassified' }
+Z3Context >> mkRealSort [
+	^Z3 mk_real_sort: self
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -53,6 +53,11 @@ Z3Context class >> global [
 	^Global
 ]
 
+{ #category : #'instance creation' }
+Z3Context class >> new [
+	^ self shouldNotImplement. "Use #from: or #fromDefault"
+]
+
 { #category : #'system info' }
 Z3Context class >> z3fullVersion [
 	^LibZ3 getFullVersion 

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -226,6 +226,16 @@ Z3Context >> mkPattern: terms [
 ]
 
 { #category : #'as yet unclassified' }
+Z3Context >> mkSolver [
+	^ Z3 mk_solver: self
+]
+
+{ #category : #'as yet unclassified' }
+Z3Context >> mkSolverForLogic: logic [
+	^ Z3 mk_solver_for_logic: self _: (self mkSymbol: logic)
+]
+
+{ #category : #'as yet unclassified' }
 Z3Context >> mkSymbol [
 	"The empty symbol (a special symbol in Z3).
 	 By analogy with other monoids such as String, Array etc,

--- a/src/Z3/Z3ContextQuery.class.st
+++ b/src/Z3/Z3ContextQuery.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : #Z3ContextQuery,
+	#superclass : #Query,
+	#category : #'Z3-Core'
+}
+
+{ #category : #'default values' }
+Z3ContextQuery >> defaultResumeValue [
+	"the default answer, if no one handles the query and the exception is resumed"
+
+	^ Z3Context global
+]

--- a/src/Z3/Z3QuantifierNode.class.st
+++ b/src/Z3/Z3QuantifierNode.class.st
@@ -24,12 +24,14 @@ Z3QuantifierNode class >> lambda: vs body: expr [
 
 { #category : #'instance creation' }
 Z3QuantifierNode class >> mkQuantifier: isForall vars: vs body: body [
-	| numVars weight qid skid |
+	| ctx numVars weight qid skid |
+
+	ctx := body ctx.
 	numVars := vs size.
 	numVars = 0 ifTrue: [^body].
 	weight := 1.
-	qid := Z3Symbol new.
-	skid := Z3Symbol new.
+	qid := ctx mkSymbol.
+	skid := ctx mkSymbol.
 	^Z3 mk_quantifier_const_ex: Z3Context current _: isForall _: weight _: qid _: skid
 		_: numVars _: vs
 		_: 0 _: Array new "pats"

--- a/src/Z3/Z3Solver.class.st
+++ b/src/Z3/Z3Solver.class.st
@@ -12,7 +12,7 @@ Z3Solver class >> for: logic [
 { #category : #'as yet unclassified' }
 Z3Solver class >> isValid: thm [
 	| solver answer |
-	solver := self new.
+	solver := thm ctx mkSolver.
 	answer := solver isValid: thm.
 	solver release.
 	^answer
@@ -65,8 +65,8 @@ Z3Solver >> assertInjective: f in: i [
 	finvFxs := finv value: fxs.
 	eq := finvFxs eq: xi.
 	
-	p := Z3Context current mkPattern: {fxs}.
-	q := Z3Context current mkForAll: { p }
+	p := ctx mkPattern: {fxs}.
+	q := ctx mkForAll: { p }
 		weight: 0
 		numQuantifiedVars: f domainSize
 		types: types

--- a/src/Z3/Z3Solver.class.st
+++ b/src/Z3/Z3Solver.class.st
@@ -6,7 +6,7 @@ Class {
 
 { #category : #'instance creation' }
 Z3Solver class >> for: logic [ 
-	^self on: Z3Context current for: logic
+	^Z3Context current mkSolverForLogic: logic
 ]
 
 { #category : #'as yet unclassified' }
@@ -20,19 +20,7 @@ Z3Solver class >> isValid: thm [
 
 { #category : #'instance creation' }
 Z3Solver class >> new [
-	^self on: Z3Context current
-]
-
-{ #category : #'instance creation' }
-Z3Solver class >> on: aZ3Context [
-	^aZ3Context mkSolver
-]
-
-{ #category : #'instance creation' }
-Z3Solver class >> on: aZ3Context for: logic [
-	| logicSymbol |
-	logicSymbol := aZ3Context mkSymbol: logic .
-	^aZ3Context mkSolverForLogic: logicSymbol
+	^Z3Context current mkSolver
 ]
 
 { #category : #asserting }

--- a/src/Z3/Z3Solver.class.st
+++ b/src/Z3/Z3Solver.class.st
@@ -25,16 +25,14 @@ Z3Solver class >> new [
 
 { #category : #'instance creation' }
 Z3Solver class >> on: aZ3Context [
-	^Z3 mk_solver: aZ3Context
-
+	^aZ3Context mkSolver
 ]
 
 { #category : #'instance creation' }
 Z3Solver class >> on: aZ3Context for: logic [
 	| logicSymbol |
-	logicSymbol := Z3Symbol from: logic .
-	^Z3 mk_solver_for_logic: aZ3Context _: logicSymbol
-
+	logicSymbol := aZ3Context mkSymbol: logic .
+	^aZ3Context mkSolverForLogic: logicSymbol
 ]
 
 { #category : #asserting }

--- a/src/Z3/Z3Sort.class.st
+++ b/src/Z3/Z3Sort.class.st
@@ -15,8 +15,7 @@ Z3Sort class >> bool [
 
 { #category : #'instance creation' }
 Z3Sort class >> boolSortOn: aZ3Context [
-	^Z3 mk_bool_sort: aZ3Context
-
+	^ aZ3Context mkBoolSort
 ]
 
 { #category : #'instance creation' }
@@ -26,8 +25,7 @@ Z3Sort class >> bv: sz [
 
 { #category : #'instance creation' }
 Z3Sort class >> bvSort: sz on: ctx [
-	^ Z3 mk_bv_sort: ctx _: sz
-
+	^ ctx mkBvSort: sz
 ]
 
 { #category : #private }
@@ -66,8 +64,7 @@ Z3Sort class >> int [
 
 { #category : #'instance creation' }
 Z3Sort class >> intSortOn: aZ3Context [
-	^Z3 mk_int_sort: aZ3Context
-
+	^ aZ3Context mkIntSort
 ]
 
 { #category : #'instance creation' }
@@ -77,8 +74,7 @@ Z3Sort class >> real [
 
 { #category : #'instance creation' }
 Z3Sort class >> realSortOn: aZ3Context [
-	^Z3 mk_real_sort: aZ3Context
-
+	^ aZ3Context mkRealSort
 ]
 
 { #category : #'instance creation' }

--- a/src/Z3/Z3Sort.class.st
+++ b/src/Z3/Z3Sort.class.st
@@ -10,22 +10,12 @@ Class {
 
 { #category : #'instance creation' }
 Z3Sort class >> bool [
-	^self boolSortOn: Z3Context current 
-]
-
-{ #category : #'instance creation' }
-Z3Sort class >> boolSortOn: aZ3Context [
-	^ aZ3Context mkBoolSort
+	^ Z3Context current mkBoolSort
 ]
 
 { #category : #'instance creation' }
 Z3Sort class >> bv: sz [
-	^self bvSort: sz on: Z3Context current
-]
-
-{ #category : #'instance creation' }
-Z3Sort class >> bvSort: sz on: ctx [
-	^ ctx mkBvSort: sz
+	^Z3Context current mkBvSort: sz
 ]
 
 { #category : #private }
@@ -59,32 +49,17 @@ Z3Sort class >> fromExternalAddress: anExternalAddress inContext: aZ3Context [
 
 { #category : #'instance creation' }
 Z3Sort class >> int [
-	^self intSortOn: Z3Context current
-]
-
-{ #category : #'instance creation' }
-Z3Sort class >> intSortOn: aZ3Context [
-	^ aZ3Context mkIntSort
+	^ Z3Context current mkIntSort
 ]
 
 { #category : #'instance creation' }
 Z3Sort class >> real [
-	^self realSortOn: Z3Context current
-]
-
-{ #category : #'instance creation' }
-Z3Sort class >> realSortOn: aZ3Context [
-	^ aZ3Context mkRealSort
+	^ Z3Context current mkRealSort
 ]
 
 { #category : #'instance creation' }
 Z3Sort class >> uninterpretedSortNamed: aName [
 	^(Z3Symbol from: aName) mkUninterpretedSort
-]
-
-{ #category : #'instance creation' }
-Z3Sort class >> uninterpretedSortNamed: aName on: aZ3Context [
-	self shouldBeImplemented 
 ]
 
 { #category : #'type theory' }

--- a/src/Z3/Z3Symbol.class.st
+++ b/src/Z3/Z3Symbol.class.st
@@ -18,14 +18,7 @@ Z3Symbol class >> from: anObject [
 
 { #category : #private }
 Z3Symbol class >> from: anObject on: aContext [
-	anObject isInteger ifTrue: [ 
-		^ Z3 mk_int_symbol: aContext _: anObject
-	].
-	anObject isString ifTrue: [ 
-		^ Z3 mk_string_symbol: aContext _: anObject
-	].
-	self error: 'Unsupported value type'
-
+	^ aContext mkSymbol: anObject
 ]
 
 { #category : #private }
@@ -34,7 +27,7 @@ Z3Symbol class >> new [
 	 By analogy with other monoids such as String, Array etc,
 	 we use the selector #new for 'the monoidal unit',
 	 even though Z3Symbol is not a monoid."
-	^self from: String new
+	^Z3Context current mkSymbol
 ]
 
 { #category : #converting }

--- a/src/Z3/Z3Symbol.class.st
+++ b/src/Z3/Z3Symbol.class.st
@@ -12,13 +12,7 @@ Class {
 
 { #category : #private }
 Z3Symbol class >> from: anObject [
-	^self from: anObject on: Z3Context current
-
-]
-
-{ #category : #private }
-Z3Symbol class >> from: anObject on: aContext [
-	^ aContext mkSymbol: anObject
+	^ Z3Context current mkSymbol: anObject
 ]
 
 { #category : #private }


### PR DESCRIPTION
This PR adds `Z3ContextQuery` as an a way to use custom `Z3Context` (as opposed to using single global one which is still used if no custom one is provided). 

Majority of commits is API cleanup. 