### PR TITLE
Remove `TBitVector>>isBitVector`

### DIFF
--- a/src/SpriteLang/TBitVector.class.st
+++ b/src/SpriteLang/TBitVector.class.st
@@ -80,11 +80,6 @@ TBitVector >> hash [
 	^(self class hash + length) hashMultiply
 ]
 
-{ #category : #testing }
-TBitVector >> isBitVector [
-	^true
-]
-
 { #category : #accessing }
 TBitVector >> length [
 	^ length


### PR DESCRIPTION
This is false polymorphism with the selector in Fixpoint. No other ΛBase implements this style of tester.
And it is not used anywhere in the codebase.