### PR TITLE
Allow also uppercase spelling of Bool in NNFParser

### DIFF
--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -116,6 +116,7 @@ NNFParser >> exists [
 NNFParser >> fTyCon [
 	^ ('Int' asParser ==> [ :x | Int tyCon ])
 	/ ('int' asParser ==> [ :x | Int tyCon ])
+	/ ('Bool' asParser ==> [ :x | Bool tyCon ])
 	/ ('bool' asParser ==> [ :x | Bool tyCon ])
 	/ (NNFParser upperId ==> [ :x | x symbolFTycon ])
 ]


### PR DESCRIPTION
This is required for LiquidFixpoint tests to parse.