### PR TITLE
Desist asserting exact equality when collapsing nested `ECst`

### DIFF
--- a/src/Refinements/ECst.class.st
+++ b/src/Refinements/ECst.class.st
@@ -10,12 +10,7 @@ Class {
 
 { #category : #'instance creation' }
 ECst class >> e: e sort: s [
-	(e isKindOf: ECst) ifTrue: [
-		"Don't create nested casts.
-		 Just check that the sorts match, and return one-layer cast."
-		e sort = s ifFalse: [ self error ].
-		^e
-	].
+	(e isKindOf: ECst) ifTrue: [ ^e ]. "Don't create nested casts."
 	^self basicNew
 		e:    e;
 		sort: s;


### PR DESCRIPTION
In commit 8aaee16 we understood that actual and formal arguments only match up to #≈.  The same is true of `ECst`: if you have a cast to a fully-SMTed `Z3Sort`, and you are trying to wrap it in a cast to its originating (fully-monomorphized) `PreSort`, such cast must be considered legal.

Commit 8aaee16 mentions the possibility to actually implement #≈; this now appears like it's a good idea, given that we now have more than one place where sort equality assert should be replaced by almost-equality. For now we just skip the assert, deferring to #505.