### PR TITLE
Coerce Z3 if-then-else if a branch isn't Z3 yet

### DIFF
--- a/src/Refinements-Tests/SimpleZ3Test.extension.st
+++ b/src/Refinements-Tests/SimpleZ3Test.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : #SimpleZ3Test }
 
 { #category : #'*Refinements-Tests' }
+SimpleZ3Test >> testCoerceEVar [
+	| result |
+	result := 3 toInt + (EVar of: 'four').
+	self assert: result sort equals: Int sort.
+	self assert: result expr bop equals: #+
+]
+
+{ #category : #'*Refinements-Tests' }
 SimpleZ3Test >> testFuncSort [
 	self
 		assert: (Int sort ⇴ Int sort) printString

--- a/src/Refinements/Expr.class.st
+++ b/src/Refinements/Expr.class.st
@@ -439,6 +439,11 @@ Expr >> kvarsExpr [
 	^#()
 ]
 
+{ #category : #elaboration }
+Expr >> mkIf: b then: t else: e [ 
+	^EIte if: b then: t else: e
+]
+
 { #category : #logic }
 Expr >> not [
 	^PNot of: self

--- a/src/Z3-Tests/SimpleZ3Test.class.st
+++ b/src/Z3-Tests/SimpleZ3Test.class.st
@@ -219,6 +219,11 @@ SimpleZ3Test >> testBoundVar [
 ]
 
 { #category : #tests }
+SimpleZ3Test >> testCoerce3plus4 [
+	self assert: 3 toInt + 4 equals: 7
+]
+
+{ #category : #tests }
 SimpleZ3Test >> testContext [
 	| ctx |
 

--- a/src/Z3/Bool.class.st
+++ b/src/Z3/Bool.class.st
@@ -112,6 +112,8 @@ Bool >> findCounterexample [
 
 { #category : #'logical operations' }
 Bool >> ifThen: trueAST else: falseAST [
+	trueAST  isNode ifFalse: [ ^trueAST  mkIf: self then: trueAST else: falseAST ].
+	falseAST isNode ifFalse: [ ^falseAST mkIf: self then: trueAST else: falseAST ].
 	trueAST sort == falseAST sort ifFalse: [ self error: 'Branches must have same sort' ].
 	^ Z3 mk_ite: ctx _: self _: trueAST _: falseAST
 


### PR DESCRIPTION
Ideally, ITE should be homogeneous with how Z3ArithmeticNode>>+ and friends coerce arguments. But this will do for now.