### PR TITLE
Don't assume any `ΛPrimOp` stands for an `EBin`

### DIFF
--- a/src/SpriteLang/BAnd.class.st
+++ b/src/SpriteLang/BAnd.class.st
@@ -13,3 +13,11 @@ BAnd class >> operator [
 BAnd class >> rTypeSrc [
 	^'x:bool => y:bool => bool[v|v <=> (x & y)]'
 ]
+
+{ #category : #'reflect - embedding' }
+BAnd >> embedPrim: es [
+"
+embedPrim BAnd   es       = F.PAnd es
+"
+	^PAnd of: es
+]

--- a/src/SpriteLang/BEq.class.st
+++ b/src/SpriteLang/BEq.class.st
@@ -15,6 +15,13 @@ BEq class >> rTypeSrc [
 ]
 
 { #category : #'reflect - embedding' }
-BEq class >> smalltalkSelector [
-	^#'==='
+BEq >> embedPrim: args [
+"
+embedPrim BEq    [e1, e2] = F.PAtom F.Eq    e1 e2
+"
+	self assert: args size = 2.
+	^PAtom
+		brel: #===
+		x: args first
+		y: args second
 ]

--- a/src/SpriteLang/BGe.class.st
+++ b/src/SpriteLang/BGe.class.st
@@ -15,6 +15,13 @@ BGe class >> rTypeSrc [
 ]
 
 { #category : #'reflect - embedding' }
-BGe class >> smalltalkSelector [
-	^#>=
+BGe >> embedPrim: args [
+"
+embedPrim BGe    [e1, e2] = F.PAtom F.Ge    e1 e2
+"
+	self assert: args size = 2.
+	^PAtom
+		brel: #>=
+		x: args first
+		y: args second
 ]

--- a/src/SpriteLang/BGt.class.st
+++ b/src/SpriteLang/BGt.class.st
@@ -15,6 +15,13 @@ BGt class >> rTypeSrc [
 ]
 
 { #category : #'reflect - embedding' }
-BGt class >> smalltalkSelector [
-	^#>
+BGt >> embedPrim: args [
+"
+embedPrim BGt    [e1, e2] = F.PAtom F.Gt    e1 e2
+"
+	self assert: args size = 2.
+	^PAtom
+		brel: #>
+		x: args first
+		y: args second
 ]

--- a/src/SpriteLang/BIff.class.st
+++ b/src/SpriteLang/BIff.class.st
@@ -13,3 +13,11 @@ BIff class >> operator [
 BIff class >> rTypeSrc [
 	^'x:''a => y:''a => bool[zzz|zzz <=> (x <=> y)]'
 ]
+
+{ #category : #'reflect - embedding' }
+BIff >> embedPrim: args [
+	self assert: args size = 2.
+	^PIff
+		lhs: args first
+		rhs: args second
+]

--- a/src/SpriteLang/BImply.class.st
+++ b/src/SpriteLang/BImply.class.st
@@ -13,3 +13,8 @@ BImply class >> operator [
 BImply class >> rTypeSrc [
 	^'x:''a => y:''a => bool[zzz|zzz <=> (x ==> y)]'
 ]
+
+{ #category : #'reflect - embedding' }
+BImply >> embedPrim: args [
+	self shouldBeImplemented "need PImp"
+]

--- a/src/SpriteLang/BLe.class.st
+++ b/src/SpriteLang/BLe.class.st
@@ -15,6 +15,13 @@ BLe class >> rTypeSrc [
 ]
 
 { #category : #'reflect - embedding' }
-BLe class >> smalltalkSelector [
-	^#<=
+BLe >> embedPrim: args [
+"
+embedPrim BLe    [e1, e2] = F.PAtom F.Le    e1 e2
+"
+	self assert: args size = 2.
+	^PAtom
+		brel: #<=
+		x: args first
+		y: args second
 ]

--- a/src/SpriteLang/BLt.class.st
+++ b/src/SpriteLang/BLt.class.st
@@ -15,6 +15,13 @@ BLt class >> rTypeSrc [
 ]
 
 { #category : #'reflect - embedding' }
-BLt class >> smalltalkSelector [
-	^#<
+BLt >> embedPrim: args [
+"
+embedPrim BLt    [e1, e2] = F.PAtom F.Lt    e1 e2
+"
+	self assert: args size = 2.
+	^PAtom
+		brel: #<
+		x: args first
+		y: args second
 ]

--- a/src/SpriteLang/BMinus.class.st
+++ b/src/SpriteLang/BMinus.class.st
@@ -15,6 +15,13 @@ BMinus class >> rTypeSrc [
 ]
 
 { #category : #'reflect - embedding' }
-BMinus class >> smalltalkSelector [
-	^#-
+BMinus >> embedPrim: args [
+"
+embedPrim BMinus [e1, e2] = F.EBin  F.Minus e1 e2
+"
+	self assert: args size = 2.
+	^EBin
+		bop: #-
+		left: args first
+		right: args second
 ]

--- a/src/SpriteLang/BNe.class.st
+++ b/src/SpriteLang/BNe.class.st
@@ -13,3 +13,12 @@ BNe class >> operator [
 BNe class >> rTypeSrc [
 	^'x:''a => y:''a => bool[zzz|zzz <=> (x === y) not]'
 ]
+
+{ #category : #'reflect - embedding' }
+BNe >> embedPrim: args [
+	self assert: args size = 2.
+	^(PAtom
+		brel: #===
+		x: args first
+		y: args second) not
+]

--- a/src/SpriteLang/BOr.class.st
+++ b/src/SpriteLang/BOr.class.st
@@ -13,3 +13,11 @@ BOr class >> operator [
 BOr class >> rTypeSrc [
 	^'x:bool => y:bool => bool[v|v <=> (x | y)]'
 ]
+
+{ #category : #'reflect - embedding' }
+BOr >> embedPrim: es [
+"
+embedPrim BOr    es       = F.POr  es
+"
+	^POr of: es
+]

--- a/src/SpriteLang/BPlus.class.st
+++ b/src/SpriteLang/BPlus.class.st
@@ -15,6 +15,13 @@ BPlus class >> rTypeSrc [
 ]
 
 { #category : #'reflect - embedding' }
-BPlus class >> smalltalkSelector [
-	^#+
+BPlus >> embedPrim: args [
+"
+embedPrim BPlus  [e1, e2] = F.EBin  F.Plus  e1 e2
+"
+	self assert: args size = 2.
+	^EBin
+		bop: #+
+		left: args first
+		right: args second
 ]

--- a/src/SpriteLang/BTimes.class.st
+++ b/src/SpriteLang/BTimes.class.st
@@ -15,6 +15,13 @@ BTimes class >> rTypeSrc [
 ]
 
 { #category : #'reflect - embedding' }
-BTimes class >> smalltalkSelector [
-	^#*
+BTimes >> embedPrim: args [
+"
+embedPrim BTimes [e1, e2] = F.EBin  F.Times e1 e2
+"
+	self assert: args size = 2.
+	^EBin
+		bop: #*
+		left: args first
+		right: args second
 ]

--- a/src/SpriteLang/BVOp.class.st
+++ b/src/SpriteLang/BVOp.class.st
@@ -70,8 +70,12 @@ BVOp class >> rTypeSrc [
 ]
 
 { #category : #'reflect - embedding' }
-BVOp class >> smalltalkSelector [
-	^self shouldNotImplement
+BVOp >> embedPrim: args [
+	self assert: args size = 2.
+	^EBin
+		bop: selector
+		left: args first
+		right: args second
 ]
 
 { #category : #accessing }
@@ -115,9 +119,4 @@ BVOp >> signature [
 { #category : #initialization }
 BVOp >> signature: anObject [
 	signature := anObject
-]
-
-{ #category : #'reflect - embedding' }
-BVOp >> smalltalkSelector [
-	^selector
 ]

--- a/src/SpriteLang/ΛPrimOp.class.st
+++ b/src/SpriteLang/ΛPrimOp.class.st
@@ -14,11 +14,6 @@ Class {
 	self subclassResponsibility 
 ]
 
-{ #category : #'reflect - embedding' }
-ΛPrimOp class >> smalltalkSelector [
-	^self subclassResponsibility
-]
-
 { #category : #selfifization }
 ΛPrimOp >> binOpTy [
 	^self rType
@@ -40,11 +35,7 @@ Class {
 embedPrim :: PrimOp -> [F.Expr] -> F.Expr
 Cf. L₈ Reflect.hs
 "
-	self assert: args size = 2.
-	^EBin
-		bop: self smalltalkSelector
-		left: args first
-		right: args second
+	^self subclassResponsibility
 ]
 
 { #category : #printing }
@@ -60,9 +51,4 @@ Cf. L₈ Reflect.hs
 { #category : #selfification }
 ΛPrimOp >> rTypeSrc [
 	^self class rTypeSrc
-]
-
-{ #category : #'reflect - embedding' }
-ΛPrimOp >> smalltalkSelector [
-	^self class smalltalkSelector
 ]


### PR DESCRIPTION
The theory that all `ΛPrimOps` are `EBin`s, is just plain bogus.
For example, `BLt` (`<`) is a `PAtom`: a relation, not a term.
And therefore `#smalltalkSelector` as the [sole] differentiator
between `PrimOp`s is useless.