### PR TITLE
CI: disable Windows for schedule builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os:
+          - ubuntu-latest
+          - windows-latest
         dialect: [ pharo ]
         scheduled:
-          - ${{ github.event_name == 'schedule' }}
+           - ${{ github.event_name == 'schedule' }}
         exclude:
-          # We only run tests on Windows on scheduled builds
-          # as they take longer and slows down PR checks.
-          - scheduled: false
-            os: windows-latest
+           # We only run tests on Windows on scheduled builds
+           # as they take longer and slows down PR checks.
+           - scheduled: false
+             os: windows-latest
+
+           # No, do not run tests on Windows not even for scheduled builds.
+           # Builds were consistently failing for unknown reason and until
+           # someone would actively use Windows, we do not bother to fix it.
+           - scheduled: true
+             os: windows-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
This commit removes CI checks for Windows even for scheduled builds. These builds were consistently failing and are hard to debug as one does not have an access to the build node itself.

At the moment nobody is using MA on Windows. Once somebody active shows up we may fix Windows again.

Implementation note: I could have just as well removed all that `scheduled:` and `exclude:` config from build matrix, but I decided to keep it there in case we will want to enable Windows again in the future.