### PR TITLE
Port LiquidFixpoint's FQ ("new-format") tests

### DIFF
--- a/src/Refinements-Parsing/FQParser.class.st
+++ b/src/Refinements-Parsing/FQParser.class.st
@@ -1,0 +1,107 @@
+Class {
+	#name : #FQParser,
+	#superclass : #FixpointParser,
+	#instVars : [
+		'subC',
+		'bind',
+		'refa',
+		'sortedReft'
+	],
+	#category : #'Refinements-Parsing'
+}
+
+{ #category : #grammar }
+FQParser >> bind [
+	^ self class lowerId trim,
+	$: asParser
+	==> #first
+]
+
+{ #category : #grammar }
+FQParser >> constraint [
+	^ 'constraint:' asParser trim
+	, subC
+	==> #second
+]
+
+{ #category : #grammar }
+FQParser >> def [
+	^ self fixpoint
+	/ self constraint
+	/ 'everything else' asParser
+]
+
+{ #category : #grammar }
+FQParser >> fInfo [
+	^ self def trim plus
+	==> [ :x | FInfo defsFInfo: x ]
+]
+
+{ #category : #grammar }
+FQParser >> ref: kind [
+"
+-- | (Sorted) Refinements
+"
+	^self refBind: bind rp: refa kind: kind
+]
+
+{ #category : #grammar }
+FQParser >> refBind: bp rp: rp kind: kindP [
+"
+-- (Sorted) Refinements with configurable sub-parsers
+"
+	^(
+		bp trim,
+		kindP trim,
+		'|' asParser trim,
+		rp
+	) braces
+	==> [ :x | x second value: (Reft symbol: x first expr: x fourth) ]
+]
+
+{ #category : #grammar }
+FQParser >> refa [
+"
+-- | Refa
+refaP :: Parser Expr
+refaP =  try (pAnd <$> brackets (sepBy predP semi))
+     <|> predP
+Cf. top-level Parse.hs
+"
+	^".... and .... | "
+	pred
+]
+
+{ #category : #grammar }
+FQParser >> sortedReft [
+	^ self ref: (sort ==> [ :aSort | [ :r | SortedReft sort: aSort reft: r ]])
+]
+
+{ #category : #grammar }
+FQParser >> start [
+	^self fInfo trim end
+]
+
+{ #category : #grammar }
+FQParser >> subC [
+	^ ('env []' asParser trim ==> [ :_ | IBindEnv empty])
+	, 'lhs' asParser trim, sortedReft trim
+	, 'rhs' asParser trim, sortedReft trim
+	, 'id'  asParser, Character space asParser plus, PPParser decimalNat trim
+	, self tag
+	==> [ :x | SubC
+			mkSubC: x first
+			lhs: x third
+			rhs: x fifth
+			i: x eighth
+			tag: x ninth
+	]
+]
+
+{ #category : #grammar }
+FQParser >> tag [
+	^ 'tag' asParser
+	, Character space asParser
+	, PPParser decimalNat semicolonSeparated brackets
+	==> [ :x | x third ]
+]

--- a/src/Refinements-Tests/FQNegTest.class.st
+++ b/src/Refinements-Tests/FQNegTest.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #FQNegTest,
+	#superclass : #FQTest,
+	#category : #'Refinements-Tests'
+}
+
+{ #category : #tests }
+FQNegTest >> testConjRhs [
+	self proveNeg: '
+constraint:
+  env []
+  lhs {v:int | Bool true }
+  rhs {v:int | ((0 toInt < 1) & (1 toInt < 0)) }
+  id 1
+  tag [1]
+'
+]

--- a/src/Refinements-Tests/FQPosTest.class.st
+++ b/src/Refinements-Tests/FQPosTest.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #FQPosTest,
+	#superclass : #FQTest,
+	#category : #'Refinements-Tests'
+}
+
+{ #category : #tests }
+FQPosTest >> testConjRhs [
+	self provePos: '
+constraint:
+  env []
+  lhs {v:int | Bool true }
+  rhs {v:int | ((0 toInt < 1) & (1 toInt > 0)) }
+  id 1
+  tag [1]
+'
+]

--- a/src/Refinements-Tests/FQTest.class.st
+++ b/src/Refinements-Tests/FQTest.class.st
@@ -1,0 +1,21 @@
+Class {
+	#name : #FQTest,
+	#superclass : #TestCase,
+	#category : #'Refinements-Tests'
+}
+
+{ #category : #proving }
+FQTest >> proveNeg: txt [
+	| q |
+	q := FQParser parse: txt.
+	self deny: q isPetitFailure.
+	self deny: q solve isSafe
+]
+
+{ #category : #proving }
+FQTest >> provePos: txt [
+	| q |
+	q := FQParser parse: txt.
+	self deny: q isPetitFailure.
+	self assert: q solve isSafe
+]

--- a/src/Refinements/CstrHead.class.st
+++ b/src/Refinements/CstrHead.class.st
@@ -49,11 +49,7 @@ CstrHead >> goScope: k [
 CstrHead >> goS′: kve _: env _: lhs _: be [
 	| rhs subc |
 	rhs := lhs updSortedReft_kve: kve p: self pred.
-	subc := SubC new
-		env: env;
-		rhs: rhs;
-		lhs: lhs;
-		yourself.
+	subc := SubC mkSubC: env lhs: lhs rhs: rhs i: nil tag: #().
 	^be -> { Either right: subc }
 ]
 

--- a/src/Refinements/FInfo.class.st
+++ b/src/Refinements/FInfo.class.st
@@ -4,6 +4,15 @@ Class {
 	#category : #Refinements
 }
 
+{ #category : #'instance creation' }
+FInfo class >> defsFInfo: defs [
+"
+defsFInfo :: [Def a] -> FInfo a
+Cf. Parse.hs
+"
+	^self basicNew initializeFromDefs: defs
+]
+
 { #category : #logic }
 FInfo >> convertFormat [
 	"Convert FInfo query to SInfo.
@@ -15,6 +24,26 @@ FInfo >> convertFormat [
 	bindm := bindm_fi′ key.  fi′ := bindm_fi′ value.
 	fi′ cm: (fi′ cm collect: [ :subc | subc toSimpC: bindm_fi′ key ]).
 	^fi′ as: SInfo
+]
+
+{ #category : #'private - initialization' }
+FInfo >> initializeFromDefs: defs [
+"
+Cf. Parse.hs
+This is inefficient as it walks over defs multiple times,
+but at least textually consistent with LF.
+"
+	self initializeMempty.
+	cm := Dictionary newFromAssociations: (defs select: [ :def | def isKindOf: SubC ] thenCollect: [ :subc | subc id -> subc ]).
+	bs := BindEnv empty.
+	ebinds := #().
+	ws := KVEnv new.
+	quals := OrderedCollection new.
+	gLits := SEnv new.
+	kuts := Kuts new.
+	ddecls := OrderedCollection new.
+	ae := AxiomEnv new.
+	options := QueryOptions new.
 ]
 
 { #category : #logic }

--- a/src/Refinements/SubC.class.st
+++ b/src/Refinements/SubC.class.st
@@ -7,6 +7,27 @@ Class {
 	#category : #Refinements
 }
 
+{ #category : #'instance creation' }
+SubC class >> mkSubC: env lhs: lhs rhs: rhs i: i tag: tag [
+"
+mkSubC :: IBindEnv -> SortedReft -> SortedReft -> Maybe Integer -> Tag -> a  -> SubC a
+           env          lhs           rhs             i            tag   label
+Cf. Constraints.hs
+"
+	^self basicNew
+		env: env;
+		rhs: rhs;
+		lhs: lhs;
+		id: i;
+		tag: tag;
+		yourself
+]
+
+{ #category : #'instance creation' }
+SubC class >> new [
+	self shouldNotImplement
+]
+
 { #category : #logic }
 SubC >> clhs: be [
 	^(be envCs: env) copyWith: lhs bind


### PR DESCRIPTION


The "chain of tests" (as explained in the "_Towards a Dynabook…_" paper) follows the structure of the processing pipeline, i.e., for MachineArithmetic in particular,

> SpriteLang → Horn → SMT,

meaning we have 6 kinds of tests. However, if we zoom in, we shall see an intermediate processing stage:

> SpriteLang → Horn → FInfo → SMT.

In March 2024, the upstream LiquidFixpoint switched to "new format" tests (e.g. `tests/pos/*.fq`) where FInfos are spelled out explicitly. This PR ports these "new-format" capability to MA. This is important because much of essential functionality is covered by the "new-format" tests but not the Horn tests.
