### PR TITLE
Selfify ℤ and 𝔹 programmatically

### DIFF
--- a/src/Refinements/Bool.extension.st
+++ b/src/Refinements/Bool.extension.st
@@ -51,6 +51,15 @@ Bool >> predKs [
 ]
 
 { #category : #'*Refinements' }
+Bool >> prop [
+"
+instance Predicate Expr where
+  prop = id
+"
+	^self
+]
+
+{ #category : #'*Refinements' }
 Bool >> refaConjuncts [
 	^{self}
 ]

--- a/src/Refinements/Boolean.extension.st
+++ b/src/Refinements/Boolean.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Boolean }
+
+{ #category : #'*Refinements' }
+Boolean >> expr [
+	^self toBool
+]

--- a/src/Refinements/Expr.class.st
+++ b/src/Refinements/Expr.class.st
@@ -91,9 +91,7 @@ Expr >> <= rhs [
 
 { #category : #'theory symbols' }
 Expr >> <=> rhs [
-	^ECst
-		e: (EMessageSend of: (MessageSend receiver: self selector: #<=> argument: rhs))
-		sort: Bool sort
+	^PIff lhs: self rhs: rhs
 ]
 
 { #category : #'theory symbols' }

--- a/src/Refinements/Expr.class.st
+++ b/src/Refinements/Expr.class.st
@@ -447,6 +447,15 @@ Expr >> mkIf: b then: t else: e [
 	^EIte if: b then: t else: e
 ]
 
+{ #category : #Predicate }
+Expr >> mkProp [
+"
+mkProp :: Expr -> Pred
+mkProp = id
+"
+	^self
+]
+
 { #category : #logic }
 Expr >> not [
 	^PNot of: self

--- a/src/Refinements/False.extension.st
+++ b/src/Refinements/False.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #False }
+
+{ #category : #'*Refinements' }
+False >> prop [
+"
+instance Predicate Bool where
+  prop True  = PTrue
+  prop False = PFalse
+"
+	^Expr PFalse
+]

--- a/src/Refinements/Integer.extension.st
+++ b/src/Refinements/Integer.extension.st
@@ -21,6 +21,15 @@ Integer >> evaluateIn: anEvalEnv ifUndeclared: vndBlock [
 ]
 
 { #category : #'*Refinements' }
+Integer >> expr [
+"
+instance Expression Integer where
+  expr = ECon . I
+"
+	^self toInt
+]
+
+{ #category : #'*Refinements' }
 Integer >> mkVV [
 "
 mkVV :: Maybe Integer -> Symbol

--- a/src/Refinements/Object.extension.st
+++ b/src/Refinements/Object.extension.st
@@ -15,6 +15,16 @@ Object >> dNonCut [
 ]
 
 { #category : #'*Refinements' }
+Object >> eVar [
+"
+eVar ::  Symbolic a => a -> Expr
+eVar = EVar . symbol
+Cf. Types/Refinements.hs
+"
+	^EVar of: self symbol
+]
+
+{ #category : #'*Refinements' }
 Object >> elabApply: _ [ 
 	^self
 ]

--- a/src/Refinements/Object.extension.st
+++ b/src/Refinements/Object.extension.st
@@ -15,6 +15,16 @@ Object >> dNonCut [
 ]
 
 { #category : #'*Refinements' }
+Object >> eProp [
+"
+eProp ::  Symbolic a => a -> Expr
+eProp = mkProp . eVar
+Cf. Types/Refinements.hs
+"
+	^self eVar mkProp
+]
+
+{ #category : #'*Refinements' }
 Object >> eVar [
 "
 eVar ::  Symbolic a => a -> Expr
@@ -76,6 +86,16 @@ Object >> printStringInHotel: h [
 { #category : #'*Refinements' }
 Object >> printUncastOn: aStream [ 
 	self printOn: aStream
+]
+
+{ #category : #'*Refinements' }
+Object >> prop [
+"
+class Predicate a where
+  prop   :: a -> Expr
+Cf. Types/Refinements.hs
+"
+	^self error: 'No "instance Predicate ', self class name, ' where…"'
 ]
 
 { #category : #'*Refinements' }

--- a/src/Refinements/Object.extension.st
+++ b/src/Refinements/Object.extension.st
@@ -25,6 +25,17 @@ Object >> evaluateIn: γ [
 ]
 
 { #category : #'*Refinements' }
+Object >> expr [
+"
+-- | Values that can be viewed as Expressions
+class Expression a where
+  expr   :: a -> Expr
+Cf. Types/Refinements.hs
+"
+	^self error: 'No "instance Expression ', self class name, ' where…"'
+]
+
+{ #category : #'*Refinements' }
 Object >> mapKVars: aBlock [
 	^self mapKVars′: [ :kv′_☐ |
 		| kv′ |

--- a/src/Refinements/Object.extension.st
+++ b/src/Refinements/Object.extension.st
@@ -56,6 +56,15 @@ Cf. Types/Refinements.hs
 ]
 
 { #category : #'*Refinements' }
+Object >> exprReft [
+"
+exprReft ::  (Expression a) => a -> Reft
+Cf. Types/Refinements.hs
+"
+	^self relReft: #===
+]
+
+{ #category : #'*Refinements' }
 Object >> mapKVars: aBlock [
 	^self mapKVars′: [ :kv′_☐ |
 		| kv′ |
@@ -104,7 +113,21 @@ Object >> propReft [
 propReft      ::  (Predicate a) => a -> Reft
 cf. Refinements.hs
 "
-	^Reft symbol: String vv_ expr: self shouldBeImplemented
+	^Reft symbol: String vv_ expr: (String vv_ eProp <=> self prop)
+]
+
+{ #category : #'*Refinements' }
+Object >> relReft: aRelationSelector [
+"
+relReft :: (Expression a) => Brel -> a -> Reft
+relReft r e   = Reft (vv_, PAtom r (eVar vv_)  (expr e))
+Cf. Types/Refinements.hs
+"
+	| vv_ exprReft |
+	vv_ := VariableAlphabet freshVariableName. "Issue #454"
+	^Reft
+		symbol: vv_
+		expr: (PAtom brel: aRelationSelector x: vv_ eVar y: self expr)
 ]
 
 { #category : #'*Refinements' }

--- a/src/Refinements/PIff.class.st
+++ b/src/Refinements/PIff.class.st
@@ -1,0 +1,73 @@
+Class {
+	#name : #PIff,
+	#superclass : #Expr,
+	#instVars : [
+		'lhs',
+		'rhs'
+	],
+	#category : #Refinements
+}
+
+{ #category : #'instance creation' }
+PIff class >> lhs: l rhs: r [
+	^self basicNew
+		lhs: l;
+		rhs: r;
+		yourself
+]
+
+{ #category : #comparing }
+PIff >> = another [
+	self class = another class ifFalse: [ ^false ].
+	^ (lhs = another lhs)
+	& (rhs = another rhs)
+]
+
+{ #category : #visiting }
+PIff >> accept: aVisitor [ 
+	^PIff
+		lhs: (lhs accept: aVisitor)
+		rhs: (rhs accept: aVisitor)
+]
+
+{ #category : #'term rewriting' }
+PIff >> evaluateIn: aBindEnv ifUndeclared: vndBlock [
+	^ (lhs evaluateIn: aBindEnv ifUndeclared: vndBlock)
+		<=>
+	  (rhs evaluateIn: aBindEnv ifUndeclared: vndBlock)
+]
+
+{ #category : #comparing }
+PIff >> hash [
+	^lhs hash
+]
+
+{ #category : #logic }
+PIff >> isTautoPred [
+	^lhs = rhs
+]
+
+{ #category : #accessing }
+PIff >> lhs [
+	^ lhs
+]
+
+{ #category : #accessing }
+PIff >> lhs: anObject [
+	lhs := anObject
+]
+
+{ #category : #accessing }
+PIff >> rhs [
+	^ rhs
+]
+
+{ #category : #accessing }
+PIff >> rhs: anObject [
+	rhs := anObject
+]
+
+{ #category : #'SMT interface' }
+PIff >> smt2: γ [
+	^(lhs smt2: γ) <=> (rhs smt2: γ)
+]

--- a/src/Refinements/Reft.class.st
+++ b/src/Refinements/Reft.class.st
@@ -95,9 +95,13 @@ Reft >> evaluateIn: anEvalEnv ifUndeclared: vndBlock [
 		expr: (expr evaluateIn: anEvalEnv ifUndeclared: vndBlock)
 ]
 
-{ #category : #accessing }
+{ #category : #Expression }
 Reft >> expr [
-	^ expr
+"
+instance Expression Reft where
+  expr (Reft(_, e)) = e
+"
+	^expr
 ]
 
 { #category : #accessing }

--- a/src/Refinements/SortedReft.class.st
+++ b/src/Refinements/SortedReft.class.st
@@ -112,6 +112,15 @@ SortedReft >> evaluateIn: anEvalEnv ifUndeclared: vndBlock [
 		reft: (sr_reft evaluateIn: anEvalEnv ifUndeclared: vndBlock)
 ]
 
+{ #category : #Expression }
+SortedReft >> expr [
+"
+instance Expression SortedReft where
+  expr (RR _ r) = expr r
+"
+	^sr_reft expr
+]
+
 { #category : #'as yet unclassified' }
 SortedReft >> isConc [
 	^sr_reft isConc

--- a/src/Refinements/String.extension.st
+++ b/src/Refinements/String.extension.st
@@ -77,6 +77,16 @@ String >> oneSuka: xs [
 ]
 
 { #category : #'*Refinements' }
+String >> prop [
+"
+instance Predicate Symbol where
+  prop = eProp
+Cf. Types/Refinements.hs
+"
+	^self eProp
+]
+
+{ #category : #'*Refinements' }
 String >> suffixSymbol: s [
 	"Ugly transliteration from LiquidFixpoint.
 	Please someone get rid of this."

--- a/src/Refinements/True.extension.st
+++ b/src/Refinements/True.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #True }
+
+{ #category : #'*Refinements' }
+True >> prop [
+"
+instance Predicate Bool where
+  prop True  = PTrue
+  prop False = PFalse
+"
+	^Expr PTrue
+]

--- a/src/Refinements/Z3Node.extension.st
+++ b/src/Refinements/Z3Node.extension.st
@@ -36,6 +36,11 @@ Z3Node >> elabAs: t inElabEnv: _ [
 ]
 
 { #category : #'*Refinements' }
+Z3Node >> expr [
+	^self
+]
+
+{ #category : #'*Refinements' }
 Z3Node >> kvarsExpr [
 	^#()
 ]

--- a/src/SpriteLang/PBool.class.st
+++ b/src/SpriteLang/PBool.class.st
@@ -26,15 +26,10 @@ PBool >> bool: anObject [
 PBool >> constTy [
 
 "
-constTy _ (PBool True)  = TBase TBool (F.propReft F.PTrue)
-constTy _ (PBool False) = TBase TBool (F.propReft F.PFalse)
+constTy _ (PBool True)  = TBase TBool (known $ F.propReft F.PTrue)
+constTy _ (PBool False) = TBase TBool (known $ F.propReft F.PFalse)
 "
-	| argName r |
-	argName := VariableAlphabet freshVariableName.
-	r := bool
-		ifTrue: [ (DecidableRefinement text: argName) ]
-		ifFalse: [ (DecidableRefinement text: argName) not ].
-	^TBase b: TBool instance r: (Reft symbol: argName expr: r) known
+	^TBase b: TBool instance r: bool propReft known
 
 ]
 

--- a/src/SpriteLang/PInt.class.st
+++ b/src/SpriteLang/PInt.class.st
@@ -4,6 +4,9 @@ Class {
 	#instVars : [
 		'integer'
 	],
+	#pools : [
+		'Brel'
+	],
 	#category : #SpriteLang
 }
 
@@ -15,14 +18,11 @@ PInt class >> integer: integer [
 { #category : #'primitive types' }
 PInt >> constTy [
 "
-constTy _ (PInt n) = TBase TInt (F.exprReft (F.expr n))
+constTy _ (PInt  n)     = TBase TInt  (known $ F.exprReft (F.expr n))
 "
-	| freshVar exprReft |
-	freshVar := '_VV'.
-	exprReft := Reft
-		symbol: freshVar
-		expr: (DecidableRefinement text: freshVar, ' === ', integer printString).
-	^TBase b: TInt instance r: exprReft known
+	^TBase
+		b: TInt instance
+		r: integer expr exprReft known
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
This PR partially addresses #75.  PBin and PBitVector>>constTy still go through DecidableRefinement, but at least ℤ and 𝔹 now don't.