### PR TITLE
Generalize Sprite to provide access to any of the builtin type-constructors and functions

### DIFF
--- a/src/Refinements/TheorySymbol.class.st
+++ b/src/Refinements/TheorySymbol.class.st
@@ -26,6 +26,11 @@ Class {
 }
 
 { #category : #'known theories' }
+TheorySymbol class >> interpSymbol: key [
+	^(Dictionary newFromAssociations: self interpSymbols) at: key
+]
+
+{ #category : #'known theories' }
 TheorySymbol class >> interpSymbols [
 "
 interpSymbols :: [(Symbol, TheorySymbol)]

--- a/src/SpriteLang-Tests/SpriteSetNegTest.class.st
+++ b/src/SpriteLang-Tests/SpriteSetNegTest.class.st
@@ -1,0 +1,55 @@
+Class {
+	#name : #SpriteSetNegTest,
+	#superclass : #SpriteLangNegTest,
+	#category : #'SpriteLang-Tests-Simple'
+}
+
+{ #category : #tests }
+SpriteSetNegTest >> test_Cap_10 [
+	self processString: '
+⟦val check : int => bool[v|v]⟧
+let check = (x) => {
+  let ten = Set_sng(10);
+  let twenty = Set_sng(20);
+  let intersection = Set_cap(ten, twenty);
+  let t = Set_mem(10, intersection);
+  t
+};
+'
+]
+
+{ #category : #tests }
+SpriteSetNegTest >> test_Cup [
+	self processString: '
+⟦val check : int => bool[v|v]⟧
+let check = (x) => {
+  let ten = Set_sng(10);
+  let twenty = Set_sng(20);
+  let both = Set_cup(ten, twenty);
+  let t = Set_mem(42, both);
+  t
+};
+'
+]
+
+{ #category : #tests }
+SpriteSetNegTest >> test_EmptySetHasNoElements [
+	self processString: '
+⟦val check : x:int => xs:Set_Set(int)[v| v === (Set_empty∘0)] => int[v| Set_mem value: x value: xs ]⟧
+let check = (x, xs) => {
+  0
+};
+'
+]
+
+{ #category : #tests }
+SpriteSetNegTest >> test_Singleton [
+	self processString: '
+⟦val check : int => bool[v|v]⟧
+let check = (x) => {
+  let xs = Set_sng(42);
+  let t = Set_mem(43, xs);
+  t
+};
+'
+]

--- a/src/SpriteLang-Tests/SpriteSetPosTest.class.st
+++ b/src/SpriteLang-Tests/SpriteSetPosTest.class.st
@@ -1,0 +1,84 @@
+Class {
+	#name : #SpriteSetPosTest,
+	#superclass : #SpriteLangPosTest,
+	#category : #'SpriteLang-Tests-Simple'
+}
+
+{ #category : #tests }
+SpriteSetPosTest >> test_Cup_10 [
+	self processString: '
+⟦val check : int => bool[v|v]⟧
+let check = (x) => {
+  let ten = Set_sng(10);
+  let twenty = Set_sng(20);
+  let both = Set_cup(ten, twenty);
+  let t = Set_mem(10, both);
+  t
+};
+'
+]
+
+{ #category : #tests }
+SpriteSetPosTest >> test_Cup_20 [
+	self processString: '
+⟦val check : int => bool[v|v]⟧
+let check = (x) => {
+  let ten = Set_sng(10);
+  let twenty = Set_sng(20);
+  let both = Set_cup(ten, twenty);
+  let t = Set_mem(20, both);
+  t
+};
+'
+]
+
+{ #category : #tests }
+SpriteSetPosTest >> test_EmptySetHasNoElements_00 [
+	self processString: '
+⟦val check : x:int => xs:Set_Set(int)[v| v === (Set_empty∘0)] => int[v| (Set_mem value: x value: xs) not ]⟧
+let check = (x, xs) => {
+  0
+};
+'
+]
+
+{ #category : #tests }
+SpriteSetPosTest >> test_EmptySetHasNoElements_01 [
+	self processString: '
+⟦val not : x:bool => bool[v|x <=> v not]⟧
+let not = (x) => { if (x) {false} else {true} };
+
+⟦val check : x:int => xs:Set_Set(int)[v| v === (Set_empty∘0)] => bool[v|v]⟧
+let check = (x, xs) => {
+  let t = Set_mem(x, xs);
+  not(t)
+};
+'
+]
+
+{ #category : #tests }
+SpriteSetPosTest >> test_EmptySetHasNoElements_02 [
+	self processString: '
+⟦val not : x:bool => bool[v|x <=> v not]⟧
+let not = (x) => { if (x) {false} else {true} };
+
+⟦val check : x:int => bool[v|v]⟧
+let check = (x) => {
+  let xs = Set_empty(0);
+  let t = Set_mem(x, xs);
+  not(t)
+};
+'
+]
+
+{ #category : #tests }
+SpriteSetPosTest >> test_Singleton [
+	self processString: '
+⟦val check : int => bool[v|v]⟧
+let check = (x) => {
+  let xs = Set_sng(42);
+  let t = Set_mem(42, xs);
+  t
+};
+'
+]

--- a/src/SpriteLang/FAbs.extension.st
+++ b/src/SpriteLang/FAbs.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #FAbs }
+
+{ #category : #'*SpriteLang' }
+FAbs >> constTyApp: function [
+	^TAll
+		var: (TVar index: int) symbol
+		type: (sort constTyApp: function)
+]

--- a/src/SpriteLang/FApp.extension.st
+++ b/src/SpriteLang/FApp.extension.st
@@ -1,0 +1,24 @@
+Extension { #name : #FApp }
+
+{ #category : #'*SpriteLang' }
+FApp >> constTyApp: value [
+	| v |
+	v := 'theoryFunctionV'.
+	^self refinedBy: (Reft
+			symbol: v
+			expr: (PAtom brel: #=== x: (EVar of: v) y: value)) known
+]
+
+{ #category : #'*SpriteLang' }
+FApp >> refinedBy: r [
+	^TCon
+		c: s typeConstructor symbol
+		ts: {t sort2bTrue}
+		ars: #()
+		r: r
+]
+
+{ #category : #'*SpriteLang' }
+FApp >> sort2bTrue [
+	^self refinedBy: Reft trueReft known
+]

--- a/src/SpriteLang/FFunc.extension.st
+++ b/src/SpriteLang/FFunc.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #FFunc }
+
+{ #category : #'*SpriteLang' }
+FFunc >> constTyApp: function [
+	| argNumCell argName arg fx |
+	argNumCell := Context readState: #argNumber.
+	argName := 'theoryFunctionArg' varSubscript: argNumCell first.
+	arg := EVar of: argName.
+	argNumCell at: 1 put: argNumCell first+1.
+	fx := EApp fun: function imm: arg.
+	^TFun
+			x: argName
+			s: from sort2bTrue
+			t: (to constTyApp: fx)
+]

--- a/src/SpriteLang/FVar.extension.st
+++ b/src/SpriteLang/FVar.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FVar }
+
+{ #category : #'*SpriteLang' }
+FVar >> sort2bTrue [
+	^(TVar index: i) bTrue
+]

--- a/src/SpriteLang/PreSort.extension.st
+++ b/src/SpriteLang/PreSort.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #PreSort }
+
+{ #category : #'*SpriteLang' }
+PreSort >> constTyApp: f [
+	^self subclassResponsibility
+]
+
+{ #category : #'*SpriteLang' }
+PreSort >> sort2bTrue [
+	^self subclassResponsibility
+]

--- a/src/SpriteLang/TVar.class.st
+++ b/src/SpriteLang/TVar.class.st
@@ -7,7 +7,14 @@ Class {
 	#category : #SpriteLang
 }
 
-{ #category : #accessing }
+{ #category : #'instance creation' }
+TVar class >> index: j [ 
+	| s |
+	s := '@(', j printString, ')'.
+	^self symbol: s encodeUnsafe
+]
+
+{ #category : #'instance creation' }
 TVar class >> symbol: s [
 	^self basicNew symbol: s; yourself
 ]

--- a/src/SpriteLang/TheorySymbol.extension.st
+++ b/src/SpriteLang/TheorySymbol.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #TheorySymbol }
+
+{ #category : #'*SpriteLang' }
+TheorySymbol >> constTy [
+	(tsInterp = SemTheory) ifFalse: [ self error ].
+	[^tsSort constTyApp: (EVar of: tsSym)] runReader: #argNumber initialState: {1}
+]

--- a/src/SpriteLang/Z3BoolSort.extension.st
+++ b/src/SpriteLang/Z3BoolSort.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Z3BoolSort }
+
+{ #category : #'*SpriteLang' }
+Z3BoolSort >> λBase [
+	^TBool instance
+]

--- a/src/SpriteLang/Z3IntSort.extension.st
+++ b/src/SpriteLang/Z3IntSort.extension.st
@@ -4,3 +4,8 @@ Extension { #name : #Z3IntSort }
 Z3IntSort >> canBeTerminationMetric [
 	^true
 ]
+
+{ #category : #'*SpriteLang' }
+Z3IntSort >> λBase [
+	^TInt instance
+]

--- a/src/SpriteLang/Z3Sort.extension.st
+++ b/src/SpriteLang/Z3Sort.extension.st
@@ -4,3 +4,19 @@ Extension { #name : #Z3Sort }
 Z3Sort >> canBeTerminationMetric [
 	^false
 ]
+
+{ #category : #'*SpriteLang' }
+Z3Sort >> constTyApp: value [
+	| v |
+	v := 'theoryFunctionV'.
+	^TBase
+		b: self λBase
+		r: (Reft
+			symbol: v
+			expr: (PAtom brel: #=== x: (EVar of: v) y: value)) known
+]
+
+{ #category : #'*SpriteLang' }
+Z3Sort >> sort2bTrue [
+	^self λBase bTrue
+]

--- a/src/SpriteLang/ΓContext.class.st
+++ b/src/SpriteLang/ΓContext.class.st
@@ -218,6 +218,8 @@ getEnv :: Env -> F.Symbol -> Maybe RType
 { #category : #accessing }
 ΓContext >> getEnvDamit: sym [
 	^eBinds at: sym
+	"last chance, maybe it's a theory symbol"
+	ifAbsent: [ (TheorySymbol interpSymbol: sym) constTy ]
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
For its didactic purpose Sprite suffices to provide just a few built-in primitives such as `+`, `-`, `<`, `=>` and a few others.  Moreover, these builtins are implemented by reflecting them into Sprite source which embeds refinement predicates expressed as Smalltalk blocks.

For practical use this is insufficient.  This PR provides access to the stock of "TheorySymbol" interpreted theories in Fixpoint — so it is now possible to call things like `bv_add` from Sprite.