### PR TITLE
Use proper Z3 API to create BV from Int

### DIFF
--- a/src/Z3/BitVector.class.st
+++ b/src/Z3/BitVector.class.st
@@ -30,12 +30,14 @@ BitVector class >> sym: variableNameString length: xlen [
 ]
 
 { #category : #'instance creation' }
-BitVector class >> value: anInteger length: xlen [
-	| bvSort |
-	xlen = 0 ifTrue: [ ^self empty ].
-	bvSort := Z3Sort bv: xlen.
-	^Z3AST numeral: anInteger printString ofSort: bvSort
-
+BitVector class >> value: v length: n [
+	"Create an n-bit Bitvector from the integer argument v,
+	 which can be a Smalltalk Integer or a Z3 Int.
+	
+	The resulting bit-vector has n bits, where the i'th bit
+	(counting from 0 to n-1) is 1 if (v div 2^i) mod 2 is 1.
+	"
+	^v toBitVector: n
 ]
 
 { #category : #'bit operators' }

--- a/src/Z3/Int.class.st
+++ b/src/Z3/Int.class.st
@@ -39,7 +39,8 @@ Int >> retry: selector coercing: rhs [
 
 { #category : #converting }
 Int >> toBitVector: size [
-	^ Z3 mk_int2bv: ctx _: size _: self
+	size = 0 ifTrue: [ ^BitVector empty ].
+	^(Z3 mk_int2bv: ctx _: size _: self) simplify
 
 ]
 

--- a/src/Z3/Integer.extension.st
+++ b/src/Z3/Integer.extension.st
@@ -12,7 +12,7 @@ Integer >> ones [
 
 { #category : #'*Z3' }
 Integer >> toBitVector: length [
-	^BitVector value: self length: length
+	^self toInt toBitVector: length
 ]
 
 { #category : #'*Z3' }


### PR DESCRIPTION
Do not print and then make Z3 re-parse the numeral.

Caveat programmator:
this creates new semantics when the integer is symbolic, because
```
(Z3Sort bv: 32) mkConst: 'x'
```
is NOT the same as
```
'x' toInt toBitVector: 32.
```