### PR TITLE
Fix bogus antidependency of FP on Sprite

### DIFF
--- a/src/Refinements/EBin.class.st
+++ b/src/Refinements/EBin.class.st
@@ -39,7 +39,7 @@ EBin >> bop: anObject [
 { #category : #'term rewriting' }
 EBin >> evaluateIn: anEvalEnv ifUndeclared: vndBlock [
 	^(left evaluateIn: anEvalEnv ifUndeclared: vndBlock)
-		perform: bop smalltalkSelector
+		perform: bop
 		with: (right evaluateIn: anEvalEnv ifUndeclared: vndBlock)
 ]
 

--- a/src/SpriteLang/ΛPrimOp.class.st
+++ b/src/SpriteLang/ΛPrimOp.class.st
@@ -38,10 +38,11 @@ Class {
 ΛPrimOp >> embedPrim: args [
 "
 embedPrim :: PrimOp -> [F.Expr] -> F.Expr
+Cf. L₈ Reflect.hs
 "
 	self assert: args size = 2.
 	^EBin
-		bop: self
+		bop: self smalltalkSelector
 		left: args first
 		right: args second
 ]


### PR DESCRIPTION
This was resulting from confusion between Λ.BPlus vs F.Plus: they are not the same thing.