### PR TITLE
Make BitVec a functor from BitVecSize index category to Sort

### DIFF
--- a/src/Refinements/FTycon.class.st
+++ b/src/Refinements/FTycon.class.st
@@ -57,18 +57,6 @@ FTycon >> isListTC [
 	^false
 ]
 
-{ #category : #bitvectors }
-FTycon >> sizeBv [
-"
-sizeBv :: FTycon -> Maybe Int
-Cf. 
-Answer the X in 'SizeX', or nil if the name is not of SizeX form.
-"
-	| s |
-	s := self fTyconSymbol.
-	^self shouldBeImplemented
-]
-
 { #category : #'as yet unclassified' }
 FTycon >> smtApply: ts originalFApp: anFApp in: γ [
 	^self subclassResponsibility

--- a/src/Refinements/FTycon.class.st
+++ b/src/Refinements/FTycon.class.st
@@ -17,12 +17,18 @@ FTycon class >> conName [
 ]
 
 { #category : #'instance creation' }
+FTycon class >> named: aString [
+	self conName = aString ifFalse: [ ^nil ].
+	^self basicNew
+]
+
+{ #category : #'instance creation' }
 FTycon class >> symbolFTycon: c [
 "
 symbolFTycon :: LocSymbol -> FTycon
 "
-	self subclassesDo: [ :eachSpecialTycon |
-		c = eachSpecialTycon conName ifTrue: [ ^eachSpecialTycon new ] ].
+	(self subclasses without: TC) do: [ :eachSpecialTycon |
+		(eachSpecialTycon named: c) ifNotNil: [ :instance | ^instance ] ].
 	"non-special TC"
 	^TC symbol: c
 ]

--- a/src/Refinements/FTyconBitVec.class.st
+++ b/src/Refinements/FTyconBitVec.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #FTyconBitVec,
+	#superclass : #FTycon,
+	#category : #Refinements
+}
+
+{ #category : #names }
+FTyconBitVec class >> conName [
+	^'BitVec'
+]
+
+{ #category : #'as yet unclassified' }
+FTyconBitVec >> smtApply: ts originalFApp: _ in: γ [
+	| xlen |
+	self assert: ts size = 1. "(BitVec SizeXX) must have exactly one SizeXX argument"
+	xlen := ts first typeConstructor size.
+	^Z3Sort bv: xlen
+]

--- a/src/Refinements/FTyconBitVecSize.class.st
+++ b/src/Refinements/FTyconBitVecSize.class.st
@@ -1,0 +1,47 @@
+Class {
+	#name : #FTyconBitVecSize,
+	#superclass : #FTycon,
+	#instVars : [
+		'size'
+	],
+	#category : #Refinements
+}
+
+{ #category : #names }
+FTyconBitVecSize class >> conName [
+	^self shouldNotImplement
+]
+
+{ #category : #'instance creation' }
+FTyconBitVecSize class >> named: aString [
+	| XX i |
+	(aString beginsWith: 'Size') ifFalse: [ ^nil ].
+	XX := aString copyFrom: 5 to: aString size.
+	i := PPParser decimalNat end parse: XX. "Pharo's asInteger and readFrom: happily eat junk postfices"
+	^i isPetitFailure
+		ifTrue: [ nil ]
+		ifFalse: [ self size: i ]
+]
+
+{ #category : #'instance creation' }
+FTyconBitVecSize class >> size: anInteger [
+	^self basicNew
+		size: anInteger;
+		yourself
+]
+
+{ #category : #printing }
+FTyconBitVecSize >> printOn: aStream [
+	aStream nextPutAll: 'Size'.
+	size printOn: aStream
+]
+
+{ #category : #accessing }
+FTyconBitVecSize >> size [
+	^ size
+]
+
+{ #category : #accessing }
+FTyconBitVecSize >> size: anObject [
+	size := anObject
+]

--- a/src/Refinements/TC.class.st
+++ b/src/Refinements/TC.class.st
@@ -9,8 +9,7 @@ Class {
 
 { #category : #names }
 TC class >> conName [
-	"Special marker that doesn't match any known conName in symbolFTycon"
-	^nil
+	^self shouldNotImplement
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Working in terms of a single category of types (such as `Hask`, or shall we call it `Sort` in our case for roughly a union of Z3Sorts and PreSorts), type constructors are endofunctors in Sort.  This commit makes the `BitVec` type constructor fit homogeneously within that treatment: acting on `i` it returns the `(BitVec i)` sort.  This would suggest that BitVec's domain is a special index category; we introduce the special index sort BitVecSize so we can keep regarding BitVec an endofunctor.