### PR TITLE
Do not discard the VariableNotDeclared that came from the Smalltalk compiler

### DIFF
--- a/src/Refinements/Object.extension.st
+++ b/src/Refinements/Object.extension.st
@@ -21,7 +21,7 @@ Object >> elabApply: _ [
 
 { #category : #'*Refinements' }
 Object >> evaluateIn: γ [
-	^self evaluateIn: γ ifUndeclared: [ VariableNotDeclared new signal ]
+	^self evaluateIn: γ ifUndeclared: #signal
 ]
 
 { #category : #'*Refinements' }


### PR DESCRIPTION
The original code culls the block, discarding the `VariableNotDeclared` exception instance, creates a new one and signals it.  This causes the programmer to chase a few frames down the stack to find out which variable caused the problem.  No; just signal the original exception.