### PR TITLE
Run CI against multiple Z3 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ on:
   workflow_dispatch:
 
 env:
+  GH_TOKEN: ${{ github.token }}
   PROJECT: MachineArithmetic
-  Z3_DOWNLOAD_URL_WINDOWS: https://github.com/Z3Prover/z3/releases/download/z3-4.8.17/z3-4.8.17-x64-win.zip
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   full:
-    name: "Full - ${{matrix.dialect}}, ${{matrix.os}}"
+    name: "Full - ${{matrix.dialect}}, ${{matrix.os}}, ${{matrix.z3}}"
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     strategy:
@@ -33,6 +33,10 @@ jobs:
           - ubuntu-latest
           - windows-latest
         dialect: [ pharo ]
+        z3:
+          - 'z3-4.13.0'
+          - 'z3-4.8.12'
+          - '' #latest
         scheduled:
            - ${{ github.event_name == 'schedule' }}
         exclude:
@@ -60,17 +64,42 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: pacman --noconfirm -Syu wget make unzip
 
-      - name: Install Z3 (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install libz3-4 libz3-dev
-
-      - name: Install Z3 (Windows)
-        if: matrix.os == 'windows-latest'
+      - name: Install Z3
         run: |
-          cd pharo
-          wget --quiet --output-document=z3.zip ${{env.Z3_DOWNLOAD_URL_WINDOWS}}
+          case ${{matrix.os}} in
+            ubuntu*)
+              gh release      -R Z3prover/z3 download ${{matrix.z3}} -p 'z3-*-x64-glibc-2.35.zip' -O 'z3.zip' --clobber \
+                || gh release -R Z3prover/z3 download ${{matrix.z3}} -p 'z3-*-x64-glibc*.zip' -O 'z3.zip' --clobber
+              ;;
+            windows*)
+              gh release -R Z3prover/z3 download ${{matrix.z3}} -p 'z3-*-x64-win.zip' -O 'z3.zip' --clobber
+              ;;
+            *)
+              echo "Unsupported OS" && false
+              ;;
+          esac
           unzip z3.zip
