### PR TITLE
Clear error in `#errorCheck`

### DIFF
--- a/apigen.py
+++ b/apigen.py
@@ -303,6 +303,16 @@ Z3_decide_eh    = Z3ClosureType('Z3_decide_eh',  VOID,    ()) # (void* ctx, Z3_s
 Z3_on_clause_eh = Z3ClosureType('Z3_on_clause_eh',VOID,   ()) # (void* ctx, Z3_ast proof_hint, Z3_ast_vector literals));
 
 
+# For some API functions, error check makes no sense
+# or it is not desirable. NO_ERROR_CHECK lists such
+# functions.
+NO_ERROR_CHECK = (
+    'Z3_del_context',
+    'Z3_get_error_code',
+    'Z3_get_error_msg'
+)
+
+
 API_MATCHER = re.compile("/\*\*\n    (.*?(?=\*/))\*/\n\s+([^;/]+)", re.M | re.S)
 DEF_MATCHER = re.compile("def_API\(.*\)\n", re.M | re.S)
 FUN_MATCHER = re.compile("\w+\s+Z3_API\s+\w+\s*\((.*)\)", re.M | re.S)
@@ -530,7 +540,7 @@ class Generator:
             # Check whether API call resulted in an error
             if api.has_context_arg():
                 # For some APIs, error check is undesirable...
-                if api.cname not in ('Z3_del_context', 'Z3_get_error_code' , 'Z3_get_error_msg'):
+                if api.cname not in NO_ERROR_CHECK:
                     body += f"{api.context_arg_name()} errorCheck.\n    "
 
             if (api.rettype.is_z3contexted_type()):

--- a/apigen.py
+++ b/apigen.py
@@ -309,7 +309,8 @@ Z3_on_clause_eh = Z3ClosureType('Z3_on_clause_eh',VOID,   ()) # (void* ctx, Z3_a
 NO_ERROR_CHECK = (
     'Z3_del_context',
     'Z3_get_error_code',
-    'Z3_get_error_msg'
+    'Z3_get_error_msg',
+    'Z3_set_error',
 )
 
 

--- a/src/Z3/Z3.class.st
+++ b/src/Z3/Z3.class.st
@@ -16455,7 +16455,6 @@ Z3 class >> set_error: c _: e [
 
 	c ensureValidZ3Object.
 	retval := lib _set_error: c _: e.
-	c errorCheck.
 	^ retval
 
 

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -77,6 +77,26 @@ Z3Context >> errorCheck [
 
 	code := Z3 get_error_code: self.
 	code ~~ OK ifTrue: [
+		"Here we have to clear the error code. Some APIs don't do it
+		 (like some dec_refs and possibly others). If we do not do it,
+		 it could happen that, after encounting error (and reporting it)
+		 we call another Z3 functions which does not clear it and
+		 subsequent #errorCheck would report an error (see [1]).
+
+		 An obvious solution not to call errorCheck for those API is
+		 bit fragile - Z3 API is not explicit about which do and which
+		 don't and this is known to change version to version. So instead,
+		 we took the approach of clearing the error - this way each (detected)
+		 error is reported only once.
+
+		 Note, that at this point we have already extracted the error code
+		 (in `code` local variable) so we can safely clear it in the context.
+
+		 [1]: https://github.com/shingarov/MachineArithmetic/issues/348
+		"
+		Z3 set_error: self _: OK.
+
+		"Report an error."
 		Z3Error new
 			code: code;
 			messageText: (Z3 get_error_msg: self _: code);


### PR DESCRIPTION
Some Z3 APIs don't clear error (like some dec_refs and possibly others),
so it could happen that, after encounting error (and reporting it)
we call another Z3 functions which does not clear it and subsequent
`#errorCheck` would report an error again (see #348).

An obvious solution - not to call `#errorCheck` for those API - is bit
fragile - Z3 API is not explicit about which do and which don't and this
is known to change version to version.

So instead, we took the approach of clearing the error - this way each
(detected) error is reported only once.