### PR TITLE
[CI] do not cancel other jobs if one job fails (fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,12 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
     strategy:
+      #
+      # Do not cancel other jobs if one job fails.
+      #
+      # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
+      #
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         dialect: [ pharo , stx ]


### PR DESCRIPTION
This commit is a follow up fix for earlier commit

  2bc8ba4 "[CI] do not cancel other jobs if one job fails"

I forgot to update the second job ("z3bindings").