-          cp z3*win/bin/*.dll .
+          rm z3.zip
+          mv z3-*-x64-* z3
+          case ${{matrix.os}} in
+            ubuntu*)
+              export Z3_LIBRARY_PATH=$(realpath z3/bin/libz3.so)
+              ;;
+            windows*)
+              export Z3_LIBRARY_PATH=$(realpath z3/bin/libz3.dll)
+              ;;
+            *)
+              echo "Unsupported OS" && false
+              ;;
+          esac
+
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$Z3_LIBRARY_PATH
+
+          echo "Z3_LIBRARY_PATH=$Z3_LIBRARY_PATH"
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+
+          echo "Z3_LIBRARY_PATH=$Z3_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Fetch commits so that Iceberg doesn't crash
         run: git fetch --unshallow
@@ -84,13 +113,17 @@ jobs:
           make -C ${{matrix.dialect}} test
 
   z3bindings:
-    name: "Z3 bindings only - ${{matrix.dialect}}, ${{matrix.os}}"
+    name: "Z3 bindings only - ${{matrix.dialect}}, ${{matrix.os}}, ${{matrix.z3}}"
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
         dialect: [ pharo , stx ]
+        z3:
+          - 'z3-4.13.0'
+          - 'z3-4.8.12'
+          - '' #latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -105,17 +138,42 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: pacman --noconfirm -Syu wget make unzip
 
-      - name: Install Z3 (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install libz3-4 libz3-dev
-
-      - name: Install Z3 (Windows)
-        if: matrix.os == 'windows-latest'
+      - name: Install Z3
         run: |
-          cd pharo
-          wget --quiet --output-document=z3.zip ${{env.Z3_DOWNLOAD_URL_WINDOWS}}
+          case ${{matrix.os}} in
+            ubuntu*)
+              gh release      -R Z3prover/z3 download ${{matrix.z3}} -p 'z3-*-x64-glibc-2.35.zip' -O 'z3.zip' --clobber \
+                || gh release -R Z3prover/z3 download ${{matrix.z3}} -p 'z3-*-x64-glibc*.zip' -O 'z3.zip' --clobber
+              ;;
+            windows*)
+              gh release -R Z3prover/z3 download ${{matrix.z3}} -p 'z3-*-x64-win.zip' -O 'z3.zip' --clobber
+              ;;
+            *)
+              echo "Unsupported OS" && false
+              ;;
+          esac
           unzip z3.zip
-          cp z3*win/bin/*.dll .
+          rm z3.zip
+          mv z3-*-x64-* z3
+          case ${{matrix.os}} in
+            ubuntu*)
+              export Z3_LIBRARY_PATH=$(realpath z3/bin/libz3.so)
+              ;;
+            windows*)
+              export Z3_LIBRARY_PATH=$(realpath z3/bin/libz3.dll)
+              ;;
+            *)
+              echo "Unsupported OS" && false
+              ;;
+          esac
+
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$Z3_LIBRARY_PATH
+
+          echo "Z3_LIBRARY_PATH=$Z3_LIBRARY_PATH"
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+
+          echo "Z3_LIBRARY_PATH=$Z3_LIBRARY_PATH" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
       - name: Fetch commits so that Iceberg doesn't crash
         run: git fetch --unshallow

--- a/pharo/GNUmakefile
+++ b/pharo/GNUmakefile
@@ -31,6 +31,7 @@ check-deps: $(PROJECT).image $(PHARO_VM)
 	$(PHARO_VM_HEADLESS) $< check-deps.st
 
 test: $(PROJECT).image $(PHARO_VM)
+	$(PHARO_VM_HEADLESS) $< eval "'Current Z3 version: ', Z3 getVersion storeString"
 	$(PHARO_VM_HEADLESS) $< test --fail-on-failure \
 		'PreSmalltalks-Tests' \
 		'Z3-Tests' \

--- a/src/Z3-FFI-Pharo/LibZ3.class.st
+++ b/src/Z3-FFI-Pharo/LibZ3.class.st
@@ -10138,17 +10138,45 @@ LibZ3 >> _update_term: c _: a _: num_args _: args [
 
 ]
 
+{ #category : #'accessing platform-private' }
+LibZ3 >> getLibraryName: default [
+	"Return path to Z3 shared library / DLL to use (as string).
+	 If relative, the library is looked up according to OS conventions.
+
+   By default, passed `default` is used.
+
+	 It is possible to use specific library by either setting
+	 Z3_LIBRARY_PATH environment variable or - alternatively -
+	 by using `LibZ3 class >> libraryName:`.
+    "
+    LibraryName isNil ifTrue:[
+        | libraryNameFromEnv |
+
+        libraryNameFromEnv := Smalltalk os environment at: 'Z3_LIBRARY_PATH' ifAbsent:[nil].
+        libraryNameFromEnv notNil ifTrue:[
+            libraryNameFromEnv asFileReference exists ifFalse:[
+                self error:'Z3 shared library set in Z3_LIBRARY_PATH environment var does not exits: ', libraryNameFromEnv.
+                ^ nil.
+            ].
+            ^ libraryNameFromEnv
+        ].
+
+        ^default
+    ].
+    ^ LibraryName
+]
+
 { #category : #'accessing platform' }
 LibZ3 >> macLibraryName [
-	LibraryName ifNil: [^'libz3.dylib'] ifNotNil: [^LibraryName]
+	^self getLibraryName: 'libz3.dylib'.
 ]
 
 { #category : #'accessing platform' }
 LibZ3 >> unixLibraryName [
-	LibraryName ifNil: [^'libz3.so'] ifNotNil: [^LibraryName]
+	^self getLibraryName: 'libz3.so'.
 ]
 
 { #category : #'accessing platform' }
 LibZ3 >> win32ModuleName [
-	LibraryName ifNil: [^'libz3.dll'] ifNotNil: [^LibraryName]
+	^self getLibraryName: 'libz3.dll'.
 ]

--- a/src/Z3-FFI-SmalltalkX/LibZ3.class.st
+++ b/src/Z3-FFI-SmalltalkX/LibZ3.class.st
@@ -14,12 +14,31 @@ Class {
 
 { #category : #accessing }
 LibZ3 class >> libraryName [
+	"Return path to Z3 shared library / DLL to use (as string).
+	 If relative, the library is looked up according to OS conventions.
 
+	 By default, the OS-shipped version is used.
+
+	 It is possible to use specific library by either setting
+	 Z3_LIBRARY_PATH environment variable or - alternatively -
+	 by using `LibZ3 class >> libraryName:`.
+	"
 	LibraryName isNil ifTrue:[
+		| libraryNameFromEnv |
+
+		libraryNameFromEnv := OperatingSystem getEnvironment: 'Z3_LIBRARY_PATH'.
+		libraryNameFromEnv notNil ifTrue:[
+			libraryNameFromEnv asFilename exists ifFalse:[
+				self error:'Z3 shared library set in Z3_LIBRARY_PATH environment var does not exits: ', libraryNameFromEnv.
+				^ nil.
+			].
+			^ libraryNameFromEnv
+		].
+
 		OperatingSystem isMSWINDOWSlike ifTrue: [
-			LibraryName := 'libz3.dll'.
+			^ 'libz3.dll'.
 		] ifFalse: [
-			LibraryName := 'libz3.so'.
+			^  'libz3.so'.
 		].
 	].
 	^ LibraryName

--- a/stx/GNUmakefile
+++ b/stx/GNUmakefile
@@ -20,7 +20,10 @@ run: $(STX)
 	$(STX) --package-path ../src --load BaselineOf$(PROJECT)
 
 test: $(STX)
-	$(STX) --package-path ../src --load BaselineOf$(PROJECT) --run Builder::ReportRunner -r Builder::TestReport --fail-on-failure -p Z3-Tests
+	$(STX) --package-path ../src --load BaselineOf$(PROJECT) --run Builder::ReportRunner \
+		-S "Stdout nextPutLine:'Current Z3 version: ', Z3 getVersion storeString" \
+		-r Builder::TestReport --fail-on-failure \
+		-p Z3-Tests
 
 ifndef Z3_SOURCE_DIR
 Z3_SOURCE_DIR=error-Z3-SOURCE-not-defined


### PR DESCRIPTION
This PR updates CI pipeline to run tests against multiple Z3
versions. Pre-build binaries of libz3 are taken from Z3's github
releases. For now, 4.8.12, 4.8.13 and "latest" versions are tested.