### PR TITLE
[PP] Allow spaces "inside" `#parens` parser

### DIFF
--- a/src/PreSmalltalks-Parser/PPParser.extension.st
+++ b/src/PreSmalltalks-Parser/PPParser.extension.st
@@ -105,8 +105,14 @@ parses to {1->true. 2->false}.
 { #category : #'*PreSmalltalks-Parser' }
 PPParser >> parens [
 	"NB: () will parse to nil."
-	^$( asParser, self optional, $) asParser
+	^$( asParser trimRight, self optional, $) asParser trimLeft
 	==> #second
+	
+	"
+	$x asParser parens parse: '()'
+	$x asParser parens parse: '( x  )'
+	$x asParser parens parse: '(  )'
+	"
 ]
 
 { #category : #'*PreSmalltalks-Parser' }

--- a/src/PreSmalltalks-Tests/PParserExtensionsTest.class.st
+++ b/src/PreSmalltalks-Tests/PParserExtensionsTest.class.st
@@ -5,6 +5,15 @@ Class {
 }
 
 { #category : #tests }
+PParserExtensionsTest >> testParens [
+	self assert: ($x asParser parens parse: '()') isNil.
+	self assert: ($x asParser parens parse: '(x)') = $x.
+	self assert: ($x asParser parens parse: '( x  )') = $x.
+	self assert: ($x asParser parens parse: '(  )') isNil
+
+]
+
+{ #category : #tests }
 PParserExtensionsTest >> testPostconditionFail [
 	| intP intOtherThan42P p |
 	intP := #digit asParser plus flatten ==> #asInteger.


### PR DESCRIPTION
The `#parens` parser seem to be unnecessarily strict. For example: consider following parser `$x asParser parens`. This parser parses `'(x)'` and `'()'` but *not* `'( x )'` nor `'( )'`.

This results in a lot of confusion, because in most languages (at least in most those we parse) spaces are not significant (or should not be).

So this commit relaxed `#parens` so that it allow spaces inside parens. With this change, all the above inputs parse just fine.