### PR TITLE
[cosmetic] Groom Refinements

### DIFF
--- a/src/Refinements/AbstractC.class.st
+++ b/src/Refinements/AbstractC.class.st
@@ -8,7 +8,7 @@ Class {
 		'tag',
 		'info'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }
 
 { #category : #logic }

--- a/src/Refinements/Alts.class.st
+++ b/src/Refinements/Alts.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'xs'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Environments'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/BindEnv.class.st
+++ b/src/Refinements/BindEnv.class.st
@@ -2,12 +2,12 @@
 -- Invariant: All BindIds in the map are less than beSize
 type BindEnv       = SizedEnv (Symbol, SortedReft)
 
-Cf. Types/Environments
+Cf. Types/Environments.hs
 "
 Class {
 	#name : #BindEnv,
 	#superclass : #SizedEnv,
-	#category : #Refinements
+	#category : #'Refinements-Environments'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/BindM.class.st
+++ b/src/Refinements/BindM.class.st
@@ -1,9 +1,11 @@
 "
 type BindM = M.HashMap Integer BindId
 type BindId        = Int
+
+Cf. Types/Constraints.hs
 "
 Class {
 	#name : #BindM,
 	#superclass : #Dictionary,
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }

--- a/src/Refinements/BindMap.class.st
+++ b/src/Refinements/BindMap.class.st
@@ -1,8 +1,10 @@
 "
 type BindMap a     = M.HashMap BindId a
+
+Cf. Types/Environments.hs
 "
 Class {
 	#name : #BindMap,
 	#superclass : #Dictionary,
-	#category : #Refinements
+	#category : #'Refinements-Environments'
 }

--- a/src/Refinements/Bop.class.st
+++ b/src/Refinements/Bop.class.st
@@ -7,7 +7,7 @@ Class {
 		'Plus',
 		'Times'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'class initialization' }

--- a/src/Refinements/Brel.class.st
+++ b/src/Refinements/Brel.class.st
@@ -12,7 +12,7 @@ Class {
 		'Ueq',
 		'Une'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'class initialization' }

--- a/src/Refinements/CDeps.class.st
+++ b/src/Refinements/CDeps.class.st
@@ -1,12 +1,15 @@
 "
-Constraint Dependencies
+--------------------------------------------------------------------------------
+-- | Constraint Dependencies ---------------------------------------------------
+--------------------------------------------------------------------------------
 
-IVars:
-cSucc   :: !(F.CMap [F.SubcId]) -- ^ Constraints *written by* a SubcId
-cPrev   :: !(F.CMap [F.KVar])   -- ^ (Cut) KVars *read by*    a SubcId
-cRank   :: !(F.CMap Rank)       -- ^ SCC rank of a SubcId
-cNumScc :: !Int                 -- ^ Total number of Sccs
+data CDeps = CDs { cSucc   :: !(F.CMap [F.SubcId]) -- ^ Constraints *written by* a SubcId
+                 , cPrev   :: !(F.CMap [F.KVar])   -- ^ (Cut) KVars *read by*    a SubcId
+                 , cRank   :: !(F.CMap Rank)       -- ^ SCC rank of a SubcId
+                 , cNumScc :: !Int                 -- ^ Total number of Sccs
+                 }
 
+Cf. Graph/Types.hs
 "
 Class {
 	#name : #CDeps,
@@ -17,7 +20,7 @@ Class {
 		'rank',
 		'numScc'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/CVertex.class.st
+++ b/src/Refinements/CVertex.class.st
@@ -1,7 +1,15 @@
+"
+data CVertex = KVar  !KVar    -- ^ real kvar vertex
+             | DKVar !KVar    -- ^ dummy to ensure each kvar has a successor
+             | EBind !F.Symbol  -- ^ existentially bound ""ghost paramter"" to solve for
+             | Cstr  !Integer -- ^ constraint-id which creates a dependency
+               deriving (Eq, Ord, Show, Generic)
+Cf. Graph/Types.hs
+"
 Class {
 	#name : #CVertex,
 	#superclass : #Object,
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Refinements/Cand.class.st
+++ b/src/Refinements/Cand.class.st
@@ -1,7 +1,10 @@
 "
-A Solution Candidate is an association list indexed by predicates
-  type Cand a   = [(Expr, a)]
-cf. Types/Solutions.hs
+--------------------------------------------------------------------------------
+-- | A `Cand` is an association list indexed by predicates
+--------------------------------------------------------------------------------
+type Cand a   = [(Expr, a)]
+
+Cf. Types/Solutions.hs
 
 "
 Class {
@@ -10,7 +13,7 @@ Class {
 	#instVars : [
 		'list'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Solutions'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Refinements/CoSub.class.st
+++ b/src/Refinements/CoSub.class.st
@@ -5,11 +5,13 @@
 --   domain and range are both Symbol and not the Int used for real ty-vars.
 --------------------------------------------------------------------------------
 type CoSub = M.HashMap Symbol Sort
+
+Cf. Types/Visitor.hs
 "
 Class {
 	#name : #CoSub,
 	#superclass : #Dictionary,
-	#category : #Refinements
+	#category : #'Refinements-Visitor'
 }
 
 { #category : #API }

--- a/src/Refinements/CombinedEnv.class.st
+++ b/src/Refinements/CombinedEnv.class.st
@@ -1,3 +1,17 @@
+"
+data CombinedEnv = CEnv
+  { ceCid  :: !Cid
+  , ceBEnv :: !F.BindEnv
+  , ceIEnv :: !F.IBindEnv
+  , ceSpan :: !F.SrcSpan
+    -- | These are the bindings that the smt solver knows about and can be
+    -- referred as @EVar (bindSymbol <bindId>)@ instead of serializing them
+    -- again.
+  , ceBindingsInSmt :: !F.IBindEnv
+  } deriving Show
+
+Cf. Solver/Solution.hs
+"
 Class {
 	#name : #CombinedEnv,
 	#superclass : #Object,
@@ -7,7 +21,7 @@ Class {
 		'iEnv',
 		'bindingsInSmt'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Solver'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Refinements/ConstraintGraph.class.st
+++ b/src/Refinements/ConstraintGraph.class.st
@@ -28,7 +28,7 @@ Class {
 		'succ',
 		'nSccs'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Refinements/CstrAll.class.st
+++ b/src/Refinements/CstrAll.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #CstrAll,
 	#superclass : #CstrQuantifier,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #logic }

--- a/src/Refinements/CstrAnd.class.st
+++ b/src/Refinements/CstrAnd.class.st
@@ -8,7 +8,7 @@ Class {
 	#instVars : [
 		'conjuncts'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/CstrAny.class.st
+++ b/src/Refinements/CstrAny.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #CstrAny,
 	#superclass : #CstrQuantifier,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #logic }

--- a/src/Refinements/CstrHead.class.st
+++ b/src/Refinements/CstrHead.class.st
@@ -1,5 +1,5 @@
 "
-If we think of a constraint as a tree, then am a ""goal leaf"".
+If we think of a constraint as a tree, then I am a ""goal leaf"".
 "
 Class {
 	#name : #CstrHead,
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'pred'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/CstrQuantifier.class.st
+++ b/src/Refinements/CstrQuantifier.class.st
@@ -13,7 +13,7 @@ Class {
 		'bind',
 		'p'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/CstrVertex.class.st
+++ b/src/Refinements/CstrVertex.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'id'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #accessing }

--- a/src/Refinements/Cube.class.st
+++ b/src/Refinements/Cube.class.st
@@ -1,6 +1,7 @@
 "
-I am a single constraint defining a KVar
-
+--------------------------------------------------------------------------------
+-- | A `Cube` is a single constraint defining a KVar ---------------------------
+--------------------------------------------------------------------------------
 type Hyp      = ListNE Cube
 
 data Cube = Cube
@@ -9,6 +10,8 @@ data Cube = Cube
   , cuId    :: SubcId    -- ^ Id            of   defining Cstr
   , cuTag   :: Tag       -- ^ Tag           of   defining Cstr (DEBUG)
   } deriving (Generic, NFData)
+
+Cf. Types/Solutions.hs
 "
 Class {
 	#name : #Cube,
@@ -18,7 +21,7 @@ Class {
 		'subst',
 		'id'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Solutions'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/CyclicConstraint.class.st
+++ b/src/Refinements/CyclicConstraint.class.st
@@ -4,7 +4,7 @@ I may be signaled when an elim on a cyclic constraint is attempted.
 Class {
 	#name : #CyclicConstraint,
 	#superclass : #Error,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'exception description' }

--- a/src/Refinements/DKVarVertex.class.st
+++ b/src/Refinements/DKVarVertex.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'kvar'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/DataCtor.class.st
+++ b/src/Refinements/DataCtor.class.st
@@ -11,7 +11,7 @@ Class {
 		'dcName',
 		'dcFields'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/DataDecl.class.st
+++ b/src/Refinements/DataDecl.class.st
@@ -41,7 +41,7 @@ Class {
 		'ddVars',
 		'ddCtors'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/DataField.class.st
+++ b/src/Refinements/DataField.class.st
@@ -13,7 +13,7 @@ Class {
 		'dfName',
 		'dfSort'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/DecidableRefinement.class.st
+++ b/src/Refinements/DecidableRefinement.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'text'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/DelayedSubst.class.st
+++ b/src/Refinements/DelayedSubst.class.st
@@ -5,7 +5,7 @@ Class {
 		'substitutions',
 		'expression'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/DepEdge.class.st
+++ b/src/Refinements/DepEdge.class.st
@@ -1,3 +1,8 @@
+"
+type DepEdge = (F.SubcId, F.SubcId, [F.SubcId])
+
+Cf. Graph/Types.hs
+"
 Class {
 	#name : #DepEdge,
 	#superclass : #Object,
@@ -6,7 +11,7 @@ Class {
 		'y',
 		'zs'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #accessing }

--- a/src/Refinements/EApp.class.st
+++ b/src/Refinements/EApp.class.st
@@ -13,7 +13,7 @@ Class {
 		'fun',
 		'imm'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/EBin.class.st
+++ b/src/Refinements/EBin.class.st
@@ -15,7 +15,7 @@ Class {
 		'left',
 		'right'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/EBindVertex.class.st
+++ b/src/Refinements/EBindVertex.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'symbol'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #accessing }

--- a/src/Refinements/EBvRepeat.class.st
+++ b/src/Refinements/EBvRepeat.class.st
@@ -5,7 +5,7 @@ Class {
 		'bitvector',
 		'times'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/ECst.class.st
+++ b/src/Refinements/ECst.class.st
@@ -5,7 +5,7 @@ Class {
 		'e',
 		'sort'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/EIte.class.st
+++ b/src/Refinements/EIte.class.st
@@ -11,7 +11,7 @@ Class {
 		'thenE',
 		'elseE'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/EMessageSend.class.st
+++ b/src/Refinements/EMessageSend.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'messageSend'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/EQual.class.st
+++ b/src/Refinements/EQual.class.st
@@ -1,3 +1,15 @@
+"
+--------------------------------------------------------------------------------
+-- | Instantiated Qualifiers ---------------------------------------------------
+--------------------------------------------------------------------------------
+data EQual = EQL
+  { eqQual :: !Qualifier
+  , eqPred  :: !Expr
+  , _eqArgs :: ![Expr]
+  } deriving (Eq, Show, Data, Typeable, Generic)
+
+Cf. Types/Solutions.hs
+"
 Class {
 	#name : #EQual,
 	#superclass : #Object,
@@ -6,7 +18,7 @@ Class {
 		'pred',
 		'args'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Solutions'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/EVar.class.st
+++ b/src/Refinements/EVar.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'sym'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/EbDef.class.st
+++ b/src/Refinements/EbDef.class.st
@@ -5,7 +5,7 @@ Class {
 		'cs',
 		'sym'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Solutions'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/EbIncr.class.st
+++ b/src/Refinements/EbIncr.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #EbIncr,
 	#superclass : #EbindSol,
-	#category : #Refinements
+	#category : #'Refinements-Solutions'
 }

--- a/src/Refinements/EbSol.class.st
+++ b/src/Refinements/EbSol.class.st
@@ -4,5 +4,5 @@ Class {
 	#instVars : [
 		'expr'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Solutions'
 }

--- a/src/Refinements/EbindSol.class.st
+++ b/src/Refinements/EbindSol.class.st
@@ -1,5 +1,21 @@
+"
+--------------------------------------------------------------------------------
+-- | An `EbindSol` contains the relevant information for an existential-binder;
+--   (See tests/pos/ebind-*.fq for examples.) This is either 
+--   1. the constraint whose HEAD is a singleton that defines the binder, OR 
+--   2. the solved out TERM that we should use in place of the ebind at USES.
+--------------------------------------------------------------------------------
+data EbindSol
+  = EbDef [SimpC ()] Symbol -- ^ The constraint whose HEAD ""defines"" the Ebind
+                             -- and the @Symbol@ for that EBind
+  | EbSol Expr             -- ^ The solved out term that should be used at USES.
+  | EbIncr                 -- ^ EBinds not to be solved for (because they're currently being solved for)
+   deriving (Show, Generic, NFData)
+
+Cf. Types/Solutions.hs
+"
 Class {
 	#name : #EbindSol,
 	#superclass : #Object,
-	#category : #Refinements
+	#category : #'Refinements-Solutions'
 }

--- a/src/Refinements/EdgeRank.class.st
+++ b/src/Refinements/EdgeRank.class.st
@@ -1,7 +1,12 @@
+"
+type EdgeRank = M.HashMap F.KVar Integer
+
+Cf. Graph/Deps.hs
+"
 Class {
 	#name : #EdgeRank,
 	#superclass : #Dictionary,
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/ElabEnv.class.st
+++ b/src/Refinements/ElabEnv.class.st
@@ -1,7 +1,5 @@
 "
-type ElabEnv  = (SymEnv, Env),
-where
-type Env      = Symbol -> SESearch Sort
+type ElabEnv  = (SymEnv, Env)
 
 cf. SortCheck.hs
 "
@@ -12,7 +10,7 @@ Class {
 		'senv',
 		'env'
 	],
-	#category : #Refinements
+	#category : #'Refinements-SortCheck'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/Elims.class.st
+++ b/src/Refinements/Elims.class.st
@@ -1,3 +1,15 @@
+"
+--------------------------------------------------------------------------------
+-- | Generic Dependencies ------------------------------------------------------
+--------------------------------------------------------------------------------
+data Elims a
+  = Deps { depCuts    :: !(S.HashSet a)
+         , depNonCuts :: !(S.HashSet a)
+         }       
+    deriving (Show)
+
+Cf. Graph/Deps.hs
+"
 Class {
 	#name : #Elims,
 	#superclass : #Object,
@@ -5,7 +17,7 @@ Class {
 		'depCuts',
 		'depNonCuts'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/Env.class.st
+++ b/src/Refinements/Env.class.st
@@ -1,8 +1,13 @@
+"
+SortCheck.hs:type Env      = Symbol -> SESearch Sort
+
+Cf. SortCheck.hs
+"
 Class {
 	#name : #Env,
 	#superclass : #BlockClosure,
 	#type : #variable,
-	#category : #Refinements
+	#category : #'Refinements-SortCheck'
 }
 
 { #category : #'sort-checking' }

--- a/src/Refinements/EvalEnv.class.st
+++ b/src/Refinements/EvalEnv.class.st
@@ -1,10 +1,13 @@
+"
+NB: This is NOT the EvalEnv in Solver/PLE.hs, NOR the EvalEnv in Solver/Instantiate.hs!
+"
 Class {
 	#name : #EvalEnv,
 	#superclass : #Object,
 	#instVars : [
 		'constants'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/Expr.class.st
+++ b/src/Refinements/Expr.class.st
@@ -26,7 +26,7 @@ data Expr = ESym !SymConst
 Class {
 	#name : #Expr,
 	#superclass : #Object,
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #constants }

--- a/src/Refinements/ExprInfo.class.st
+++ b/src/Refinements/ExprInfo.class.st
@@ -1,3 +1,8 @@
+"
+type ExprInfo    = (F.Expr, KInfo)
+
+Cf. Solver/Solution.hs
+"
 Class {
 	#name : #ExprInfo,
 	#superclass : #Object,
@@ -5,7 +10,7 @@ Class {
 		'expr',
 		'kInfo'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Solver'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/FAbs.class.st
+++ b/src/Refinements/FAbs.class.st
@@ -5,7 +5,7 @@ Class {
 		'int',
 		'sort'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/FApp.class.st
+++ b/src/Refinements/FApp.class.st
@@ -12,7 +12,7 @@ Class {
 		's',
 		't'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/FFunc.class.st
+++ b/src/Refinements/FFunc.class.st
@@ -19,7 +19,7 @@ Class {
 		'from',
 		'to'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/FInfo.class.st
+++ b/src/Refinements/FInfo.class.st
@@ -1,7 +1,12 @@
+"
+type FInfo a   = GInfo SubC a
+
+Cf. Types/Constraints.hs
+"
 Class {
 	#name : #FInfo,
 	#superclass : #HornInfo,
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/FObj.class.st
+++ b/src/Refinements/FObj.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'symbol'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/FTC.class.st
+++ b/src/Refinements/FTC.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'typeConstructor'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/FTycon.class.st
+++ b/src/Refinements/FTycon.class.st
@@ -8,7 +8,7 @@ the TCInfo information is kept in the subclass hierarchy.
 Class {
 	#name : #FTycon,
 	#superclass : #Object,
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #names }

--- a/src/Refinements/FTyconBitVec.class.st
+++ b/src/Refinements/FTyconBitVec.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FTyconBitVec,
 	#superclass : #SingletonFTycon,
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #names }

--- a/src/Refinements/FTyconBitVecSize.class.st
+++ b/src/Refinements/FTyconBitVecSize.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'length'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #names }

--- a/src/Refinements/FTyconBool.class.st
+++ b/src/Refinements/FTyconBool.class.st
@@ -4,7 +4,7 @@ boolFTyCon = TC (dummyLoc boolLConName) defTcInfo
 Class {
 	#name : #FTyconBool,
 	#superclass : #SingletonFTycon,
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #names }

--- a/src/Refinements/FTyconInt.class.st
+++ b/src/Refinements/FTyconInt.class.st
@@ -4,7 +4,7 @@ intFTyCon  = TC (dummyLoc ""int""       ) numTcInfo
 Class {
 	#name : #FTyconInt,
 	#superclass : #SingletonFTycon,
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #names }

--- a/src/Refinements/FTyconSet.class.st
+++ b/src/Refinements/FTyconSet.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FTyconSet,
 	#superclass : #SingletonFTycon,
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #names }

--- a/src/Refinements/FTyconUnknownBitVecSize.class.st
+++ b/src/Refinements/FTyconUnknownBitVecSize.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #FTyconUnknownBitVecSize,
 	#superclass : #FTyconBitVecSize,
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/FVar.class.st
+++ b/src/Refinements/FVar.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'i'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/Found.class.st
+++ b/src/Refinements/Found.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'x'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Environments'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/HBind.class.st
+++ b/src/Refinements/HBind.class.st
@@ -1,3 +1,17 @@
+"
+--------------------------------------------------------------------------------
+-- | @Cst@ is an NNF Horn Constraint. 
+-------------------------------------------------------------------------------
+-- Note that a @Bind@ is a simplified @F.SortedReft@ ...
+data Bind = Bind
+  { bSym  :: !F.Symbol 
+  , bSort :: !F.Sort
+  , bPred :: !Pred
+  }
+  deriving (Data, Typeable, Generic, Eq)
+  
+Cf. Horn/Types.hs
+"
 Class {
 	#name : #HBind,
 	#superclass : #Object,
@@ -6,7 +20,7 @@ Class {
 		'τ',
 		'p'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #naming }

--- a/src/Refinements/HCon.class.st
+++ b/src/Refinements/HCon.class.st
@@ -5,7 +5,7 @@ Class {
 		'symbol',
 		'sort'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/HCstr.class.st
+++ b/src/Refinements/HCstr.class.st
@@ -23,7 +23,7 @@ which in Z3 is valid iff pi∧¬qi is UNSAT.
 Class {
 	#name : #HCstr,
 	#superclass : #HThing,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }
@@ -84,6 +84,24 @@ cf. Horn/Transformations.hs
 
 { #category : #'as yet unclassified' }
 HCstr >> elim [
+"
+------------------------------------------------------------------------------
+-- | elim solves all of the KVars in a Cstr (assuming no cycles...)
+-- >>> elim . qCstr . fst <$> parseFromFile hornP 'tests/horn/pos/test00.smt2'
+-- (and (forall ((x int) (x > 0)) (forall ((y int) (y > x)) (forall ((v int) (v == x + y)) ((v > 0))))))
+-- >>> elim . qCstr . fst <$> parseFromFile hornP 'tests/horn/pos/test01.smt2'
+-- (and (forall ((x int) (x > 0)) (and (forall ((y int) (y > x)) (forall ((v int) (v == x + y)) ((v > 0)))) (forall ((z int) (z > 100)) (forall ((v int) (v == x + z)) ((v > 100)))))))
+-- >>> elim . qCstr . fst <$> parseFromFile hornP 'tests/horn/pos/test02.smt2'
+-- (and (forall ((x int) (x > 0)) (and (forall ((y int) (y > x + 100)) (forall ((v int) (v == x + y)) ((true)))) (forall ((y int) (y > x + 100)) (forall ((v int) (v == x + y)) (forall ((z int) (z == v)) (forall ((v int) (v == x + z)) ((v > 100)))))))))
+------------------------------------------------------------------------------
+elim :: Cstr a -> Cstr a 
+------------------------------------------------------------------------------
+elim c = if S.null $ boundKvars res then res else error 'called elim on cyclic constraint'
+  where
+  res = S.foldl elim1 c (boundKvars c)
+
+Cf. Horn/Transformations.hs
+"
 	| res |
 	res := self boundKVars inject: self into: [ :c :k | c elim1: k ].
 	res boundKVars isEmpty ifFalse: [ CyclicConstraint signal ].
@@ -94,11 +112,16 @@ HCstr >> elim [
 HCstr >> elim1: κ [
 	"ICFP'17 26:20.
 	By Theorem 5.9 (Elim-Preserves-Satisfiability), c elim1: κ
-	is satisfiable iff c is satisfiable.
-	
-	Find a `sol1` solution to a kvar κ,
-	and then subsitute in the solution for each rhs occurrence of κ.
-	cf. Horn/Transformations.hs"
+	is satisfiable iff c is satisfiable."
+"
+elim1 :: Cstr a -> F.Symbol -> Cstr a
+-- Find a `sol1` solution to a kvar κ, and then subsitute in the solution for
+-- each rhs occurrence of κ.
+elim1 c k = simplify $ doelim k sol c 
+  where sol = sol1 k (scope k c)
+
+Cf. Horn/Transformations.hs
+"
 	| scope sol |
 	scope := self scope: κ.
 	sol := scope sol1: κ.

--- a/src/Refinements/HDat.class.st
+++ b/src/Refinements/HDat.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #HDat,
 	#superclass : #HThing,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }

--- a/src/Refinements/HDis.class.st
+++ b/src/Refinements/HDis.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #HDis,
 	#superclass : #HThing,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }

--- a/src/Refinements/HMat.class.st
+++ b/src/Refinements/HMat.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #HMat,
 	#superclass : #HThing,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }

--- a/src/Refinements/HOpt.class.st
+++ b/src/Refinements/HOpt.class.st
@@ -4,7 +4,7 @@ Cf. 'data Config' in Types/Config.hs
 Class {
 	#name : #HOpt,
 	#superclass : #HThing,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/HOptEliminate.class.st
+++ b/src/Refinements/HOptEliminate.class.st
@@ -12,7 +12,7 @@ Class {
 	#instVars : [
 		'what'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/HOptFuel.class.st
+++ b/src/Refinements/HOptFuel.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'n'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #construction }

--- a/src/Refinements/HOptRewrite.class.st
+++ b/src/Refinements/HOptRewrite.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #HOptRewrite,
 	#superclass : #HOpt,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #construction }

--- a/src/Refinements/HOptSave.class.st
+++ b/src/Refinements/HOptSave.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #HOptSave,
 	#superclass : #HOpt,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #construction }

--- a/src/Refinements/HPred.class.st
+++ b/src/Refinements/HPred.class.st
@@ -11,6 +11,7 @@ data Pred
   | Var   !F.Symbol ![F.Symbol]                 -- ^ $k(y₁,...yₙ) 
   | PAnd  ![Pred]                               -- ^ p₁ ∧ ... ∧ pₙ 
   deriving (Data, Typeable, Generic, Eq)
+Cf. Horn/Types.hs
 
 Caveat programmator: this is H.Pred from Horn/Types.hs,
 NOT X.Pred from Types/Refinements.hs which is simply a type alias for Expr.
@@ -18,7 +19,7 @@ NOT X.Pred from Types/Refinements.hs which is simply a type alias for Expr.
 Class {
 	#name : #HPred,
 	#superclass : #Object,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/HPredAnd.class.st
+++ b/src/Refinements/HPredAnd.class.st
@@ -8,7 +8,7 @@ Class {
 	#instVars : [
 		'ps'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/HReft.class.st
+++ b/src/Refinements/HReft.class.st
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'expr'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/HThing.class.st
+++ b/src/Refinements/HThing.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #HThing,
 	#superclass : #Object,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }

--- a/src/Refinements/HVar.class.st
+++ b/src/Refinements/HVar.class.st
@@ -23,7 +23,7 @@ Class {
 		'name',
 		'domain'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/HornInfo.class.st
+++ b/src/Refinements/HornInfo.class.st
@@ -1,4 +1,6 @@
 "
+data GInfo c a = FI
+{
 cm       :: !(M.HashMap SubcId (c a))  -- ^ cst id |-> Horn Constraint
 ws       :: !(M.HashMap KVar (WfC a))  -- ^ Kvar  |-> WfC defining its scope/args
 bs       :: !BindEnv                   -- ^ Bind  |-> (Symbol, SortedReft)
@@ -12,6 +14,8 @@ ddecls   :: ![DataDecl]                -- ^ User-defined data declarations
 hoInfo   :: !HOInfo                    -- ^ Higher Order info
 asserts  :: ![Triggered Expr]          -- ^ TODO: what is this?
 ae       :: AxiomEnv                   -- ^ Information about reflected function defs
+}
+Cf. Types/Constraints.hs
 
 In Smalltalk, there is also symbolSorts, keeping an updateable master copy.
 "
@@ -31,7 +35,7 @@ Class {
 		'ddecls',
 		'options'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Refinements/HornQuery.class.st
+++ b/src/Refinements/HornQuery.class.st
@@ -30,7 +30,7 @@ Class {
 		'optionEliminate',
 		'options'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Refinements/IBindEnv.class.st
+++ b/src/Refinements/IBindEnv.class.st
@@ -1,7 +1,7 @@
 "
-Indexed Bind Environment.
+newtype IBindEnv   = FB (S.HashSet BindId) deriving (Eq, Data, Show, Typeable, Generic)
 
-newtype IBindEnv   = FB (S.HashSet BindId)
+Cf. Types/Environments.hs
 "
 Class {
 	#name : #IBindEnv,
@@ -9,7 +9,7 @@ Class {
 	#instVars : [
 		'indexes'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Environments'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/JustSub.class.st
+++ b/src/Refinements/JustSub.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #JustSub,
 	#superclass : #QPSubst,
-	#category : #Refinements
+	#category : #'Refinements-Solver'
 }

--- a/src/Refinements/KInfo.class.st
+++ b/src/Refinements/KInfo.class.st
@@ -1,6 +1,13 @@
 "
-Information about size of formula corresponding to an ""eliminated"" KVar.
-Cf. Solution.hs
+--------------------------------------------------------------------------------
+-- | Information about size of formula corresponding to an ""eliminated"" KVar.
+--------------------------------------------------------------------------------
+data KInfo = KI { kiTags  :: [Tag]
+                , kiDepth :: !Int
+                , kiCubes :: !Integer
+                } deriving (Eq, Ord, Show)
+
+Cf. Solver/Solution.hs
 "
 Class {
 	#name : #KInfo,
@@ -10,7 +17,7 @@ Class {
 		'depth',
 		'cubes'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Solver'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/KVEnv.class.st
+++ b/src/Refinements/KVEnv.class.st
@@ -1,8 +1,10 @@
 "
 type KVEnv a  = HashMap Language.Fixpoint.Symbol (Language.Fixpoint.Horn.Info.KVInfo a)
+
+Cf. Horn/Info.hs
 "
 Class {
 	#name : #KVEnv,
 	#superclass : #Dictionary,
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }

--- a/src/Refinements/KVInfo.class.st
+++ b/src/Refinements/KVInfo.class.st
@@ -12,7 +12,7 @@ Class {
 		'kvWfC',
 		'domain'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/KVSub.class.st
+++ b/src/Refinements/KVSub.class.st
@@ -7,7 +7,7 @@ Class {
 		'kVar',
 		'subst'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/KVarVertex.class.st
+++ b/src/Refinements/KVarVertex.class.st
@@ -7,7 +7,7 @@ Class {
 	#instVars : [
 		'kvar'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/Kuts.class.st
+++ b/src/Refinements/Kuts.class.st
@@ -1,10 +1,13 @@
+"
+newtype Kuts = KS { ksVars :: S.HashSet KVar }
+"
 Class {
 	#name : #Kuts,
 	#superclass : #Object,
 	#instVars : [
 		'ksVars'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/KvBads.class.st
+++ b/src/Refinements/KvBads.class.st
@@ -2,13 +2,13 @@
 type KvBads    = M.HashMap F.KVar [F.Symbol]
 "
 Class {
-	#name : #KVBads,
-	#superclass : #SEnv,
-	#category : #Refinements
+	#name : #KvBads,
+	#superclass : #Dictionary,
+	#category : #'Refinements-Solver'
 }
 
 { #category : #sanitizing }
-KVBads >> dropBadParams: k _: kEnv [
+KvBads >> dropBadParams: k _: kEnv [
 "
 dropBadParams :: KvBads -> F.KVar -> F.SEnv F.BindId -> F.SEnv F.BindId
                   self      k           kEnv

--- a/src/Refinements/KvDom.class.st
+++ b/src/Refinements/KvDom.class.st
@@ -1,15 +1,16 @@
 "
 type KvDom     = M.HashMap F.KVar (F.SEnv F.BindId)
-Cf. Sanitize.hs
+
+Cf. Solver/Sanitize.hs
 "
 Class {
-	#name : #KVDom,
+	#name : #KvDom,
 	#superclass : #Dictionary,
-	#category : #Refinements
+	#category : #'Refinements-Solver'
 }
 
 { #category : #sanitizing }
-KVDom >> restrictWf: k wfc: w [
+KvDom >> restrictWf: k wfc: w [
 "
 Restrict the env of `w` to the parameters in `kve k`.
 restrictWf :: KvDom -> F.KVar -> F.WfC a -> F.WfC a

--- a/src/Refinements/NaturalTransformation.class.st
+++ b/src/Refinements/NaturalTransformation.class.st
@@ -6,7 +6,7 @@ Class {
 		'components',
 		'preSort'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/NoSub.class.st
+++ b/src/Refinements/NoSub.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #NoSub,
 	#superclass : #QPSubst,
-	#category : #Refinements
+	#category : #'Refinements-Solver'
 }

--- a/src/Refinements/PAnd.class.st
+++ b/src/Refinements/PAnd.class.st
@@ -11,7 +11,7 @@ Class {
 	#instVars : [
 		'conjuncts'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/PAtom.class.st
+++ b/src/Refinements/PAtom.class.st
@@ -20,7 +20,7 @@ Class {
 	#pools : [
 		'Brel'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/PIff.class.st
+++ b/src/Refinements/PIff.class.st
@@ -5,7 +5,7 @@ Class {
 		'lhs',
 		'rhs'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/PKVar.class.st
+++ b/src/Refinements/PKVar.class.st
@@ -10,7 +10,7 @@ Class {
 		'var',
 		's'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/PNot.class.st
+++ b/src/Refinements/PNot.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'p'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/POr.class.st
+++ b/src/Refinements/POr.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'disjuncts'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/PatExact.class.st
+++ b/src/Refinements/PatExact.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #PatExact,
 	#superclass : #QualPattern,
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }

--- a/src/Refinements/PatNone.class.st
+++ b/src/Refinements/PatNone.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PatNone,
 	#superclass : #QualPattern,
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }
 
 { #category : #matching }

--- a/src/Refinements/PatPrefix.class.st
+++ b/src/Refinements/PatPrefix.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #PatPrefix,
 	#superclass : #QualPattern,
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }

--- a/src/Refinements/PatSuffix.class.st
+++ b/src/Refinements/PatSuffix.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #PatSuffix,
 	#superclass : #QualPattern,
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }

--- a/src/Refinements/PreSort.class.st
+++ b/src/Refinements/PreSort.class.st
@@ -20,7 +20,7 @@ data Sort = FInt
 Class {
 	#name : #PreSort,
 	#superclass : #Object,
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #hotel }

--- a/src/Refinements/QBind.class.st
+++ b/src/Refinements/QBind.class.st
@@ -1,10 +1,15 @@
+"
+newtype QBind  = QB [EQual]   deriving (Show, Data, Typeable, Generic, Eq)
+
+Cf. Types/Solutions.hs
+"
 Class {
 	#name : #QBind,
 	#superclass : #Object,
 	#instVars : [
 		'eQuals'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Solutions'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/QCSig.class.st
+++ b/src/Refinements/QCSig.class.st
@@ -5,5 +5,5 @@ Class {
 	#name : #QCSig,
 	#superclass : #Array,
 	#type : #variable,
-	#category : #Refinements
+	#category : #'Refinements-Solver'
 }

--- a/src/Refinements/QCluster.class.st
+++ b/src/Refinements/QCluster.class.st
@@ -4,7 +4,7 @@ type QCluster = M.HashMap QCSig [Qualifier]
 Class {
 	#name : #QCluster,
 	#superclass : #Dictionary,
-	#category : #Refinements
+	#category : #'Refinements-Solver'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Refinements/QPSubst.class.st
+++ b/src/Refinements/QPSubst.class.st
@@ -1,5 +1,10 @@
+"
+data QPSubst = NoSub | JustSub Int F.Symbol
+
+Cf. Solver/Solution.hs
+"
 Class {
 	#name : #QPSubst,
 	#superclass : #Object,
-	#category : #Refinements
+	#category : #'Refinements-Solver'
 }

--- a/src/Refinements/QualParam.class.st
+++ b/src/Refinements/QualParam.class.st
@@ -1,3 +1,13 @@
+"
+data QualParam = QP 
+  { qpSym  :: !Symbol
+  , qpPat  :: !QualPattern 
+  , qpSort :: !Sort
+  } 
+  deriving (Eq, Ord, Show, Data, Typeable, Generic)
+
+Cf. Types/Constraints.hs
+"
 Class {
 	#name : #QualParam,
 	#superclass : #HThing,
@@ -6,7 +16,7 @@ Class {
 		'pattern',
 		'sort'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/QualPattern.class.st
+++ b/src/Refinements/QualPattern.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #QualPattern,
 	#superclass : #Object,
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }

--- a/src/Refinements/Qualifier.class.st
+++ b/src/Refinements/Qualifier.class.st
@@ -1,3 +1,14 @@
+"
+data Qualifier = Q
+  { qName   :: !Symbol     -- ^ Name
+  , qParams :: [QualParam] -- ^ Parameters
+  , qBody   :: !Expr       -- ^ Predicate
+  , qPos    :: !SourcePos  -- ^ Source Location
+  }
+  deriving (Eq, Ord, Show, Data, Typeable, Generic)
+
+Cf. Types/Constraints.hs
+"
 Class {
 	#name : #Qualifier,
 	#superclass : #HThing,
@@ -6,7 +17,7 @@ Class {
 		'params',
 		'body'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/QueryOptions.class.st
+++ b/src/Refinements/QueryOptions.class.st
@@ -7,7 +7,7 @@ Class {
 		'save',
 		'rewriteAxioms'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #accessing }

--- a/src/Refinements/Rank.class.st
+++ b/src/Refinements/Rank.class.st
@@ -1,7 +1,10 @@
 "
-scc  :: !Int    -- ^ SCC number with ALL dependencies
-icc  :: !Int    -- ^ SCC number without CUT dependencies
-tag  :: !F.Tag  -- ^ The constraint's Tag
+data Rank = Rank { rScc  :: !Int    -- ^ SCC number with ALL dependencies
+                 , rIcc  :: !Int    -- ^ SCC number without CUT dependencies
+                 , rTag  :: !F.Tag  -- ^ The constraint's Tag
+                 } deriving (Eq, Show)
+
+Cf. Graph/Types.hs
 "
 Class {
 	#name : #Rank,
@@ -11,7 +14,7 @@ Class {
 		'icc',
 		'tag'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/RefVarApp.class.st
+++ b/src/Refinements/RefVarApp.class.st
@@ -13,7 +13,7 @@ Class {
 		'var',
 		'args'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Horn'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/Reft.class.st
+++ b/src/Refinements/Reft.class.st
@@ -37,7 +37,7 @@ Class {
 		'symbol',
 		'expr'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #naming }

--- a/src/Refinements/ResolvedPredicate.class.st
+++ b/src/Refinements/ResolvedPredicate.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'z3bool'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/SESearch.class.st
+++ b/src/Refinements/SESearch.class.st
@@ -1,7 +1,12 @@
+"
+data SESearch a = Found a | Alts [Symbol]
+
+Cf. Types/Environments.hs
+"
 Class {
 	#name : #SESearch,
 	#superclass : #Object,
-	#category : #Refinements
+	#category : #'Refinements-Environments'
 }
 
 { #category : #'case switching' }

--- a/src/Refinements/SEnv.class.st
+++ b/src/Refinements/SEnv.class.st
@@ -1,7 +1,12 @@
+"
+newtype SEnv a     = SE { seBinds :: M.HashMap Symbol a }
+
+Cf. Types/Environments.hs
+"
 Class {
 	#name : #SEnv,
 	#superclass : #Dictionary,
-	#category : #Refinements
+	#category : #'Refinements-Environments'
 }
 
 { #category : #environments }
@@ -51,7 +56,7 @@ lookupSEnv x (SE env)   = M.lookup x env
 	^self at: x ifAbsent: [ nil ]
 ]
 
-{ #category : #'*Refinements' }
+{ #category : #'as yet unclassified' }
 SEnv >> lookupSEnvWithDistance: key [
 	^Found x: (self at: key ifAbsent: [ ^Alts shouldBeImplemented  ])
 

--- a/src/Refinements/SEnv.extension.st
+++ b/src/Refinements/SEnv.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : #SEnv }
-
-{ #category : #'*Refinements' }
-SEnv >> lookupSEnvWithDistance: key [
-	^Found x: (self at: key ifAbsent: [ ^Alts shouldBeImplemented  ])
-
-]

--- a/src/Refinements/SInfo.class.st
+++ b/src/Refinements/SInfo.class.st
@@ -1,7 +1,12 @@
+"
+type SInfo a   = GInfo SimpC a
+
+Cf. Types/Constraints.hs
+"
 Class {
 	#name : #SInfo,
 	#superclass : #HornInfo,
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }
 
 { #category : #'as yet unclassified' }
@@ -41,7 +46,7 @@ badParams :: F.SInfo a -> F.SimpC a -> KvBads
 					ifNil: [ sEnv ] ifNotNil: [ sEnv insert: v ].
 				su associations select: [ :x_e | x_e value badArg: vEnv ] thenCollect: [ :xe | k -> xe key ] ].
 	bads := bads concat. "this should be renamed to #join"
-	^bads groupAssociations as: KVBads
+	^bads groupAssociations as: KvBads
 ]
 
 { #category : #'as yet unclassified' }
@@ -228,7 +233,7 @@ SInfo >> initKvarEnv [
 "
 initKvarEnv :: F.SInfo a -> KvDom
 "
-	^(ws collect: [ :each | self initEnv: each ]) as: KVDom
+	^(ws collect: [ :each | self initEnv: each ]) as: KvDom
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Refinements/SMTSem.class.st
+++ b/src/Refinements/SMTSem.class.st
@@ -14,7 +14,7 @@ data Sem
 Class {
 	#name : #SMTSem,
 	#superclass : #Object,
-	#category : #Refinements
+	#category : #'Refinements-Theories'
 }
 
 { #category : #yoneda }

--- a/src/Refinements/SemCtor.class.st
+++ b/src/Refinements/SemCtor.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SemCtor,
 	#superclass : #SMTSem,
-	#category : #Refinements
+	#category : #'Refinements-Theories'
 }
 
 { #category : #yoneda }

--- a/src/Refinements/SemField.class.st
+++ b/src/Refinements/SemField.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SemField,
 	#superclass : #SMTSem,
-	#category : #Refinements
+	#category : #'Refinements-Theories'
 }
 
 { #category : #yoneda }

--- a/src/Refinements/SemTest.class.st
+++ b/src/Refinements/SemTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SemTest,
 	#superclass : #SMTSem,
-	#category : #Refinements
+	#category : #'Refinements-Theories'
 }
 
 { #category : #yoneda }

--- a/src/Refinements/SemTheory.class.st
+++ b/src/Refinements/SemTheory.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SemTheory,
 	#superclass : #SMTSem,
-	#category : #Refinements
+	#category : #'Refinements-Theories'
 }
 
 { #category : #yoneda }

--- a/src/Refinements/SemUninterp.class.st
+++ b/src/Refinements/SemUninterp.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #SemUninterp,
 	#superclass : #SMTSem,
-	#category : #Refinements
+	#category : #'Refinements-Theories'
 }

--- a/src/Refinements/ShallowRefinement.class.st
+++ b/src/Refinements/ShallowRefinement.class.st
@@ -5,7 +5,7 @@ Class {
 		'B',
 		'e'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/SimpC.class.st
+++ b/src/Refinements/SimpC.class.st
@@ -1,10 +1,22 @@
+"
+data SimpC a = SimpC
+  { _cenv  :: !IBindEnv
+  , _crhs  :: !Expr
+  , _cid   :: !(Maybe Integer)
+  , cbind  :: !BindId               -- ^ Id of lhs/rhs binder
+  , _ctag  :: !Tag
+  , _cinfo :: !a
+  }
+  deriving (Generic, Functor)
+Cf. Types/Constraints.hs
+"
 Class {
 	#name : #SimpC,
 	#superclass : #AbstractC,
 	#instVars : [
 		'bindId'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }
 
 { #category : #visiting }

--- a/src/Refinements/SingletonFTycon.class.st
+++ b/src/Refinements/SingletonFTycon.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SingletonFTycon,
 	#superclass : #FTycon,
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #comparing }

--- a/src/Refinements/SizedEnv.class.st
+++ b/src/Refinements/SizedEnv.class.st
@@ -12,7 +12,7 @@ Class {
 		'_beSize',
 		'beBinds'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Environments'
 }
 
 { #category : #'private - instance creation' }

--- a/src/Refinements/Slice.class.st
+++ b/src/Refinements/Slice.class.st
@@ -11,7 +11,7 @@ Class {
 		'concCs',
 		'edges'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #accessing }

--- a/src/Refinements/Solution.class.st
+++ b/src/Refinements/Solution.class.st
@@ -25,7 +25,7 @@ Class {
 		'sxEnv',
 		'__binds'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Solutions'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/SolverInfo.class.st
+++ b/src/Refinements/SolverInfo.class.st
@@ -1,12 +1,16 @@
 "
-I contain all the stuff needed to produce a result,
-I am the the essential ingredient of the state needed by solve_.
+--------------------------------------------------------------------------------
+-- | `SolverInfo` contains all the stuff needed to produce a result, and is the
+--   the essential ingredient of the state needed by solve_
+--------------------------------------------------------------------------------
+data SolverInfo a b = SI
+  { siSol     :: !(F.Sol b F.QBind)             -- ^ the initial solution
+  , siQuery   :: !(F.SInfo a)                   -- ^ the whole input query
+  , siDeps    :: !CDeps                         -- ^ dependencies between constraints/ranks etc.
+  , siVars    :: !(S.HashSet F.KVar)            -- ^ set of KVars to actually solve for
+  }
 
-siSol     :: !(F.Sol b F.QBind)             -- ^ the initial solution
-siQuery   :: !(F.SInfo a)                   -- ^ the whole input query
-siDeps    :: !CDeps                         -- ^ dependencies between constraints/ranks etc.
-siVars    :: !(S.HashSet F.KVar)            -- ^ set of KVars to actually solve for
-
+Cf. Graph/Types.hs
 "
 Class {
 	#name : #SolverInfo,
@@ -17,7 +21,7 @@ Class {
 		'deps',
 		'vars'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Graph'
 }
 
 { #category : #accessing }

--- a/src/Refinements/SortSubst.class.st
+++ b/src/Refinements/SortSubst.class.st
@@ -1,11 +1,12 @@
 "
 type SortSubst = M.HashMap Symbol Sort
+
 Cf. Types/Sorts.hs
 "
 Class {
 	#name : #SortSubst,
 	#superclass : #Dictionary,
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/SortedQuantifier.class.st
+++ b/src/Refinements/SortedQuantifier.class.st
@@ -1,3 +1,8 @@
+"
+newtype SEnv a     = SE { seBinds :: M.HashMap Symbol a }
+
+Cf. Types/Environments.hs
+"
 Class {
 	#name : #SortedQuantifier,
 	#superclass : #Object,
@@ -5,7 +10,7 @@ Class {
 		'sort',
 		'quantifier'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Environments'
 }
 
 { #category : #accessing }

--- a/src/Refinements/SortedReft.class.st
+++ b/src/Refinements/SortedReft.class.st
@@ -11,7 +11,7 @@ Class {
 		'sr_sort',
 		'sr_reft'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Core'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Refinements/SubC.class.st
+++ b/src/Refinements/SubC.class.st
@@ -1,10 +1,22 @@
+"
+data SubC a = SubC
+  { _senv  :: !IBindEnv
+  , slhs   :: !SortedReft
+  , srhs   :: !SortedReft
+  , _sid   :: !(Maybe SubcId) 
+  , _stag  :: !Tag
+  , _sinfo :: !a
+  } 
+  deriving (Eq, Generic, Functor)
+Cf. Types/Constraints.hs
+"
 Class {
 	#name : #SubC,
 	#superclass : #AbstractC,
 	#instVars : [
 		'lhs'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/SymEnv.class.st
+++ b/src/Refinements/SymEnv.class.st
@@ -10,6 +10,7 @@ seLits    :: !(SEnv Sort)              -- ^ Distinct Constant symbols
 seAppls   :: !(M.HashMap FuncSort Int) -- ^ Types at which `apply` was used;
                                           --   see [NOTE:apply-monomorphization]
 }
+Cf. Types/Theories.hs
 "
 Class {
 	#name : #SymEnv,
@@ -22,7 +23,7 @@ Class {
 		'appls',
 		'naturalTransformations'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Theories'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/TC.class.st
+++ b/src/Refinements/TC.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'symbol'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #names }

--- a/src/Refinements/TVSubst.class.st
+++ b/src/Refinements/TVSubst.class.st
@@ -1,12 +1,12 @@
 "
-API for manipulating Sort Substitutions
 newtype TVSubst = Th (M.HashMap Int Sort)
+
 Cf. SortCheck.hs
 "
 Class {
 	#name : #TVSubst,
 	#superclass : #Dictionary,
-	#category : #Refinements
+	#category : #'Refinements-SortCheck'
 }
 
 { #category : #API }

--- a/src/Refinements/TheorySymbol.class.st
+++ b/src/Refinements/TheorySymbol.class.st
@@ -22,7 +22,7 @@ Class {
 		'tsSort',
 		'tsInterp'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Theories'
 }
 
 { #category : #'known theories' }

--- a/src/Refinements/UncurriedFFunc.class.st
+++ b/src/Refinements/UncurriedFFunc.class.st
@@ -5,7 +5,7 @@ Class {
 		'dom',
 		'cod'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Sorts'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Refinements/WfC.class.st
+++ b/src/Refinements/WfC.class.st
@@ -38,7 +38,7 @@ Class {
 		'env',
 		'rft'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Constraints'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/WorkItem.class.st
+++ b/src/Refinements/WorkItem.class.st
@@ -1,3 +1,11 @@
+"
+data WorkItem = WorkItem { wiCId  :: !F.SubcId   -- ^ Constraint Id
+                         , wiTime :: !Int   -- ^ Time at which inserted
+                         , wiRank :: !Rank  -- ^ Rank of constraint
+                         } deriving (Eq, Show)
+
+Cf. Solver/Worklist.hs
+"
 Class {
 	#name : #WorkItem,
 	#superclass : #Object,
@@ -6,7 +14,7 @@ Class {
 		'time',
 		'rank'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Solver'
 }
 
 { #category : #'instance creation' }

--- a/src/Refinements/WorkSet.class.st
+++ b/src/Refinements/WorkSet.class.st
@@ -1,10 +1,12 @@
 "
-I am a Set of WorkItems.
+type WorkSet  = S.Set WorkItem
+
+Cf. Solver/Worklist.hs
 "
 Class {
 	#name : #WorkSet,
 	#superclass : #Set,
-	#category : #Refinements
+	#category : #'Refinements-Solver'
 }
 
 { #category : #'Set API' }

--- a/src/Refinements/Worklist.class.st
+++ b/src/Refinements/Worklist.class.st
@@ -1,3 +1,17 @@
+"
+data Worklist a = WL { wCs     :: !WorkSet
+                     , wPend   :: !(CMap ())
+                     , wDeps   :: !(CMap [F.SubcId])
+                     , wCm     :: !(CMap (F.SimpC a))
+                     , wRankm  :: !(CMap Rank)
+                     , wLast   :: !(Maybe F.SubcId)
+                     , wRanks  :: !Int
+                     , wTime   :: !Int
+                     , wConcCs :: ![F.SubcId]
+                     }
+
+Cf. Solver/Worklist.hs
+"
 Class {
 	#name : #Worklist,
 	#superclass : #Object,
@@ -12,7 +26,7 @@ Class {
 		'time',
 		'concCs'
 	],
-	#category : #Refinements
+	#category : #'Refinements-Solver'
 }
 
 { #category : #'instance creation' }


### PR DESCRIPTION
As the MachineArithmetic project progressed, and our understanding of the upstream Fixpoint solver and the involved fundamental algorithms grew, our style of code organization and especially of comments changed. At the beginning, we mostly followed the received Smalltalk-80 culture: CRC, Design Patterns etc.  The switch of the nature of the computational process leads to a change of style.  The resulting stylistic mix has grown into a mess which is starting to impede programmer productivity.

The present commit tries to improve this situation by doing two things:

1. It breaks the Refinements package up into tags following the structure of the upstream.  At this time, this is purely syntactic: no attempt is made at a "good Smalltalk (80 or 25) object design".

2. It tries to reduce the motley kaleidoscope of comment styles to a systematic dichotomy according to the [Buenos Aires FASTWS'22 paper](https://openreview.net/pdf?id=AaMvINlc7d) which talks about "implementing Cosman–Jhala’s FUSION, mutatis mutandis due to our use of Smalltalk".  Where our code follows Cosman–Jhala, we simply refer to its provenance in the upstream.  On the other hand, the parts that are unique to Smalltalk, are explained in free-form prose caring to concentrate on the reasons why the diversion was necessary.