### PR TITLE
[Z3] Add programmatic access to error code and error message

### DIFF
--- a/src/Z3-Tests/Z3CAPITest.class.st
+++ b/src/Z3-Tests/Z3CAPITest.class.st
@@ -4,6 +4,9 @@ Tests equivalent to z3/examples/c/test_capi.c
 Class {
 	#name : #Z3CAPITest,
 	#superclass : #TestCaseWithZ3Context,
+	#pools : [
+		'Z3ErrorCode'
+	],
 	#category : #'Z3-Tests'
 }
 
@@ -283,8 +286,15 @@ Z3CAPITest >> testErrorHandling1 [
 	
 	zero := 0 toInt.
 	ten := 10 toInt.
-	
-	self should: [bvsge := Z3 mk_bvsge: zero ctx _: zero _: ten] raise: Z3Error
+
+	[
+		bvsge := Z3 mk_bvsge: zero ctx _: zero _: ten.
+		self assert: false description: 'Should raise Z3Error'.
+	] on: Z3Error do: [:err|
+		self assert: err code ~~ OK.
+		self assert: err messageText notNil.
+		self assert: err messageText notEmpty.
+	].
 ]
 
 { #category : #tests }

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -73,16 +73,15 @@ Z3Context >> delete [
 
 { #category : #'error handling' }
 Z3Context >> errorCheck [
-	| error |
+	| code |
 
-	error := Z3 get_error_code: self.
-	error ~~ OK ifTrue: [ 
-		| message |
-
-		message := Z3 get_error_msg: self _: error.
-		Z3Error signal: 'Z3 error ' , error printString , ': ' , message
+	code := Z3 get_error_code: self.
+	code ~~ OK ifTrue: [
+		Z3Error new
+			code: code;
+			messageText: (Z3 get_error_msg: self _: code);
+			signal
 	].
-
 ]
 
 { #category : #'initialization & release' }

--- a/src/Z3/Z3Error.class.st
+++ b/src/Z3/Z3Error.class.st
@@ -1,5 +1,23 @@
 Class {
 	#name : #Z3Error,
 	#superclass : #Error,
+	#instVars : [
+		'code'
+	],
 	#category : #'Z3-Core'
 }
+
+{ #category : #'instance creation' }
+Z3Error class >> code: anInteger [
+	^ self new code: anInteger
+]
+
+{ #category : #accessing }
+Z3Error >> code [
+	^ code
+]
+
+{ #category : #initialization }
+Z3Error >> code: anInteger [
+	code := anInteger.
+]


### PR DESCRIPTION
This commit `Z3Error` to keep original error code in an instvar. To access it in error handler, use `#code`. To access error message, use `#messageText`.