### PR TITLE
Implement Z3 API stack for tuple/enum/list convenience APIs

### DIFF
--- a/src/Z3-Tests/Z3CAPITODOTest.class.st
+++ b/src/Z3-Tests/Z3CAPITODOTest.class.st
@@ -80,9 +80,3 @@ Z3CAPITODOTest >> testReferenceCounter [
    to manage memory efficiently."
 	self shouldBeImplemented 
 ]
-
-{ #category : #tests }
-Z3CAPITODOTest >> testTuple1 [
-	"Simple tuple type example. It creates a tuple that is a pair of real numbers."
-	self shouldBeImplemented 
-]

--- a/src/Z3-Tests/Z3CAPITest.class.st
+++ b/src/Z3-Tests/Z3CAPITest.class.st
@@ -233,29 +233,31 @@ Z3CAPITest >> testDemorgan [
 Z3CAPITest >> testEnum [
 	"Create an enumeration data type."
 	| fruit consts testers apple banana orange fruity solver |
-	consts  := Array new: 3.
-	testers := Array new: 3.
-	fruit := Z3Context current mkEnumerationSort: 'fruit'
-		elements: { 'apple'. 'banana'. 'orange'. }
+	consts  := Cell new.
+	testers := Cell new.
+	fruit := Z3DatatypeSort
+		mkEnumerationSort: 'fruit'
+		elements: { 'apple'. 'banana'. 'orange' }
 		consts: consts
 		testers: testers.
 	"it's instructive to look around the consts and testers at this point"
-	apple  := consts first value.
-	banana := consts second value.
-	orange := consts third value.
+	apple  := consts get first value.
+	banana := consts get second value.
+	orange := consts get third value.
 	"Apples are different from oranges"
 	self assert: apple ~== orange.
 	"Apples pass the apple test"
-	self assert: (testers first value: apple) simplify.
-	"Oranges pass the apple test"
-	self deny: (testers first value: orange).
+	self assert: (testers get first value: apple) isValid.
+	"Oranges fail the apple test"
+	self deny: (testers get first value: orange) isValid.
 	
 	"If something is fruity, then it is an apple, banana, or orange"
 	fruity := fruit mkConst: 'fruity'.
-	solver := Z3Solver new.
-	solver proveValid: (Bool or: { fruity===apple. fruity===banana. fruity===orange. }).
-	solver release.
-
+	self assert: (Bool or: { fruity===apple. fruity===banana. fruity===orange }) isValid.
+	
+	"No fruity can ever be an apple and banana at the same time"
+	self assert: (Bool and: { fruity===apple. fruity===banana }) not isValid.
+	
 ]
 
 { #category : #tests }
@@ -390,6 +392,65 @@ Z3CAPITest >> testITE [
 	zero := 0 toInt.
 	ite := f ifThen: one else: zero.
 	ite astToString.
+]
+
+{ #category : #tests }
+Z3CAPITest >> testList [
+	"Create a list datatype."
+	| intList nilDecl isNilDecl consDecl isConsDecl headDecl tailDecl NIL l1 l2 x y u v fml1 |
+	nilDecl := Cell new.
+	isNilDecl := Cell new.
+	consDecl := Cell new.
+	isConsDecl := Cell new.
+	headDecl := Cell new.
+	tailDecl := Cell new.
+	intList := Z3DatatypeSort 
+		mkListSort: 'int_list'
+		elementSort: Int sort
+		nilDecl: nilDecl
+		isNilDecl: isNilDecl
+		consDecl: consDecl
+		isConsDecl: isConsDecl
+		headDecl: headDecl
+		tailDecl: tailDecl.
+	nilDecl := nilDecl get.
+	isNilDecl := isNilDecl get.
+	consDecl := consDecl get.
+	isConsDecl := isConsDecl get.
+	headDecl := headDecl get.
+	tailDecl := tailDecl get.
+	NIL := nilDecl value.
+	l1 := consDecl value: 1 value: NIL.
+	l2 := consDecl value: 2 value: NIL.
+	self assert: (NIL ~== l1) isValid.
+	self assert: (l1 ~== l2) isValid.
+	x := 'x' toInt.  y := 'y' toInt.
+	u := intList mkConst: 'u'. v := intList mkConst: 'v'.
+	self assert: (
+		(consDecl value: x value: NIL) === (consDecl value: y value: NIL)
+			==>
+		(x===y)
+	) isValid.
+	self assert: (
+		(consDecl value: x value: u) === (consDecl value: y value: v)
+			==>
+		(x===y)
+	) isValid.
+	self assert: (
+		(consDecl value: x value: u) === (consDecl value: y value: v)
+			==>
+		(u===v)
+	) isValid.
+	self assert: (
+		(isNilDecl value: u) | (isConsDecl value: u)
+	) isValid.
+	self assert: (
+		u ~== (consDecl value: x value: u) "occurs check"
+	) isValid.
+	"destructors: u = cons(head(u),tail(u)) if isCons(u)"
+	fml1 := u === (consDecl value: (headDecl value: u) value: (tailDecl value: u)).
+	self deny: fml1 isValid.
+	self assert: ((isConsDecl value: u) ==> fml1) isValid
 ]
 
 { #category : #tests }
@@ -568,6 +629,33 @@ Z3CAPITest >> testSubstituteVars [
 	self assert: r isApp.
 	self assert: r functorName equals: 'f'.
 	self assert: (r argAt: 2) astToString equals: 'a'
+
+]
+
+{ #category : #tests }
+Z3CAPITest >> testTuple1 [
+	"Simple tuple type example.
+	 Create a tuple that is a pair of real numbers."
+	| R mkTuple projDecls pairSort |
+	R := Real sort.
+	mkTuple := Cell new.
+	projDecls := Cell new.
+	pairSort := Z3DatatypeSort
+		mkTupleSort: 'mk_pair'
+		projections:  { 'get_x'->R . 'get_y'->R }
+		mkTupleDecl: mkTuple
+		projDecls: projDecls.
+	mkTuple := mkTuple get. projDecls := projDecls get.
+	"prove that get_x(mk_pair(x,y)) = 1 implies x = 1"
+	self assert: (
+		(projDecls first value: (mkTuple value: 'x' value: 'y')) === 1 toReal
+		 ==>
+		(1 toReal === 'x')) isValid.
+	"disprove that get_x(mk_pair(x,y)) = 1 implies y = 1"
+	self deny: (
+		(projDecls first value: (mkTuple value: 'x' value: 'y')) === 1 toReal
+		 ==>
+		(1 toReal === 'y')) isValid.
 
 ]
 

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -171,12 +171,16 @@ Z3Context >> mkEnumerationSort: name elements: elements consts: consts testers: 
 	to A, B, C in consts.  The array testers has three predicates of type (s -> Bool).
 	The first predicate (corresponding to A) is true when applied to A, and false otherwise.
 	Similarly for the other predicates."
-	^Z3 mk_enumeration_sort: self
+	| enumSort |
+	consts  set: (Array new: elements size).
+	testers set: (Array new: elements size).
+	enumSort := Z3 mk_enumeration_sort: self
 		_: name toZ3Symbol
 		_: elements size
 		_: (elements collect: #toZ3Symbol)
-		_: consts
-		_: testers
+		_: consts get
+		_: testers get.
+	^enumSort
 ]
 
 { #category : #'API wrappers' }
@@ -224,6 +228,34 @@ Z3Context >> mkIntVar: name [
 ]
 
 { #category : #'API wrappers' }
+Z3Context >> mkListSort: listName elementSort: elementSort nilDecl: nilDecl isNilDecl: isNilDecl consDecl: consDecl isConsDecl: isConsDecl headDecl: headDecl tailDecl: tailDecl [
+	| listSort nilDeclArray isNilDeclArray consDeclArray isConsDeclArray headDeclArray tailDeclArray |
+	nilDeclArray := Array new: 1.
+	isNilDeclArray := Array new: 1.
+ consDeclArray := Array new: 1.
+ isConsDeclArray := Array new: 1.
+ headDeclArray := Array new: 1.
+ tailDeclArray := Array new: 1.
+	listSort := Z3
+		mk_list_sort: self
+		_: listName toZ3Symbol
+		_: elementSort
+		_: nilDeclArray
+		_: isNilDeclArray
+		_: consDeclArray
+		_: isConsDeclArray
+		_: headDeclArray
+		_: tailDeclArray.
+	nilDecl set: nilDeclArray anyOne.
+	isNilDecl set: isNilDeclArray anyOne.
+	consDecl set: consDeclArray anyOne.
+	isConsDecl set: isConsDeclArray anyOne.
+	headDecl set: headDeclArray anyOne.
+	tailDecl set: tailDeclArray anyOne.
+	^listSort
+]
+
+{ #category : #'API wrappers' }
 Z3Context >> mkPattern: terms [
 	^Z3 mk_pattern: self _: terms size _: terms
 ]
@@ -268,6 +300,25 @@ Z3Context >> mkTrue [
 	"Create an AST node representing true."
 	^Z3 mk_true: self
 
+]
+
+{ #category : #'API wrappers' }
+Z3Context >> mkTupleSort: constructorName projections: projAssocs mkTupleDecl: tupleDeclCell projDecls: projDeclCell [
+	| projNames projSorts mkTupleDeclArray tupleSort |
+	projNames := projAssocs collect: #key.
+	projSorts := projAssocs collect: #value.
+	mkTupleDeclArray := Array new: 1.
+	projDeclCell set: (Array new: projAssocs size).
+	tupleSort := Z3
+		mk_tuple_sort: self
+		_: constructorName toZ3Symbol
+		_: projAssocs size
+		_: (projNames collect: #toZ3Symbol)
+		_: projSorts
+		_: mkTupleDeclArray
+		_: projDeclCell get.
+	tupleDeclCell set: mkTupleDeclArray anyOne.
+	^tupleSort
 ]
 
 { #category : #'API wrappers' }

--- a/src/Z3/Z3DatatypeSort.class.st
+++ b/src/Z3/Z3DatatypeSort.class.st
@@ -7,7 +7,38 @@ Class {
 	#category : #'Z3-Core'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation - convenience' }
+Z3DatatypeSort class >> mkEnumerationSort: enumName elements: elements consts: consts testers: testers [
+	^Z3Context current
+		mkEnumerationSort: enumName
+		elements: elements
+		consts: consts
+		testers: testers
+]
+
+{ #category : #'instance creation - convenience' }
+Z3DatatypeSort class >> mkListSort: listName elementSort: elementSort nilDecl: nilDecl isNilDecl: isNilDecl consDecl: consDecl isConsDecl: isConsDecl headDecl: headDecl tailDecl: tailDecl [
+	^Z3Context current
+		mkListSort: listName
+		elementSort: elementSort
+		nilDecl: nilDecl
+		isNilDecl: isNilDecl
+		consDecl: consDecl
+		isConsDecl: isConsDecl
+		headDecl: headDecl
+		tailDecl: tailDecl
+]
+
+{ #category : #'instance creation - convenience' }
+Z3DatatypeSort class >> mkTupleSort: constructorName projections: projAssocs mkTupleDecl: tupleDeclCell projDecls: projDeclCell [
+	^Z3Context current
+		mkTupleSort: constructorName
+		projections: projAssocs
+		mkTupleDecl: tupleDeclCell
+		projDecls: projDeclCell
+]
+
+{ #category : #accessing }
 Z3DatatypeSort >> accessor: i idx: j [ 
 	^ Z3 get_datatype_sort_constructor_accessor: ctx _: self _: i _: j
 ]
@@ -28,7 +59,7 @@ Z3DatatypeSort >> cast: val [
 	^val toDatatype: self
 ]
 
-{ #category : #'F-Algebra' }
+{ #category : #accessing }
 Z3DatatypeSort >> constructor: idx [
  	"Answer a constructor of the datatype self.
 	 NB: idx follows Z3's 0-based convention.
@@ -36,7 +67,7 @@ Z3DatatypeSort >> constructor: idx [
 	^ Z3 get_datatype_sort_constructor: ctx _: self _: idx
 ]
 
-{ #category : #'F-Algebra' }
+{ #category : #accessing }
 Z3DatatypeSort >> constructors [
 	^(1 to: self numConstructors) collect: [ :i | self constructor: i-1 ]
 ]
@@ -51,23 +82,61 @@ Z3DatatypeSort >> doesNotUnderstand: aMessage [
 	^fn valueWithArguments: convertedArgs
 ]
 
+{ #category : #accessing }
+Z3DatatypeSort >> getTupleSortFieldDecl: i [
+	^Z3 get_tuple_sort_field_decl: ctx _: self _: i
+]
+
+{ #category : #accessing }
+Z3DatatypeSort >> getTupleSortNumFields [
+	^Z3 get_tuple_sort_num_fields: ctx _: self
+]
+
+{ #category : #GT }
+Z3DatatypeSort >> gtInspectorConstructorsIn: composite [
+	<gtInspectorPresentationOrder: 40>
+	self isTuple ifTrue: [ ^nil ].
+	composite fastList
+		title: 'Constructors';
+		display: [ self constructors ]
+]
+
+{ #category : #GT }
+Z3DatatypeSort >> gtInspectorTupleFieldsIn: composite [
+	<gtInspectorPresentationOrder: 41>
+	self isTuple ifFalse: [ ^nil ].
+	composite fastList
+		title: 'Fields';
+		display: [ self tupleFields ]
+]
+
+{ #category : #accessing }
+Z3DatatypeSort >> isTuple [
+	^self numConstructors = 1
+]
+
 { #category : #'type theory' }
 Z3DatatypeSort >> nodeClass [
 	^ Datatype
 
 ]
 
-{ #category : #'F-Algebra' }
+{ #category : #accessing }
 Z3DatatypeSort >> numConstructors [
 	^ Z3 get_datatype_sort_num_constructors: ctx _: self
 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 Z3DatatypeSort >> recognizer: idx [
 	"In Z3, each constructor has an associated recognizer predicate.                                                          
 	 If the constructor is named `name`, then the recognizer `is_name`.
 	 NB: idx follows Z3's 0-based convention.
 	"	
 	^ Z3 get_datatype_sort_recognizer: ctx _: self _: idx
+]
+
+{ #category : #accessing }
+Z3DatatypeSort >> tupleFields [
+	^(1 to: self getTupleSortNumFields) collect: [ :j | self getTupleSortFieldDecl: j-1 ]
 ]


### PR DESCRIPTION
As a convenience to the C programmer, Z3 has some pre-written C/C++ for commonly-met-with algebraic datatypes.  ADTs are polynomial type constructors: x×y×z+….
"Tuples" are monomial (i.e. 1-injection) datatypes. "Enumerations" are 0-degree polynomials.  "List" provides convenience C code for the standard "nil+cons" construction.

This commit also implements related Z3CAPITests which previously either lived in Z3CAPITODOTest or were missing altogether.