### PR TITLE
[PreSmalltalks] When currying a block, downcast to the same subclass

### DIFF
--- a/src/PreSmalltalks-Pharo/BlockClosure.extension.st
+++ b/src/PreSmalltalks-Pharo/BlockClosure.extension.st
@@ -23,11 +23,11 @@ BlockClosure >> curryArgs: argArray [
 	right now but it should be doable."
 	| n |
 	n := self argumentCount - argArray size.
-	^{ 
+	^({
 		[ :x | self valueWithArguments: argArray, {x} ].
 		[ :x :y | self valueWithArguments: argArray, {x.y} ].
 		[ :x :y :z | self valueWithArguments: argArray, {x.y.z} ]
-	} at: n
+	} at: n) as: self class
 ]
 
 { #category : #'*PreSmalltalks-Pharo' }
@@ -35,11 +35,11 @@ BlockClosure >> curryLazy: argArray [
 	"Like #curryArgs: but non-strict in argArray."
 	| n |
 	n := self argumentCount - argArray size.
-	^{ 
+	^({
 		[ :x | self valueWithArguments: (argArray collect: #value), {x} ].
 		[ :x :y | self valueWithArguments: (argArray collect: #value), {x.y} ].
 		[ :x :y :z | self valueWithArguments: (argArray collect: #value), {x.y.z} ]
-	} at: n
+	} at: n) as: self class
 ]
 
 { #category : #'*PreSmalltalks-Pharo' }


### PR DESCRIPTION
In the current [admittedly half-assed] implementation of currying, the answer is the BlockClosure created by the Smalltalk compiler. As such, its class is always `BlockClosure`.

This can be undesirable when the receiver is of some other class. Imagine `MyBlockClosure` is a subclass of `BlockClosure` and we have a MyBlockClosure,
```
b := [ :x :y | x+y ] as: MyBlockClosure.
```
Partially-evaluating it:
```
b value: 3
```
we would like to get the MyBlockClosure `3+□` but we get the BlockClosure `3+□` instead.

In this commit, we simply downcast to MyBlockClosure. Ut omnia candide legantur, & defectus in materia tam difficili non tam reprehendantur, quam novis lectorum conatibus investigentur, & benigne suppleantur, enixe rogo (_Newton_).