### PR TITLE
[Test parsing] Change `bindP` to take `symbolP` for var id

### DIFF
--- a/src/Refinements-Parsing/FQParser.class.st
+++ b/src/Refinements-Parsing/FQParser.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #grammar }
 FQParser >> bind [
-	^ self class lowerId trim,
+	^ self class symbol trim,
 	$: asParser
 	==> #first
 ]

--- a/src/Refinements-Tests/FQPosTest.class.st
+++ b/src/Refinements-Tests/FQPosTest.class.st
@@ -414,6 +414,13 @@ constraint:
 ]
 
 { #category : #tests }
+FQPosTest >> testFuncArg [
+	self provePos: '
+bind 0 foo : {VV : func(0, [func(0, [int])]) | Bool true}
+'.
+]
+
+{ #category : #tests }
 FQPosTest >> testTest00a [
 	self provePos: '
 qualif Zog(v:`a) : (10 <= v)


### PR DESCRIPTION
LF commit [53695d](https://github.com/ucsd-progsys/liquid-fixpoint/commit/53695d0f9c12d6e39149653089bbe4ae2b70d66b) changed variable id in `bindP` from `lowerIdP` to `symbolP`.
This is later used in e.g. `pos/func-arg.fq`.