### PR TITLE
Don't print a textual formula for `exprReft` only to parse it back

### DIFF
--- a/src/SpriteLang/PBin.class.st
+++ b/src/SpriteLang/PBin.class.st
@@ -12,7 +12,7 @@ PBin class >> primOp: primOp [
 	^self basicNew primOp: primOp; yourself 
 ]
 
-{ #category : #'primitive types' }
+{ #category : #selfification }
 PBin >> constTy [
 "
 constTy l (PBin  o)     = binOpTy l o

--- a/src/SpriteLang/PBitVector.class.st
+++ b/src/SpriteLang/PBitVector.class.st
@@ -16,14 +16,11 @@ PBitVector class >> length: length value: value [
 		yourself.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #selfification }
 PBitVector >> constTy [
-	| freshVar exprReft |
-	freshVar := '_VV'.
-	exprReft := Reft
-		symbol: freshVar
-		expr: (DecidableRefinement text: freshVar, ' === (', value printString ,' toBitVector: ', length printString ,' )').
-	^TBase b: (TBitVector instance: length) r: exprReft known
+	^TBase
+		b: (TBitVector instance: length)
+		r: (value///length) exprReft known
 ]
 
 { #category : #'term rewriting' }

--- a/src/SpriteLang/PBool.class.st
+++ b/src/SpriteLang/PBool.class.st
@@ -22,7 +22,7 @@ PBool >> bool: anObject [
 	bool := anObject
 ]
 
-{ #category : #'primitive types' }
+{ #category : #selfification }
 PBool >> constTy [
 
 "

--- a/src/SpriteLang/PInt.class.st
+++ b/src/SpriteLang/PInt.class.st
@@ -15,7 +15,7 @@ PInt class >> integer: integer [
 	^self basicNew integer: integer; yourself 
 ]
 
-{ #category : #'primitive types' }
+{ #category : #selfification }
 PInt >> constTy [
 "
 constTy _ (PInt  n)     = TBase TInt  (known $ F.exprReft (F.expr n))

--- a/src/SpriteLang/ΛPrim.class.st
+++ b/src/SpriteLang/ΛPrim.class.st
@@ -9,7 +9,7 @@ Class {
 	^self
 ]
 
-{ #category : #'primitive types' }
+{ #category : #selfification }
 ΛPrim >> constTy [
 "
 constTy :: F.SrcSpan -> Prim -> RType


### PR DESCRIPTION
Instead of computing the exprReft in some extravagant way, it's enough to send #exprReft to the expr (be that an F.Expr or a Z3Node).