### PR TITLE
Fix unification of `FObj`

### DIFF
--- a/src/Refinements/Env.class.st
+++ b/src/Refinements/Env.class.st
@@ -44,8 +44,8 @@ Cf. SortCheck.hs
 	(t2 isKindOf: Z3IntSort) ifTrue: [ ^t1 checkNumeric: self tvSubst: θ ].
 
 	((t1 isKindOf: FFunc) and: [t2 isKindOf: FFunc]) ifTrue: [ ^self unifyMany: e tvSubst: θ sorts: { t1 from . t1 to } sorts: { t2 from . t2 to } ].
-	(t1 isKindOf: Z3UninterpretedSort) ifTrue: [ |a| a := t1 name getString. ^t2 checkEqConstr: self maybeExpr: e tvSubst: θ symbol: a ].
-	(t2 isKindOf: Z3UninterpretedSort) ifTrue: [ |a| a := t2 name getString. ^t1 checkEqConstr: self maybeExpr: e tvSubst: θ symbol: a ].
+	(t1 isKindOf: FObj) ifTrue: [ ^t2 checkEqConstr: self maybeExpr: e tvSubst: θ symbol: t1 symbol ].
+	(t2 isKindOf: FObj) ifTrue: [ ^t1 checkEqConstr: self maybeExpr: e tvSubst: θ symbol: t2 symbol ].
 	
 	t1 = t2 ifTrue: [ ^θ ].
 	Incompatible signal

--- a/src/Refinements/FObj.class.st
+++ b/src/Refinements/FObj.class.st
@@ -25,6 +25,18 @@ FObj >> = rhs [
 	^symbol = rhs symbol
 ]
 
+{ #category : #'sort algebra' }
+FObj >> checkEqConstr: f maybeExpr: e tvSubst: θ symbol: a [
+"
+checkEqConstr _ _  θ a (FObj b)
+  | a == b
+  = return θ
+"
+	^symbol = a
+		ifTrue: [ θ ]
+		ifFalse: [ super checkEqConstr: f maybeExpr: e tvSubst: θ symbol: a ]
+]
+
 { #category : #'as yet unclassified' }
 FObj >> checkNumeric: f tvSubst: aCollection [
 "

--- a/src/Refinements/FTC.class.st
+++ b/src/Refinements/FTC.class.st
@@ -31,11 +31,6 @@ FTC >> = rhs [
 ]
 
 { #category : #'as yet unclassified' }
-FTC >> checkEqConstr: aBlockClosure maybeExpr: anUndefinedObject tvSubst: aCollection symbol: aString [ 
-	^nil "BOGUS?"
-]
-
-{ #category : #'as yet unclassified' }
 FTC >> containsFVar [
 	^false
 ]

--- a/src/Refinements/PreSort.class.st
+++ b/src/Refinements/PreSort.class.st
@@ -80,6 +80,17 @@ bkFun :: Sort -> Maybe [Sort]
 ]
 
 { #category : #'sort algebra' }
+PreSort >> checkEqConstr: f maybeExpr: e tvSubst: θ symbol: a [
+"
+checkEqConstr :: Env -> Maybe Expr -> TVSubst -> Symbol -> Sort -> CheckM TVSubst
+                  f          e          θ          a      t=self
+"
+	f∘a
+		ifFound: [ :tA | ^f unify1: e tvSubst: θ sort: tA sort: self ]
+		alts: [ self error ]
+]
+
+{ #category : #'sort algebra' }
 PreSort >> checkFunSort [
 	"cf. SortCheck.hs"
 	self error: 'NonFunction'


### PR DESCRIPTION
In commit b7592b7, we changed instantiation of typevars as `Z3UninterpretedSort`, to `FObj` instead.  This broke `unify1` of typevars, e.g. _'a~ℤ_ now crashes with `Incompatible`. The present commit fixes this case in `unify1`.