### PR TITLE
Express Set operations consistently with upstream

### DIFF
--- a/src/Refinements-Tests/FQPosTest.class.st
+++ b/src/Refinements-Tests/FQPosTest.class.st
@@ -421,6 +421,47 @@ bind 0 foo : {VV : func(0, [func(0, [int])]) | Bool true}
 ]
 
 { #category : #tests }
+FQPosTest >> testSets01 [
+	self provePos: '
+bind 1 m1 : {v : Set_Set Int | v === (Set_empty∘0) }
+bind 2 m2 : {v : Set_Set Int | v === (Set_cup value: (Set_cup value: m1 value: Set_sng∘10) value: Set_sng∘20) }
+bind 3 m3 : {v : Set_Set Int | v === (Set_cup value: (Set_cup value: m1 value: Set_sng∘20) value: Set_sng∘10) }
+bind 4 m4 : {v : Set_Set Int | v === (Set_cup value: m1 value: Set_sng∘10) }
+bind 5 m5 : {v : Set_Set Int | v === (Set_cup value: m1 value: Set_sng∘20) }
+
+constraint:
+  env [1]
+  lhs {v : int | Bool true }
+  rhs {v : int | (Set_mem value: 100 value: m1) not }
+  id 1 tag []
+
+constraint:
+  env [1;2]
+  lhs {v : int | Bool true }
+  rhs {v : int | (Set_mem value: 100 value: m2) not }
+  id 2 tag []
+
+constraint:
+  env [1;2]
+  lhs {v : int | Bool true }
+  rhs {v : int | Set_mem value: 10 value: m2 }
+  id 3 tag []
+
+constraint:
+  env [1;2;3]
+  lhs {v : int | Bool true }
+  rhs {v : int | m2 === m3 }
+  id 4 tag []
+
+constraint:
+  env [1;2;3;4;5]
+  lhs {v : int | Bool true }
+  rhs {v : int | m2 === (Set_cup value: m4 value: m5) }
+  id 5 tag []
+'.
+]
+
+{ #category : #tests }
 FQPosTest >> testTest00a [
 	self provePos: '
 qualif Zog(v:`a) : (10 <= v)

--- a/src/Refinements/Expr.class.st
+++ b/src/Refinements/Expr.class.st
@@ -472,13 +472,6 @@ Expr >> isConstantNamed: s [
 	^false
 ]
 
-{ #category : #'theory symbols' }
-Expr >> isEmptySet [
-	^ECst
-		e: (EMessageSend of: (MessageSend receiver: self selector: #isEmptySet))
-		sort: Bool sort
-]
-
 { #category : #testing }
 Expr >> isKVar [
 	^false

--- a/src/Refinements/PNot.class.st
+++ b/src/Refinements/PNot.class.st
@@ -23,6 +23,14 @@ PNot >> accept: aVisitor [
 ]
 
 { #category : #elaboration }
+PNot >> elab: γ [
+	^{
+		PNot of: (p elab: γ) first.
+		Bool sort
+	}
+]
+
+{ #category : #elaboration }
 PNot >> elabApplyStep: γ [ 
 	^PNot of: (p elabApply: γ)
 ]

--- a/src/Refinements/TheorySymbol.class.st
+++ b/src/Refinements/TheorySymbol.class.st
@@ -38,8 +38,15 @@ Cf. Smt/Theories.hs
 		 (the first argument to the block) — which are guaranteed to be
 		 Z3 nodes — and the Z3 return sort in the second argument to the
 		 block."
-		'setAdd' interpSym: [ :args :_ | args first add: args second ] sort: TheorySymbol setAddSort.
-		'toBitVector' interpSym: [ :args :returnSort | args first toBitVector: returnSort length ] sort: TheorySymbol toBitVectorSort.
+
+		'Set_empty' interpSym: [ :args :returnSort | Z3Set emptyOf: returnSort domain ] sort: self setEmptySort.
+		'Set_sng' interpSym: [ :args :_ | Z3Set with: args first ] sort: self setSngSort.
+		'Set_add' interpSym: [ :args :_ | args first add: args second ] sort: self setAddSort.
+		'Set_cup' interpSym: [ :args :_ | args first ∪ args second ] sort: self setBopSort.
+		'Set_cap' interpSym: [ :args :_ | args first ∩ args second ] sort: self setBopSort.
+		'Set_mem' interpSym: [ :args :_ | args first ∈ args second ] sort: self setMemSort.
+		
+		'toBitVector' interpSym: [ :args :returnSort | args first toBitVector: returnSort length ] sort: self toBitVectorSort.
 	}
 ]
 
@@ -53,6 +60,57 @@ setAddSort = FAbs 0 $ FFunc (setSort $ FVar 0) $ FFunc (FVar 0)           (setSo
 		sort: (FFunc
 			from: (FVar new: 0) mkSetSort
 			to: (FFunc from: (FVar new: 0) to: (FVar new: 0) mkSetSort))
+]
+
+{ #category : #'known theories' }
+TheorySymbol class >> setBopSort [
+"
+setAddSort = FAbs 0 $ FFunc (setSort $ FVar 0) $ FFunc (FVar 0)           (setSort $ FVar 0) →
+setBopSort = FAbs 0 $ FFunc (setSort $ FVar 0) $ FFunc (setSort $ FVar 0) (setSort $ FVar 0)
+"
+	^FAbs
+		int: 0
+		sort: (FFunc
+			from: (FVar new: 0) mkSetSort
+			to: (FFunc from: (FVar new: 0) mkSetSort to: (FVar new: 0) mkSetSort))
+]
+
+{ #category : #'known theories' }
+TheorySymbol class >> setEmptySort [
+"
+(FAbs 0 $ FFunc intSort (setSort $ FVar 0))
+"
+	^FAbs
+		int: 0
+		sort: (FFunc
+			from: Int sort
+			to: (FVar new: 0) mkSetSort)
+]
+
+{ #category : #'known theories' }
+TheorySymbol class >> setMemSort [
+"
+setMemSort = FAbs 0 $ FFunc (FVar 0) $ FFunc (setSort $ FVar 0) boolSort
+"
+	^FAbs
+		int: 0
+		sort: (FFunc
+			from: (FVar new: 0)
+			to: (FFunc
+					from: (FVar new: 0) mkSetSort
+					to: Bool sort))
+]
+
+{ #category : #'known theories' }
+TheorySymbol class >> setSngSort [
+"
+(FAbs 0 $ FFunc (FVar 0) (setSort $ FVar 0))
+"
+	^FAbs
+		int: 0
+		sort: (FFunc
+			from: (FVar new: 0)
+			to: (FVar new: 0) mkSetSort)
 ]
 
 { #category : #'known theories' }

--- a/src/SpriteLang-Tests/L5NegTest.class.st
+++ b/src/SpriteLang-Tests/L5NegTest.class.st
@@ -144,12 +144,12 @@ L5NegTest >> test_listSet [
 ⟦measure elts : list(''a) => Set_Set(''a)⟧
 
 type list(''a) =
-  | Nil                      => [v| (elts∘v) isEmptySet]
-  | Cons (x:''a, xs:list(''a)) => [v| (elts∘v) === (setAdd value: elts∘xs value: x)]
+  | Nil                        => [v| elts∘v === (Set_empty∘0)]
+  | Cons (x:''a, xs:list(''a)) => [v| elts∘v === (Set_add value: elts∘xs value: x)]
   ;
 
 
-⟦val app : xs:list(''a) => ys:list(''a) => list(''a)[v|(elts∘v) === ((elts∘xs) ∪ (elts∘xs))]⟧
+⟦val app : xs:list(''a) => ys:list(''a) => list(''a)[v|elts∘v === (Set_cup value: elts∘xs value: elts∘xs)]⟧
 let rec app = (xs, ys) => {
   switch (xs) {
     | Nil        => ys

--- a/src/SpriteLang-Tests/L5PosTest.class.st
+++ b/src/SpriteLang-Tests/L5PosTest.class.st
@@ -294,12 +294,12 @@ L5PosTest >> test_listSet [
 ⟦measure elts : list(''a) => Set_Set(''a)⟧
 
 type list(''a) =
-  | Nil                      => [v| (elts value: v) isEmptySet]
-  | Cons (x:''a, xs:list(''a)) => [v| (elts∘v) === (setAdd value: elts∘xs value: x)]
+  | Nil                        => [v| elts∘v === (Set_empty∘0)]
+  | Cons (x:''a, xs:list(''a)) => [v| elts∘v === (Set_add value: elts∘xs value: x)]
   ;
 
 
-⟦val app : xs:list(''a) => ys:list(''a) => list(''a)[v|(elts∘v) === ((elts∘xs) ∪ (elts∘ys))]⟧
+⟦val app : xs:list(''a) => ys:list(''a) => list(''a)[v|elts∘v === (Set_cup value: elts∘xs value: elts∘ys)]⟧
 let rec app = (xs, ys) => {
   switch (xs) {
     | Nil        => ys

--- a/src/SpriteLang-Tests/SpriteHornPosTest.class.st
+++ b/src/SpriteLang-Tests/SpriteHornPosTest.class.st
@@ -1049,21 +1049,21 @@ SpriteHornPosTest >> testL5listSet [
   (forall ((xs (`l `a)) (Bool true))
    (forall ((ys (`l `a)) (Bool true))
     (and
-     (forall ((xs (`l `a)) ((elts∘xs) isEmptySet))
+     (forall ((xs (`l `a)) (elts∘xs === (Set_empty∘0)))
        (forall ((VV (`l `a)) (VV === ys))
         (((elts∘VV === ((elts∘xs) ∪ (elts∘ys)))))))
      (forall ((h `a) (Bool true))
       (forall ((t (`l `a)) (Bool true))
-       (forall ((xs (`l `a)) ((elts∘xs) === (setAdd value: (elts∘t) value: h)))
+       (forall ((xs (`l `a)) (elts∘xs === (Set_add value: (elts∘t) value: h)))
         (and
          (forall ((VV `a) (Bool true)) (($k1 VV xs t ys h)))
          (forall ((VV `a) (Bool true)) (($k1 VV t t ys h)))
-         (forall ((rest (`l `a)) (elts∘rest === ((elts∘t) ∪ (elts∘ys))))
+         (forall ((rest (`l `a)) (elts∘rest === (Set_cup value: elts∘t value: elts∘ys)))
           (and
             (forall ((VV `a) (VV === h)) (($k3 VV xs t ys h rest)))
             (forall ((VV0 `a) ($k1 VV0 t t ys h)) (($k3 VV0 xs t ys h rest)))
-            (forall ((v (`l `a)) (elts∘v === (setAdd value: (elts∘rest) value: h)))
-             (((elts∘v === ((elts∘xs) ∪ (elts∘ys)))))))))))))))))
+            (forall ((v (`l `a)) (elts∘v === (Set_add value: elts∘rest value: h)))
+             (((elts∘v === (Set_cup value: elts∘xs value: elts∘ys))))))))))))))))
 '
 
 ]

--- a/src/Z3/Z3Set.class.st
+++ b/src/Z3/Z3Set.class.st
@@ -67,11 +67,6 @@ Z3Set >> intersection: anotherSet [
 ]
 
 { #category : #'set theory' }
-Z3Set >> isEmptySet [
-	^self === (Z3Set emptyOf: self sort domain)
-]
-
-{ #category : #'set theory' }
 Z3Set >> isSubsetOf: anotherSet [
 	"Check for subsetness of sets."
 	anotherSet ensureSet.


### PR DESCRIPTION
Our naïve attempt to be polymorphic with standard Smalltalk-80 selectors made sense ~7 years ago, but now we understand the need for separate, proper LiquidSmalltalk.

At this point, don't let this inconsistency with the upstream, get in the way of the current Type-Constructor work (in particular BitVector type-constructor work).