### PR TITLE
Fix incorrect name TC>>sym, it must be #symbol

### DIFF
--- a/src/Refinements/FApp.class.st
+++ b/src/Refinements/FApp.class.st
@@ -124,7 +124,7 @@ FApp >> t: anObject [
 { #category : #hotel }
 FApp >> z3sort [
 	| j |
-	( (s isKindOf: FTC) and: [ s typeConstructor sym = 'Set_Set' ] ) ifTrue: [
+	( (s isKindOf: FTC) and: [ s typeConstructor symbol = 'Set_Set' ] ) ifTrue: [
 		^t z3sort mkSetSort
 	].
 	

--- a/src/Refinements/FTycon.class.st
+++ b/src/Refinements/FTycon.class.st
@@ -11,7 +11,7 @@ symbolFTycon :: LocSymbol -> FTycon
 symbolFTycon c = symbolNumInfoFTyCon c defNumInfo defRealInfo
 "
 	^TC basicNew
-		sym: c;
+		symbol: c;
 		yourself
 ]
 

--- a/src/Refinements/TC.class.st
+++ b/src/Refinements/TC.class.st
@@ -2,7 +2,7 @@ Class {
 	#name : #TC,
 	#superclass : #FTycon,
 	#instVars : [
-		'sym'
+		'symbol'
 	],
 	#category : #Refinements
 }
@@ -14,7 +14,7 @@ instance Eq FTycon where
   (TC s _) == (TC s' _) = val s == val s'
 "
 	self class = rhs class ifFalse: [ ^false ].
-	^sym = rhs sym
+	^symbol = rhs symbol
 ]
 
 { #category : #'as yet unclassified' }
@@ -24,26 +24,26 @@ TC >> fTyconSort [
 
 { #category : #comparing }
 TC >> hash [
-	^sym hash
+	^symbol hash
 ]
 
 { #category : #'as yet unclassified' }
 TC >> isListTC [
-	^sym isListConName
+	^symbol isListConName
 ]
 
 { #category : #printing }
 TC >> printOn: aStream [
 	aStream nextPutAll: 'TC '.
-	aStream nextPutAll: sym
+	aStream nextPutAll: symbol
 ]
 
 { #category : #accessing }
-TC >> sym [
-	^ sym
+TC >> symbol [
+	^ symbol
 ]
 
 { #category : #accessing }
-TC >> sym: anObject [
-	sym := anObject
+TC >> symbol: anObject [
+	symbol := anObject
 ]


### PR DESCRIPTION
We have no leeway what to call it, because FTycon must be member of the Symbolic typeclass for the construction of dEnv in #symEnv to work.