### PR TITLE
Unify almost-equal sorts

### DIFF
--- a/src/Refinements/Env.class.st
+++ b/src/Refinements/Env.class.st
@@ -169,7 +169,11 @@ Cf. SortCheck.hs
 		(t2 isKindOf: Z3IntSort) ifTrue: [ ^Incompatible signal ].
 		(t2 isKindOf: Z3BoolSort) ifTrue: [ ^Incompatible signal ].
 		(t2 isKindOf: Z3UninterpretedSort) ifTrue: [ ^Incompatible signal ].
+		(t2 isKindOf: Z3DatatypeSort) ifTrue: [ ^self unify1: e tvSubst: θ sort: t1 sort: (PreSort hotel recallFAppFor: t2) ].
 		^self unify1: e tvSubst: θ sort: t1 sort: t2 guest
+	].
+	(t1 isKindOf: Z3DatatypeSort) ifTrue: [
+		(t2 isKindOf: FApp) ifTrue: [ ^self unify1: e tvSubst: θ sort: t₂ sort: t₁ ]
 	].
 	((t1 isKindOf: FTC) and: [t2 isKindOf: FTC]) ifTrue: [ ^self unifyTC: t1 typeConstructor with: t2 typeConstructor tvSubst: θ	].
 	(t1 isKindOf: FAbs) ifTrue: [ | t1′ |

--- a/src/Refinements/FTC.class.st
+++ b/src/Refinements/FTC.class.st
@@ -45,7 +45,11 @@ FTC >> fappSmtSort: ts originalFApp: anFApp in: γ [
 "
 fappSmtSort :: Bool -> Int -> SEnv DataDecl -> Sort -> [Sort] -> SmtSort
 "
-	^typeConstructor smtApply: ts originalFApp: anFApp in: γ
+	| z3sort |
+	z3sort := typeConstructor smtApply: ts originalFApp: anFApp in: γ.
+	[ PreSort hotel noteFAppFor: z3sort was: anFApp ]
+		on: NoAnswer do: [].
+	^z3sort
 ]
 
 { #category : #theories }

--- a/src/Refinements/Hotel.class.st
+++ b/src/Refinements/Hotel.class.st
@@ -2,5 +2,29 @@ Class {
 	#name : #Hotel,
 	#superclass : #Dictionary,
 	#type : #variable,
+	#instVars : [
+		'fApps'
+	],
 	#category : #'Refinements-SortCheck'
 }
+
+{ #category : #'FApp back mapping' }
+Hotel >> fApps [
+	fApps isNil ifTrue: [ fApps := Dictionary new ].
+	^ fApps
+]
+
+{ #category : #'FApp back mapping' }
+Hotel >> noteFAppFor: aZ3Sort was: aPreSort [
+	self fApps at: aZ3Sort put: aPreSort
+]
+
+{ #category : #'FApp back mapping' }
+Hotel >> recallFAppFor: aZ3Sort [ 
+	^self recallFAppFor: aZ3Sort ifNotFound: [ self errorKeyNotFound: aZ3Sort ]
+]
+
+{ #category : #'FApp back mapping' }
+Hotel >> recallFAppFor: aZ3Sort ifNotFound: failBlock [
+	^fApps at: aZ3Sort ifAbsent: [^failBlock value]
+]


### PR DESCRIPTION
To unify compound sorts, we unify their constituent parts. For example,
```
t₁ = (FApp List ℤ)
```
and
```
t₂ = (FApp List @(0))
```
unify by unifying @(0) with ℤ.

This is all good and well but what if t₁ already SMTed to Z3 `(List ℤ)`? How do we retrieve the ℤ from the given Z3DatatypeSort, to assign to  @(0)? The approach implemented in this PR, is to keep a Dictionary of back- references from Z3Sorts SMTed from FApps to the original FApp.