### PR TITLE
Port LiquidFixpoint's FQ ("new-format") tests

### DIFF
--- a/src/Refinements-Parsing/DecidableRefinement.extension.st
+++ b/src/Refinements-Parsing/DecidableRefinement.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #DecidableRefinement }
+
+{ #category : #'*Refinements-Parsing' }
+DecidableRefinement class >> parser [
+	^ RefinementExpressionParser new
+	==> [ :x | self text: x formattedCode ]
+]

--- a/src/Refinements-Parsing/FQParser.class.st
+++ b/src/Refinements-Parsing/FQParser.class.st
@@ -21,6 +21,7 @@ FQParser >> bind [
 FQParser >> constraint [
 	^ 'constraint:' asParser trim
 	, subC
+	==> #second
 ]
 
 { #category : #grammar }
@@ -41,8 +42,7 @@ FQParser >> ref: kind [
 "
 -- | (Sorted) Refinements
 "
-	^(self refBind: bind rp: refa kind: kind)
-	==> [ :x | x halt ]
+	^self refBind: bind rp: refa kind: kind
 ]
 
 { #category : #grammar }
@@ -50,12 +50,12 @@ FQParser >> refBind: bp rp: rp kind: kindP [
 "
 -- (Sorted) Refinements with configurable sub-parsers
 "
-	^${ asParser,
+	^(
 		bp trim,
 		kindP trim,
 		'|' asParser trim,
-		rp,
-		$} asParser
+		rp
+	) braces
 	==> [ :x | x second value: (Reft symbol: x first expr: x fourth) ]
 ]
 
@@ -84,12 +84,18 @@ FQParser >> start [
 
 { #category : #grammar }
 FQParser >> subC [
-	^ 'env []' asParser trim
+	^ ('env []' asParser trim ==> [ :_ | IBindEnv empty])
 	, 'lhs' asParser trim, sortedReft trim
 	, 'rhs' asParser trim, sortedReft trim
 	, 'id'  asParser, Character space asParser plus, PPParser decimalNat trim
 	, self tag
-	==> [ :x | x halt ]
+	==> [ :x | SubC
+			mkSubC: x first
+			lhs: x third
+			rhs: x fifth
+			i: x eighth
+			tag: x ninth
+	]
 ]
 
 { #category : #grammar }

--- a/src/Refinements-Parsing/FQParser.class.st
+++ b/src/Refinements-Parsing/FQParser.class.st
@@ -1,5 +1,101 @@
 Class {
 	#name : #FQParser,
 	#superclass : #FixpointParser,
+	#instVars : [
+		'subC',
+		'bind',
+		'refa',
+		'sortedReft'
+	],
 	#category : #'Refinements-Parsing'
 }
+
+{ #category : #grammar }
+FQParser >> bind [
+	^ self class lowerId trim,
+	$: asParser
+	==> #first
+]
+
+{ #category : #grammar }
+FQParser >> constraint [
+	^ 'constraint:' asParser trim
+	, subC
+]
+
+{ #category : #grammar }
+FQParser >> def [
+	^ self fixpoint
+	/ self constraint
+	/ 'everything else' asParser
+]
+
+{ #category : #grammar }
+FQParser >> fInfo [
+	^ self def trim plus
+	==> [ :x | FInfo defsFInfo: x ]
+]
+
+{ #category : #grammar }
+FQParser >> ref: kind [
+"
+-- | (Sorted) Refinements
+"
+	^(self refBind: bind rp: refa kind: kind)
+	==> [ :x | x halt ]
+]
+
+{ #category : #grammar }
+FQParser >> refBind: bp rp: rp kind: kindP [
+"
+-- (Sorted) Refinements with configurable sub-parsers
+"
+	^${ asParser,
+		bp trim,
+		kindP trim,
+		'|' asParser trim,
+		rp,
+		$} asParser
+	==> [ :x | x second value: (Reft symbol: x first expr: x fourth) ]
+]
+
+{ #category : #grammar }
+FQParser >> refa [
+"
+-- | Refa
+refaP :: Parser Expr
+refaP =  try (pAnd <$> brackets (sepBy predP semi))
+     <|> predP
+Cf. top-level Parse.hs
+"
+	^".... and .... | "
+	pred
+]
+
+{ #category : #grammar }
+FQParser >> sortedReft [
+	^ self ref: (sort ==> [ :aSort | [ :r | SortedReft sort: aSort reft: r ]])
+]
+
+{ #category : #grammar }
+FQParser >> start [
+	^self fInfo trim end
+]
+
+{ #category : #grammar }
+FQParser >> subC [
+	^ 'env []' asParser trim
+	, 'lhs' asParser trim, sortedReft trim
+	, 'rhs' asParser trim, sortedReft trim
+	, 'id'  asParser, Character space asParser plus, PPParser decimalNat trim
+	, self tag
+	==> [ :x | x halt ]
+]
+
+{ #category : #grammar }
+FQParser >> tag [
+	^ 'tag' asParser
+	, Character space asParser
+	, PPParser decimalNat semicolonSeparated brackets
+	==> [ :x | x third ]
+]

--- a/src/Refinements-Parsing/FQParser.class.st
+++ b/src/Refinements-Parsing/FQParser.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #FQParser,
+	#superclass : #FixpointParser,
+	#category : #'Refinements-Parsing'
+}

--- a/src/Refinements-Parsing/FixpointParser.class.st
+++ b/src/Refinements-Parsing/FixpointParser.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #FixpointParser,
+	#superclass : #PPCompositeParser,
+	#category : #'Refinements-Parsing'
+}

--- a/src/Refinements-Parsing/FixpointParser.class.st
+++ b/src/Refinements-Parsing/FixpointParser.class.st
@@ -2,7 +2,11 @@ Class {
 	#name : #FixpointParser,
 	#superclass : #PPCompositeParser,
 	#instVars : [
-		'matchedParen'
+		'matchedParen',
+		'sort',
+		'sortArg',
+		'funcSort',
+		'pred'
 	],
 	#category : #'Refinements-Parsing'
 }
@@ -15,6 +19,15 @@ FixpointParser class >> lowerId [
 { #category : #grammar }
 FixpointParser class >> upperId [
 	^(#uppercase asParser, (#word asParser / $_ asParser) star) flatten
+]
+
+{ #category : #grammar }
+FixpointParser >> fTyCon [
+	^ ('Int' asParser ==> [ :x | Int tyCon ])
+	/ ('int' asParser ==> [ :x | Int tyCon ])
+	/ ('Bool' asParser ==> [ :x | Bool tyCon ])
+	/ ('bool' asParser ==> [ :x | Bool tyCon ])
+	/ (NNFParser upperId ==> #symbolFTycon)
 ]
 
 { #category : #grammar }
@@ -34,9 +47,47 @@ FixpointParser >> fixpoint [
 	
 ]
 
+{ #category : #grammar }
+FixpointParser >> funcSort [
+	"Parser for function sorts without the 'func' keyword"
+	^(
+	PPParser decimalNat,
+	$, asParser trim,
+	sort semicolonSeparated brackets
+	) parens
+	==> [ :x | Z3Sort mkFFunc: x first sorts: x third ]
+]
+
 { #category : #'grammar - util' }
 FixpointParser >> matchedParen [
 	^(PPParser nonParen / matchedParen parens) plus flatten
+]
+
+{ #category : #grammar }
+FixpointParser >> pred [
+	^ matchedParen
+	==> [ :x | DecidableRefinement text: x ]
+]
+
+{ #category : #grammar }
+FixpointParser >> sort [
+	^ self sort′: sortArg trim star
+]
+
+{ #category : #grammar }
+FixpointParser >> sortArg [
+	^ self sort′: nil asParser
+]
+
+{ #category : #grammar }
+FixpointParser >> sort′: aSortArgParser [
+	| sap |
+	sap := aSortArgParser ==> [ :args | args ifNil: [ #() ] ]. "aSortArgParser can be EpsilonParser"
+	^ sort parens
+	/ ('func' asParser, funcSort ==> [ :x | x second ])
+	/ (sort brackets ==> [ :x | x shouldBeImplemented listFTyCon  ])
+	/ (self fTyCon trim, sap ==> [ :x | x first fAppTC: x second ])
+	/ (self tvar trim, sap ==> [ :x | x first fApp: x second ])
 ]
 
 { #category : #grammar }
@@ -46,4 +97,16 @@ FixpointParser >> tok [
 					(ch isSeparator or: [ ch == $( or: [ ch == $) ]]) not ])
 		message: 'Token expected') plus flatten
 		
+]
+
+{ #category : #grammar }
+FixpointParser >> tvar [
+	^ self varSort
+	/ ($` asParser, #lowercase asParser ==> [ :x | Z3Sort uninterpretedSortNamed: (String with: x second) ])
+]
+
+{ #category : #grammar }
+FixpointParser >> varSort [
+	^'@(' asParser, PPParser decimalInteger, ')' asParser
+	==> [ :x | FVar new: x second ]
 ]

--- a/src/Refinements-Parsing/FixpointParser.class.st
+++ b/src/Refinements-Parsing/FixpointParser.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : #FixpointParser,
 	#superclass : #PPCompositeParser,
 	#instVars : [
-		'matchedParen',
 		'sort',
 		'sortArg',
 		'funcSort',
@@ -58,15 +57,10 @@ FixpointParser >> funcSort [
 	==> [ :x | Z3Sort mkFFunc: x first sorts: x third ]
 ]
 
-{ #category : #'grammar - util' }
-FixpointParser >> matchedParen [
-	^(PPParser nonParen / matchedParen parens) plus flatten
-]
-
 { #category : #grammar }
 FixpointParser >> pred [
-	^ matchedParen
-	==> [ :x | DecidableRefinement text: x ]
+	^ RefinementExpressionParser new
+	==> [ :x | DecidableRefinement text: x formattedCode ]
 ]
 
 { #category : #grammar }

--- a/src/Refinements-Parsing/FixpointParser.class.st
+++ b/src/Refinements-Parsing/FixpointParser.class.st
@@ -8,6 +8,16 @@ Class {
 }
 
 { #category : #grammar }
+FixpointParser class >> lowerId [
+	^(#lowercase asParser, (#word asParser / $_ asParser) star) flatten
+]
+
+{ #category : #grammar }
+FixpointParser class >> upperId [
+	^(#uppercase asParser, (#word asParser / $_ asParser) star) flatten
+]
+
+{ #category : #grammar }
 FixpointParser >> fixpoint [
 	^'fixpoint' asParser trim,
 	'"--' asParser,

--- a/src/Refinements-Parsing/FixpointParser.class.st
+++ b/src/Refinements-Parsing/FixpointParser.class.st
@@ -3,3 +3,20 @@ Class {
 	#superclass : #PPCompositeParser,
 	#category : #'Refinements-Parsing'
 }
+
+{ #category : #grammar }
+FixpointParser >> fixpoint [
+	^'fixpoint' asParser trim,
+	'"--' asParser,
+	('eliminate' asParser / 'rewrite' asParser / 'save' asParser / 'fuel' asParser),
+	($= asParser, #word asParser plus flatten) optional,
+	$" asParser
+	==> [ :x |
+		| selector |
+		selector := x third asSymbol.
+		x fourth isNil
+			ifTrue: [ HOpt perform: selector ]
+			ifFalse: [ HOpt perform: selector, ':' with: x fourth second ]
+	]
+	
+]

--- a/src/Refinements-Parsing/FixpointParser.class.st
+++ b/src/Refinements-Parsing/FixpointParser.class.st
@@ -59,8 +59,7 @@ FixpointParser >> funcSort [
 
 { #category : #grammar }
 FixpointParser >> pred [
-	^ RefinementExpressionParser new
-	==> [ :x | DecidableRefinement text: x formattedCode ]
+	^DecidableRefinement parser
 ]
 
 { #category : #grammar }

--- a/src/Refinements-Parsing/FixpointParser.class.st
+++ b/src/Refinements-Parsing/FixpointParser.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #FixpointParser,
 	#superclass : #PPCompositeParser,
+	#instVars : [
+		'matchedParen'
+	],
 	#category : #'Refinements-Parsing'
 }
 
@@ -19,4 +22,18 @@ FixpointParser >> fixpoint [
 			ifFalse: [ HOpt perform: selector, ':' with: x fourth second ]
 	]
 	
+]
+
+{ #category : #'grammar - util' }
+FixpointParser >> matchedParen [
+	^(PPParser nonParen / matchedParen parens) plus flatten
+]
+
+{ #category : #grammar }
+FixpointParser >> tok [
+	^(PPPredicateObjectParser
+		on: (PPCharSetPredicate on: [ :ch |
+					(ch isSeparator or: [ ch == $( or: [ ch == $) ]]) not ])
+		message: 'Token expected') plus flatten
+		
 ]

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -3,8 +3,6 @@ Class {
 	#superclass : #FixpointParser,
 	#instVars : [
 		'constraint',
-		'forall',
-		'exists',
 		'hCstr',
 		'var',
 		'sort',
@@ -72,28 +70,12 @@ NNFParser >> define [
 ]
 
 { #category : #grammar }
-NNFParser >> exists [
-	^'exists' asParser trim,
-	hBind trim,
-	hCstr trim
-	==> [ :x | CstrAny bind: x second p: x third ]
-]
-
-{ #category : #grammar }
 NNFParser >> fTyCon [
 	^ ('Int' asParser ==> [ :x | Int tyCon ])
 	/ ('int' asParser ==> [ :x | Int tyCon ])
 	/ ('Bool' asParser ==> [ :x | Bool tyCon ])
 	/ ('bool' asParser ==> [ :x | Bool tyCon ])
 	/ (NNFParser upperId ==> [ :x | x symbolFTycon ])
-]
-
-{ #category : #grammar }
-NNFParser >> forall [
-	^'forall' asParser trim,
-	hBind trim,
-	hCstr
-	==> [ :x | CstrAll bind: x second p: x third ]
 ]
 
 { #category : #grammar }
@@ -117,8 +99,8 @@ NNFParser >> hBind [
 NNFParser >> hCstr [
 	^(
 		  ('and' asParser trim, hCstr trim star ==> [ :x | CstrAnd of: x second ])
-		/ forall
-		/ exists
+		/ ('forall' asParser trim, hBind trim, hCstr trim ==> [ :x | CstrAll bind: x second p: x third ])
+		/ ('exists' asParser trim, hBind trim, hCstr trim ==> [ :x | CstrAny bind: x second p: x third ])
 		/ cstrPred
 	) parens
 ]

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -3,7 +3,6 @@ Class {
 	#superclass : #FixpointParser,
 	#instVars : [
 		'constraint',
-		'tok',
 		'thing',
 		'cstrAnd',
 		'forall',
@@ -20,7 +19,6 @@ Class {
 		'kappa',
 		'predAnd',
 		'decidablePred',
-		'matchedParen',
 		'cstrPred',
 		'funcSort',
 		'sortArg',
@@ -42,7 +40,7 @@ NNFParser class >> upperId [
 { #category : #grammar }
 NNFParser >> constant [
 	^'constant' asParser trim,
-	tok trim, "name"
+	self tok trim, "name"
 	sort
 	==> [ :x | HCon symbol: x second sort: x third ]
 	
@@ -83,8 +81,8 @@ NNFParser >> define [
 	"Function definition equations (PLE).
 	 Cf. top-level Parse.hs"
 	^'define' asParser trim,
-	tok trim, "name"
-	(tok trim, $: asParser trim, sort ==> [ :eachArg | eachArg first -> eachArg last ]) commaList trim,
+	self tok trim, "name"
+	(self tok trim, $: asParser trim, sort ==> [ :eachArg | eachArg first -> eachArg last ]) commaList trim,
 	$: asParser trim,
 	sort,
 	'=' asParser trim,
@@ -149,13 +147,8 @@ NNFParser >> kappa [
 { #category : #grammar }
 NNFParser >> kappaApp [
 	^(kappa,
-	((#blank asParser plus), tok ==> [:x| x second]) plus) trim
+	((#blank asParser plus), self tok ==> [:x| x second]) plus) trim
 	==> [ :x | RefVarApp var: x first args: x second ]
-]
-
-{ #category : #'grammar - util' }
-NNFParser >> matchedParen [
-	^(PPParser nonParen / matchedParen parens) plus flatten
 ]
 
 { #category : #grammar }
@@ -211,21 +204,12 @@ NNFParser >> start [
 
 { #category : #'grammar - util' }
 NNFParser >> symSort [
-	^tok trim, sort
+	^self tok trim, sort
 ]
 
 { #category : #grammar }
 NNFParser >> thing [
 	^(constraint / var / qualif / constant / self fixpoint / define "match data") parens
-]
-
-{ #category : #'grammar - util' }
-NNFParser >> tok [
-	^(PPPredicateObjectParser
-		on: (PPCharSetPredicate on: [ :ch |
-					(ch isSeparator or: [ ch == $( or: [ ch == $) ]]) not ])
-		message: 'Token expected') plus flatten
-		
 ]
 
 { #category : #grammar }

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -3,7 +3,6 @@ Class {
 	#superclass : #FixpointParser,
 	#instVars : [
 		'constraint',
-		'cstrAnd',
 		'forall',
 		'exists',
 		'hCstr',
@@ -41,12 +40,6 @@ NNFParser >> constraint [
 	hCstr
 	==> [ :x | x second ]
 	
-]
-
-{ #category : #grammar }
-NNFParser >> cstrAnd [
-	^'and' asParser trim,
-	hCstr trim star ==> [ :x | CstrAnd of: x second ]
 ]
 
 { #category : #grammar }
@@ -123,7 +116,7 @@ NNFParser >> hBind [
 { #category : #grammar }
 NNFParser >> hCstr [
 	^(
-		  cstrAnd
+		  ('and' asParser trim, hCstr trim star ==> [ :x | CstrAnd of: x second ])
 		/ forall
 		/ exists
 		/ cstrPred

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -3,7 +3,6 @@ Class {
 	#superclass : #FixpointParser,
 	#instVars : [
 		'hCstr',
-		'var',
 		'sort',
 		'hBind',
 		'symSort',
@@ -97,7 +96,7 @@ NNFParser >> hQualifier [
 NNFParser >> hThing [
 	^(
 		  ('constraint' asParser trim, hCstr ==> #second)
-		/ var
+		/ self hVar
 		/ self hQualifier
 		/ ('constant' asParser trim, self tok trim, sort ==> [ :x | HCon symbol: x second sort: x third ])
 		/ self fixpoint
@@ -105,6 +104,15 @@ NNFParser >> hThing [
 		" / match"
 		" / data"
 	) parens
+]
+
+{ #category : #grammar }
+NNFParser >> hVar [
+	^'var' asParser trim,
+	self kvSym trim,
+	sort parens trim plus parens
+	==> [ :x | HVar name: x second argSorts: x third ]
+	
 ]
 
 { #category : #grammar }
@@ -155,15 +163,6 @@ NNFParser >> symSort [
 NNFParser >> tvar [
 	^ self varSort
 	/ ($` asParser, #lowercase asParser ==> [ :x | Z3Sort uninterpretedSortNamed: (String with: x second) ])
-]
-
-{ #category : #grammar }
-NNFParser >> var [
-	^'var' asParser trim,
-	self kvSym trim,
-	sort parens trim plus parens
-	==> [ :x | HVar name: x second argSorts: x third ]
-	
 ]
 
 { #category : #grammar }

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -10,8 +10,6 @@ Class {
 		'constant',
 		'hBind',
 		'symSort',
-		'kappaApp',
-		'kappa',
 		'decidablePred',
 		'hPred',
 		'funcSort',
@@ -103,7 +101,7 @@ NNFParser >> hCstr [
 NNFParser >> hPred [
 	^(
 		  ('and' asParser, 	(#blank asParser plus, hPred ==> #second) star ==> [ :x | HPredAnd of: x second ])
-		/ kappaApp
+		/ (self kvSym, ((#blank asParser plus), self tok ==> [:x| x second]) plus ==> [ :x | RefVarApp var: x first args: x second ])
 		/ decidablePred
 	) parens
 ]
@@ -114,17 +112,10 @@ NNFParser >> hThing [
 ]
 
 { #category : #grammar }
-NNFParser >> kappa [
+NNFParser >> kvSym [
 	^('$' asParser,
 	($# asParser ==> [:x|$º] / #word asParser / $_ asParser) plus)
 	==> [ :x | String withAll: x second ]
-]
-
-{ #category : #grammar }
-NNFParser >> kappaApp [
-	^(kappa,
-	((#blank asParser plus), self tok ==> [:x| x second]) plus) trim
-	==> [ :x | RefVarApp var: x first args: x second ]
 ]
 
 { #category : #grammar }
@@ -180,7 +171,7 @@ NNFParser >> tvar [
 { #category : #grammar }
 NNFParser >> var [
 	^'var' asParser trim,
-	kappa trim,
+	self kvSym trim,
 	sort parens trim plus parens
 	==> [ :x | HVar name: x second argSorts: x third ]
 	

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : #NNFParser,
 	#superclass : #FixpointParser,
 	#instVars : [
-		'fixpoint',
 		'constraint',
 		'tok',
 		'thing',
@@ -116,23 +115,6 @@ NNFParser >> fTyCon [
 ]
 
 { #category : #grammar }
-NNFParser >> fixpoint [
-	^'fixpoint' asParser trim,
-	'"--' asParser,
-	('eliminate' asParser / 'rewrite' asParser / 'save' asParser / 'fuel' asParser),
-	($= asParser, #word asParser plus flatten) optional,
-	$" asParser
-	==> [ :x |
-		| selector |
-		selector := x third asSymbol.
-		x fourth isNil
-			ifTrue: [ HOpt perform: selector ]
-			ifFalse: [ HOpt perform: selector, ':' with: x fourth second ]
-	]
-	
-]
-
-{ #category : #grammar }
 NNFParser >> forall [
 	^'forall' asParser trim,
 	hBind parens trim,
@@ -234,7 +216,7 @@ NNFParser >> symSort [
 
 { #category : #grammar }
 NNFParser >> thing [
-	^(constraint / var / qualif / constant / fixpoint / define "match data") parens
+	^(constraint / var / qualif / constant / self fixpoint / define "match data") parens
 ]
 
 { #category : #'grammar - util' }

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -122,7 +122,7 @@ NNFParser >> funcSort [
 
 { #category : #grammar }
 NNFParser >> hBind [
-	^symSort parens trim, pred parens
+	^symSort trim, pred parens
 	==> [ :x | HBind x: x first first τ: x first second p: x second ]
 ]
 
@@ -161,7 +161,7 @@ NNFParser >> predAnd [
 NNFParser >> qualif [
 	^'qualif' asParser trim,
 	NNFParser upperId trim, "name"
-	symSort parens trim plus parens trim, "params"
+	symSort trim plus parens trim, "params"
 	pred parens "body"
 	==> [ :x | Qualifier
 		name: x second
@@ -198,7 +198,7 @@ NNFParser >> start [
 
 { #category : #'grammar - util' }
 NNFParser >> symSort [
-	^self tok trim, sort
+	^(self tok trim, sort) parens
 ]
 
 { #category : #grammar }

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : #NNFParser,
 	#superclass : #FixpointParser,
 	#instVars : [
-		'constraint',
 		'hCstr',
 		'var',
 		'sort',
@@ -16,14 +15,6 @@ Class {
 	],
 	#category : #'Refinements-Parsing'
 }
-
-{ #category : #grammar }
-NNFParser >> constraint [
-	^'constraint' asParser trim,
-	hCstr
-	==> [ :x | x second ]
-	
-]
 
 { #category : #grammar }
 NNFParser >> define [
@@ -105,7 +96,7 @@ NNFParser >> hQualifier [
 { #category : #grammar }
 NNFParser >> hThing [
 	^(
-		  constraint
+		  ('constraint' asParser trim, hCstr ==> #second)
 		/ var
 		/ self hQualifier
 		/ ('constant' asParser trim, self tok trim, sort ==> [ :x | HCon symbol: x second sort: x third ])

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -3,7 +3,6 @@ Class {
 	#superclass : #FixpointParser,
 	#instVars : [
 		'constraint',
-		'thing',
 		'cstrAnd',
 		'forall',
 		'exists',
@@ -128,6 +127,11 @@ NNFParser >> hBind [
 ]
 
 { #category : #grammar }
+NNFParser >> hThing [
+	^(constraint / var / qualif / constant / self fixpoint / define "match data") parens
+]
+
+{ #category : #grammar }
 NNFParser >> kappa [
 	^('$' asParser,
 	($# asParser ==> [:x|$º] / #word asParser / $_ asParser) plus)
@@ -189,17 +193,12 @@ NNFParser >> sort′: aSortArgParser [
 
 { #category : #grammar }
 NNFParser >> start [
-	^thing trim star end ==> [ :x | HornQuery fromThings: x ]
+	^self hThing trim star end ==> [ :x | HornQuery fromThings: x ]
 ]
 
 { #category : #'grammar - util' }
 NNFParser >> symSort [
 	^self tok trim, sort
-]
-
-{ #category : #grammar }
-NNFParser >> thing [
-	^(constraint / var / qualif / constant / self fixpoint / define "match data") parens
 ]
 
 { #category : #grammar }

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -12,7 +12,6 @@ Class {
 		'symSort',
 		'kappaApp',
 		'kappa',
-		'predAnd',
 		'decidablePred',
 		'hPred',
 		'funcSort',
@@ -103,7 +102,7 @@ NNFParser >> hCstr [
 { #category : #grammar }
 NNFParser >> hPred [
 	^(
-		  predAnd
+		  ('and' asParser, 	(#blank asParser plus, hPred ==> #second) star ==> [ :x | HPredAnd of: x second ])
 		/ kappaApp
 		/ decidablePred
 	) parens
@@ -126,13 +125,6 @@ NNFParser >> kappaApp [
 	^(kappa,
 	((#blank asParser plus), self tok ==> [:x| x second]) plus) trim
 	==> [ :x | RefVarApp var: x first args: x second ]
-]
-
-{ #category : #grammar }
-NNFParser >> predAnd [
-	^'and' asParser,
-	(#blank asParser plus, hPred ==> [:x| x second]) star 
-	==> [ :x | HPredAnd of: x second ]
 ]
 
 { #category : #grammar }

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -15,7 +15,7 @@ Class {
 		'kappa',
 		'predAnd',
 		'decidablePred',
-		'cstrPred',
+		'hPred',
 		'funcSort',
 		'sortArg',
 		'define'
@@ -38,11 +38,6 @@ NNFParser >> constraint [
 	hCstr
 	==> [ :x | x second ]
 	
-]
-
-{ #category : #grammar }
-NNFParser >> cstrPred [
-	^pred parens ==> [ :x | CstrHead pred: x ]
 ]
 
 { #category : #grammar }
@@ -102,7 +97,14 @@ NNFParser >> hCstr [
 		/ ('forall' asParser trim, hBind trim, hCstr trim ==> [ :x | CstrAll bind: x second p: x third ])
 		/ ('exists' asParser trim, hBind trim, hCstr trim ==> [ :x | CstrAny bind: x second p: x third ])
 		"TODO: / tag"
-		/ cstrPred
+		/ (hPred ==> [ :x | CstrHead pred: x ])
+	) parens
+]
+
+{ #category : #grammar }
+NNFParser >> hPred [
+	^(
+		pred "will inline this"
 	) parens
 ]
 

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -21,11 +21,11 @@ NNFParser >> define [
 	$: asParser trim,
 	sort,
 	'=' asParser trim,
-	(RefinementExpressionParser new braces ==> [ :seq | seq formattedCode ])
+	(DecidableRefinement parser braces)
 	==> [ :x | Equation
 					mkEquation: x second
 					args: x third
-					expr: (DecidableRefinement text: x seventh)
+					expr: x seventh
 					sort: x fifth ]
 ]
 

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -10,7 +10,6 @@ Class {
 		'constant',
 		'hBind',
 		'symSort',
-		'pred',
 		'kappaApp',
 		'kappa',
 		'predAnd',
@@ -86,7 +85,7 @@ NNFParser >> funcSort [
 
 { #category : #grammar }
 NNFParser >> hBind [
-	^(symSort trim, pred parens) parens
+	^(symSort trim, hPred) parens
 	==> [ :x | HBind x: x first first τ: x first second p: x second ]
 ]
 
@@ -104,7 +103,9 @@ NNFParser >> hCstr [
 { #category : #grammar }
 NNFParser >> hPred [
 	^(
-		pred "will inline this"
+		  predAnd
+		/ kappaApp
+		/ decidablePred
 	) parens
 ]
 
@@ -128,14 +129,9 @@ NNFParser >> kappaApp [
 ]
 
 { #category : #grammar }
-NNFParser >> pred [
-	^predAnd / kappaApp / decidablePred
-]
-
-{ #category : #grammar }
 NNFParser >> predAnd [
 	^'and' asParser,
-	(#blank asParser plus, pred parens ==> [:x| x second]) star 
+	(#blank asParser plus, hPred ==> [:x| x second]) star 
 	==> [ :x | HPredAnd of: x second ]
 ]
 
@@ -144,7 +140,7 @@ NNFParser >> qualif [
 	^'qualif' asParser trim,
 	NNFParser upperId trim, "name"
 	symSort trim plus parens trim, "params"
-	pred parens "body"
+	hPred "body"
 	==> [ :x | Qualifier
 		name: x second
 		params: (x third collect: [ :p | QualParam symbol: p first sort: p second ])

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -74,7 +74,7 @@ NNFParser >> define [
 { #category : #grammar }
 NNFParser >> exists [
 	^'exists' asParser trim,
-	hBind parens trim,
+	hBind trim,
 	hCstr trim
 	==> [ :x | CstrAny bind: x second p: x third ]
 ]
@@ -91,7 +91,7 @@ NNFParser >> fTyCon [
 { #category : #grammar }
 NNFParser >> forall [
 	^'forall' asParser trim,
-	hBind parens trim,
+	hBind trim,
 	hCstr
 	==> [ :x | CstrAll bind: x second p: x third ]
 ]
@@ -109,7 +109,7 @@ NNFParser >> funcSort [
 
 { #category : #grammar }
 NNFParser >> hBind [
-	^symSort trim, pred parens
+	^(symSort trim, pred parens) parens
 	==> [ :x | HBind x: x first first τ: x first second p: x second ]
 ]
 

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #NNFParser,
-	#superclass : #PPCompositeParser,
+	#superclass : #FixpointParser,
 	#instVars : [
 		'fixpoint',
 		'constraint',

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -10,11 +10,11 @@ Class {
 		'constant',
 		'hBind',
 		'symSort',
-		'decidablePred',
 		'hPred',
 		'funcSort',
 		'sortArg',
-		'define'
+		'define',
+		'pred'
 	],
 	#category : #'Refinements-Parsing'
 }
@@ -34,12 +34,6 @@ NNFParser >> constraint [
 	hCstr
 	==> [ :x | x second ]
 	
-]
-
-{ #category : #grammar }
-NNFParser >> decidablePred [
-	^matchedParen
-	==> [ :x | HReft expr: (DecidableRefinement text: x) ]
 ]
 
 { #category : #grammar }
@@ -102,7 +96,7 @@ NNFParser >> hPred [
 	^(
 		  ('and' asParser, 	(#blank asParser plus, hPred ==> #second) star ==> [ :x | HPredAnd of: x second ])
 		/ (self kvSym, ((#blank asParser plus), self tok ==> [:x| x second]) plus ==> [ :x | RefVarApp var: x first args: x second ])
-		/ decidablePred
+		/ (pred ==> [ :x | HReft expr: x ])
 	) parens
 ]
 
@@ -116,6 +110,12 @@ NNFParser >> kvSym [
 	^('$' asParser,
 	($# asParser ==> [:x|$º] / #word asParser / $_ asParser) plus)
 	==> [ :x | String withAll: x second ]
+]
+
+{ #category : #grammar }
+NNFParser >> pred [
+	^ matchedParen
+	==> [ :x | DecidableRefinement text: x ]
 ]
 
 { #category : #grammar }

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -101,6 +101,7 @@ NNFParser >> hCstr [
 		  ('and' asParser trim, hCstr trim star ==> [ :x | CstrAnd of: x second ])
 		/ ('forall' asParser trim, hBind trim, hCstr trim ==> [ :x | CstrAll bind: x second p: x third ])
 		/ ('exists' asParser trim, hBind trim, hCstr trim ==> [ :x | CstrAny bind: x second p: x third ])
+		"TODO: / tag"
 		/ cstrPred
 	) parens
 ]

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -3,14 +3,10 @@ Class {
 	#superclass : #FixpointParser,
 	#instVars : [
 		'hCstr',
-		'sort',
 		'hBind',
 		'symSort',
 		'hPred',
-		'funcSort',
-		'sortArg',
-		'define',
-		'pred'
+		'define'
 	],
 	#category : #'Refinements-Parsing'
 }
@@ -31,26 +27,6 @@ NNFParser >> define [
 					args: x third
 					expr: (DecidableRefinement text: x seventh)
 					sort: x fifth ]
-]
-
-{ #category : #grammar }
-NNFParser >> fTyCon [
-	^ ('Int' asParser ==> [ :x | Int tyCon ])
-	/ ('int' asParser ==> [ :x | Int tyCon ])
-	/ ('Bool' asParser ==> [ :x | Bool tyCon ])
-	/ ('bool' asParser ==> [ :x | Bool tyCon ])
-	/ (NNFParser upperId ==> [ :x | x symbolFTycon ])
-]
-
-{ #category : #grammar }
-NNFParser >> funcSort [
-	"Parser for function sorts without the 'func' keyword"
-	^(
-	PPParser decimalNat,
-	$, asParser trim,
-	sort semicolonSeparated brackets
-	) parens
-	==> [ :x | Z3Sort mkFFunc: x first sorts: x third ]
 ]
 
 { #category : #grammar }
@@ -123,33 +99,6 @@ NNFParser >> kvSym [
 ]
 
 { #category : #grammar }
-NNFParser >> pred [
-	^ matchedParen
-	==> [ :x | DecidableRefinement text: x ]
-]
-
-{ #category : #grammar }
-NNFParser >> sort [
-	^ self sort′: sortArg trim star
-]
-
-{ #category : #grammar }
-NNFParser >> sortArg [
-	^ self sort′: nil asParser
-]
-
-{ #category : #grammar }
-NNFParser >> sort′: aSortArgParser [
-	| sap |
-	sap := aSortArgParser ==> [ :args | args ifNil: [ #() ] ]. "aSortArgParser can be EpsilonParser"
-	^ sort parens
-	/ ('func' asParser, funcSort ==> [ :x | x second ])
-	/ (sort brackets ==> [ :x | x shouldBeImplemented listFTyCon  ])
-	/ (self fTyCon trim, sap ==> [ :x | x first fAppTC: x second ])
-	/ (self tvar trim, sap ==> [ :x | x first fApp: x second ])
-]
-
-{ #category : #grammar }
 NNFParser >> start [
 	^self hThing trim star end ==> [ :x | HornQuery fromThings: x ]
 ]
@@ -157,16 +106,4 @@ NNFParser >> start [
 { #category : #'grammar - util' }
 NNFParser >> symSort [
 	^(self tok trim, sort) parens
-]
-
-{ #category : #grammar }
-NNFParser >> tvar [
-	^ self varSort
-	/ ($` asParser, #lowercase asParser ==> [ :x | Z3Sort uninterpretedSortNamed: (String with: x second) ])
-]
-
-{ #category : #grammar }
-NNFParser >> varSort [
-	^'@(' asParser, PPParser decimalInteger, ')' asParser
-	==> [ :x | FVar new: x second ]
 ]

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -6,7 +6,7 @@ Class {
 		'cstrAnd',
 		'forall',
 		'exists',
-		'cstr',
+		'hCstr',
 		'var',
 		'sort',
 		'qualif',
@@ -38,20 +38,15 @@ NNFParser >> constant [
 { #category : #grammar }
 NNFParser >> constraint [
 	^'constraint' asParser trim,
-	cstr parens
+	hCstr
 	==> [ :x | x second ]
 	
 ]
 
 { #category : #grammar }
-NNFParser >> cstr [
-	^cstrAnd / forall / exists / cstrPred
-]
-
-{ #category : #grammar }
 NNFParser >> cstrAnd [
 	^'and' asParser trim,
-	cstr parens trim star ==> [ :x | CstrAnd of: x second ]
+	hCstr trim star ==> [ :x | CstrAnd of: x second ]
 ]
 
 { #category : #grammar }
@@ -87,8 +82,7 @@ NNFParser >> define [
 NNFParser >> exists [
 	^'exists' asParser trim,
 	hBind parens trim,
-	cstr parens trim
-	"'(and)' asParser"
+	hCstr trim
 	==> [ :x | CstrAny bind: x second p: x third ]
 ]
 
@@ -105,7 +99,7 @@ NNFParser >> fTyCon [
 NNFParser >> forall [
 	^'forall' asParser trim,
 	hBind parens trim,
-	cstr parens
+	hCstr
 	==> [ :x | CstrAll bind: x second p: x third ]
 ]
 
@@ -124,6 +118,16 @@ NNFParser >> funcSort [
 NNFParser >> hBind [
 	^symSort trim, pred parens
 	==> [ :x | HBind x: x first first τ: x first second p: x second ]
+]
+
+{ #category : #grammar }
+NNFParser >> hCstr [
+	^(
+		  cstrAnd
+		/ forall
+		/ exists
+		/ cstrPred
+	) parens
 ]
 
 { #category : #grammar }

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -28,16 +28,6 @@ Class {
 }
 
 { #category : #grammar }
-NNFParser class >> lowerId [
-	^(#lowercase asParser, (#word asParser / $_ asParser) star) flatten
-]
-
-{ #category : #grammar }
-NNFParser class >> upperId [
-	^(#uppercase asParser, (#word asParser / $_ asParser) star) flatten
-]
-
-{ #category : #grammar }
 NNFParser >> constant [
 	^'constant' asParser trim,
 	self tok trim, "name"

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -7,7 +7,6 @@ Class {
 		'var',
 		'sort',
 		'qualif',
-		'constant',
 		'hBind',
 		'symSort',
 		'hPred',
@@ -18,15 +17,6 @@ Class {
 	],
 	#category : #'Refinements-Parsing'
 }
-
-{ #category : #grammar }
-NNFParser >> constant [
-	^'constant' asParser trim,
-	self tok trim, "name"
-	sort
-	==> [ :x | HCon symbol: x second sort: x third ]
-	
-]
 
 { #category : #grammar }
 NNFParser >> constraint [
@@ -102,7 +92,16 @@ NNFParser >> hPred [
 
 { #category : #grammar }
 NNFParser >> hThing [
-	^(constraint / var / qualif / constant / self fixpoint / define "match data") parens
+	^(
+		  constraint
+		/ var
+		/ qualif
+		/ ('constant' asParser trim, self tok trim, sort ==> [ :x | HCon symbol: x second sort: x third ])
+		/ self fixpoint
+		/ define
+		" / match"
+		" / data"
+	) parens
 ]
 
 { #category : #grammar }

--- a/src/Refinements-Parsing/NNFParser.class.st
+++ b/src/Refinements-Parsing/NNFParser.class.st
@@ -6,7 +6,6 @@ Class {
 		'hCstr',
 		'var',
 		'sort',
-		'qualif',
 		'hBind',
 		'symSort',
 		'hPred',
@@ -91,11 +90,24 @@ NNFParser >> hPred [
 ]
 
 { #category : #grammar }
+NNFParser >> hQualifier [
+	^'qualif' asParser trim,
+	NNFParser upperId trim, "name"
+	symSort trim plus parens trim, "params"
+	hPred "body"
+	==> [ :x | Qualifier
+		name: x second
+		params: (x third collect: [ :p | QualParam symbol: p first sort: p second ])
+		body: x fourth expr ]
+	
+]
+
+{ #category : #grammar }
 NNFParser >> hThing [
 	^(
 		  constraint
 		/ var
-		/ qualif
+		/ self hQualifier
 		/ ('constant' asParser trim, self tok trim, sort ==> [ :x | HCon symbol: x second sort: x third ])
 		/ self fixpoint
 		/ define
@@ -115,19 +127,6 @@ NNFParser >> kvSym [
 NNFParser >> pred [
 	^ matchedParen
 	==> [ :x | DecidableRefinement text: x ]
-]
-
-{ #category : #grammar }
-NNFParser >> qualif [
-	^'qualif' asParser trim,
-	NNFParser upperId trim, "name"
-	symSort trim plus parens trim, "params"
-	hPred "body"
-	==> [ :x | Qualifier
-		name: x second
-		params: (x third collect: [ :p | QualParam symbol: p first sort: p second ])
-		body: x fourth expr ]
-	
 ]
 
 { #category : #grammar }

--- a/src/Refinements-Tests/FQNegTest.class.st
+++ b/src/Refinements-Tests/FQNegTest.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #FQNegTest,
+	#superclass : #FQTest,
+	#category : #'Refinements-Tests'
+}
+
+{ #category : #tests }
+FQNegTest >> testConjRhs [
+	self proveNeg: '
+constraint:
+  env []
+  lhs {v:int | Bool true }
+  rhs {v:int | ((0 toInt < 1) & (1 toInt < 0)) }
+  id 1
+  tag [1]
+'
+]

--- a/src/Refinements-Tests/FQPosTest.class.st
+++ b/src/Refinements-Tests/FQPosTest.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #FQPosTest,
+	#superclass : #FQTest,
+	#category : #'Refinements-Tests'
+}
+
+{ #category : #tests }
+FQPosTest >> testConjRhs [
+	self provePos: '
+constraint:
+  env []
+  lhs {v:int | Bool true }
+  rhs {v:int | ((0 toInt < 1) & (1 toInt > 0)) }
+  id 1
+  tag [1]
+'
+]

--- a/src/Refinements-Tests/FQTest.class.st
+++ b/src/Refinements-Tests/FQTest.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : #FQTest,
+	#superclass : #TestCase,
+	#category : #'Refinements-Tests'
+}
+
+{ #category : #proving }
+FQTest >> proveNeg: txt [
+	| q |
+	q := FQParser parse: txt.
+	self deny: q isPetitFailure.
+	self deny: q solve isSafe
+]
+
+{ #category : #proving }
+FQTest >> provePos: txt [
+	| q |
+	q := FQParser parse: txt.
+	self deny: q isPetitFailure.
+	self assert: q solve isSafe
+]

--- a/src/Refinements-Tests/HornPosTest.class.st
+++ b/src/Refinements-Tests/HornPosTest.class.st
@@ -634,29 +634,6 @@ Cf. Horn/Transformations.hs:
 	 to experiment with, than a test."
 ]
 
-{ #category : #'tests - sol1' }
-HornPosTest >> testSol1_3 [
-"
-Cf. Horn/Transformations.hs:
--- >> let c = doParse' hCstrP '' '(forall ((a Int) (p a)) (forall ((b Int) (q b)) (and (($k a)) (($k b)))))'
--- >> sol1 'k' c
--- [[((a int) (p a)),((b int) (q b)),((_ bool) (κarg$k#1 == a))],[((a int) (p a)),((b int) (q b)),((_ bool) (κarg$k#1 == b))]]
-"
-	| c sol sa sb |
-	c := (NNFParser new productionAt: #forall) parse: 'forall ((a Int) (p a)) (forall ((b Int) (q b)) (and (($k a)) (($k b))))'.
-	self deny: c isPetitFailure.
-	sol := c sol1: 'k'.  "-> [([Bind], [F.Expr])]"
-	self assert: sol size equals: 2.
-	
-	"the 'κarg$k#1 = a' solution:"
-	sa := sol detect: [ :s | s value anySatisfy: [ :eq | eq y sym = 'a' ] ].
-	self assert: sa key size equals: 2.
-	
-	"the 'κarg$k#1 = b' solution:"
-	sb := sol detect: [ :s | s value anySatisfy: [ :eq | eq y sym = 'b' ] ].
-	self assert: sb key size equals: 2.
-]
-
 { #category : #'tests - safety' }
 HornPosTest >> testSumRec [
 	self provePos: self sumRec

--- a/src/Refinements/CstrHead.class.st
+++ b/src/Refinements/CstrHead.class.st
@@ -49,11 +49,7 @@ CstrHead >> goScope: k [
 CstrHead >> goS′: kve _: env _: lhs _: be [
 	| rhs subc |
 	rhs := lhs updSortedReft_kve: kve p: self pred.
-	subc := SubC new
-		env: env;
-		rhs: rhs;
-		lhs: lhs;
-		yourself.
+	subc := SubC mkSubC: env lhs: lhs rhs: rhs i: nil tag: #().
 	^be -> { Either right: subc }
 ]
 

--- a/src/Refinements/FInfo.class.st
+++ b/src/Refinements/FInfo.class.st
@@ -10,7 +10,7 @@ FInfo class >> defsFInfo: defs [
 defsFInfo :: [Def a] -> FInfo a
 Cf. Parse.hs
 "
-	self shouldBeImplemented.
+	^self basicNew initializeFromDefs: defs
 ]
 
 { #category : #logic }
@@ -24,6 +24,26 @@ FInfo >> convertFormat [
 	bindm := bindm_fi′ key.  fi′ := bindm_fi′ value.
 	fi′ cm: (fi′ cm collect: [ :subc | subc toSimpC: bindm_fi′ key ]).
 	^fi′ as: SInfo
+]
+
+{ #category : #'private - initialization' }
+FInfo >> initializeFromDefs: defs [
+"
+Cf. Parse.hs
+This is inefficient as it walks over defs multiple times,
+but at least textually consistent with LF.
+"
+	self initializeMempty.
+	cm := Dictionary newFromAssociations: (defs select: [ :def | def isKindOf: SubC ] thenCollect: [ :subc | subc id -> subc ]).
+	bs := BindEnv empty.
+	ebinds := #().
+	ws := KVEnv new.
+	quals := OrderedCollection new.
+	gLits := SEnv new.
+	kuts := Kuts new.
+	ddecls := OrderedCollection new.
+	ae := AxiomEnv new.
+	options := QueryOptions new.
 ]
 
 { #category : #logic }

--- a/src/Refinements/FInfo.class.st
+++ b/src/Refinements/FInfo.class.st
@@ -4,6 +4,15 @@ Class {
 	#category : #Refinements
 }
 
+{ #category : #'instance creation' }
+FInfo class >> defsFInfo: defs [
+"
+defsFInfo :: [Def a] -> FInfo a
+Cf. Parse.hs
+"
+	self shouldBeImplemented.
+]
+
 { #category : #logic }
 FInfo >> convertFormat [
 	"Convert FInfo query to SInfo.

--- a/src/Refinements/SubC.class.st
+++ b/src/Refinements/SubC.class.st
@@ -7,6 +7,27 @@ Class {
 	#category : #Refinements
 }
 
+{ #category : #'instance creation' }
+SubC class >> mkSubC: env lhs: lhs rhs: rhs i: i tag: tag [
+"
+mkSubC :: IBindEnv -> SortedReft -> SortedReft -> Maybe Integer -> Tag -> a  -> SubC a
+           env          lhs           rhs             i            tag   label
+Cf. Constraints.hs
+"
+	^self basicNew
+		env: env;
+		rhs: rhs;
+		lhs: lhs;
+		id: i;
+		tag: tag;
+		yourself
+]
+
+{ #category : #'instance creation' }
+SubC class >> new [
+	self shouldNotImplement
+]
+
 { #category : #logic }
 SubC >> clhs: be [
 	^(be envCs: env) copyWith: lhs bind

--- a/src/SpriteLang/RefinementParser.class.st
+++ b/src/SpriteLang/RefinementParser.class.st
@@ -49,12 +49,12 @@ RefinementParser >> concReftB [
 			| id pred |
 			id := id_pred first.
 			pred := id_pred last.
-			(Reft symbol: id expr: (DecidableRefinement text: pred)) known ]
+			(Reft symbol: id expr: pred) known ]
 ]
 
 { #category : #grammar }
 RefinementParser >> concReftBExpr [
-	^RefinementExpressionParser new ==> [ :seq | seq formattedCode ]
+	^DecidableRefinement parser
 ]
 
 { #category : #grammar }


### PR DESCRIPTION
The "chain of tests" (as explained in the "_Towards a Dynabook…_" paper) follows the structure of the processing pipeline, i.e., for MachineArithmetic in particular,

> SpriteLang → Horn → SMT,

meaning we have 6 kinds of tests.  However, if we zoom in, we shall see an intermediate processing stage:

> SpriteLang → Horn → FInfo → SMT.

In March 2024, the upstream LiquidFixpoint switched to "new format" tests (e.g. `tests/pos/*.fq`) where FInfos are spelled out explicitly.  This PR ports these "new-format" capability to MA.  This is important because much of essential functionality is covered by the "new-format" tests but not the Horn tests.