### PR TITLE
Do not double-escape ß in `String>>encodeUnsafe`

### DIFF
--- a/src/MathNotation-Tests/UnsafeZ3NameTest.class.st
+++ b/src/MathNotation-Tests/UnsafeZ3NameTest.class.st
@@ -5,6 +5,18 @@ Class {
 }
 
 { #category : #tests }
+UnsafeZ3NameTest >> testIdempotent [
+	"Caveat programmator:
+	 This nice idempotent property is peculiar to Smalltalk.
+	 In LH the ß would get double-escaped!"
+	| recognizerName safeRecognizerName safeSafeRecognizerName |
+	recognizerName := 'is$mkCons'.
+	safeRecognizerName := recognizerName encodeUnsafe.
+	safeSafeRecognizerName := safeRecognizerName encodeUnsafe.
+	self assert: safeRecognizerName equals: safeSafeRecognizerName.
+]
+
+{ #category : #tests }
 UnsafeZ3NameTest >> testIntName [
 	| Z |
 	Z := Int sort.

--- a/src/PreSmalltalks-FxEncoding/String.extension.st
+++ b/src/PreSmalltalks-FxEncoding/String.extension.st
@@ -35,7 +35,7 @@ Therefore '$' is not a safe character; but 'ß' is.
 	self isEmpty ifTrue: [ ^ self ].
 	c := self first.
 	cs := self allButFirst.
-	head := c isUnsafeChar
+	head := (c isUnsafeChar and: c~~$ß)
 		ifTrue: [ 'ß' , c codePoint printString , 'ß' ]
 		ifFalse: [ String with: c ].
 	tail := cs encodeUnsafe.


### PR DESCRIPTION
NB: This idempotent property is the opposite of how it works in LH.