### PR TITLE
Remove bogus Z3Context>>z3fullVersion

### DIFF
--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -66,11 +66,6 @@ Z3Context class >> new [
 	^ self shouldNotImplement. "Use #from: or #fromDefault"
 ]
 
-{ #category : #'system info' }
-Z3Context class >> z3fullVersion [
-	^LibZ3 getFullVersion 
-]
-
 { #category : #'initialization & release' }
 Z3Context >> delete [
 	Z3 del_context: self.


### PR DESCRIPTION
LibZ3 does not even understand `#getFullVersion`.