### PR TITLE
[Z3] Initial support for Z3 Strings

### DIFF
--- a/src/Z3-Tests/SimpleZ3Test.class.st
+++ b/src/Z3-Tests/SimpleZ3Test.class.st
@@ -239,6 +239,15 @@ SimpleZ3Test >> testCreateArray [
 ]
 
 { #category : #tests }
+SimpleZ3Test >> testCreateString [
+	| s |
+	s := 'abc' toZ3String.
+	self assert: s sort isStringSort.
+	self assert: s isZ3String.
+	self assert: s getString = 'abc'
+]
+
+{ #category : #tests }
 SimpleZ3Test >> testEmptySymbolHasNullPointer [
 	| emptySymbol |
 	emptySymbol := Z3Symbol new.

--- a/src/Z3/String.extension.st
+++ b/src/Z3/String.extension.st
@@ -57,3 +57,8 @@ String >> toSort [
 String >> toZ3Sort: s [
 	^s mkConst: self
 ]
+
+{ #category : #'*Z3' }
+String >> toZ3String [
+	^Z3String mkString: self
+]

--- a/src/Z3/Z3AST.class.st
+++ b/src/Z3/Z3AST.class.st
@@ -172,6 +172,11 @@ Z3AST >> isSymbolic [
 	^self simplify isNumeral not
 ]
 
+{ #category : #testing }
+Z3AST >> isZ3String [
+	^Z3Context current isZ3String: self
+]
+
 { #category : #accessing }
 Z3AST >> kind [
 	^ self subclassResponsibility

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -104,6 +104,11 @@ Z3Context >> errorCheck [
 	].
 ]
 
+{ #category : #'API wrappers' }
+Z3Context >> getString: anAST [
+	^Z3 get_string: self _: anAST
+]
+
 { #category : #'initialization & release' }
 Z3Context >> initializeWithAddress: anExternalAddress [
 	super initializeWithAddress: anExternalAddress.
@@ -149,6 +154,16 @@ Z3Context >> internAST: class address: address kind: kind sort: sort [
 
 	^ ast
 
+]
+
+{ #category : #'API wrappers' }
+Z3Context >> isStringSort: aSort [
+	^Z3 is_string_sort: self _: aSort
+]
+
+{ #category : #'API wrappers' }
+Z3Context >> isZ3String: anAST [
+	^Z3 is_string: self _: anAST
 ]
 
 { #category : #'API wrappers' }
@@ -319,6 +334,16 @@ Z3Context >> mkSolver [
 { #category : #'API wrappers' }
 Z3Context >> mkSolverForLogic: logic [
 	^ Z3 mk_solver_for_logic: self _: (self mkSymbol: logic)
+]
+
+{ #category : #'API wrappers' }
+Z3Context >> mkString: aString [ 
+	^Z3 mk_string: self _: aString
+]
+
+{ #category : #'API wrappers' }
+Z3Context >> mkStringSort [
+	^Z3 mk_string_sort: self
 ]
 
 { #category : #'API wrappers' }

--- a/src/Z3/Z3Sort.class.st
+++ b/src/Z3/Z3Sort.class.st
@@ -28,6 +28,7 @@ Z3Sort class >> classForSortKind: sortKind [
 	sortKind = BV_SORT ifTrue: [ ^ Z3BitVectorSort ].
 	sortKind = ARRAY_SORT ifTrue: [ ^ Z3ArraySort ].
 	sortKind = DATATYPE_SORT ifTrue: [ ^ Z3DatatypeSort ].
+	sortKind = SEQ_SORT ifTrue: [ ^ Z3StringSort ].
 
 	self error: '(Yet) unsupported sort kind: ' , sortKind printString             
 
@@ -55,6 +56,11 @@ Z3Sort class >> int [
 { #category : #'instance creation' }
 Z3Sort class >> real [
 	^ Z3Context current mkRealSort
+]
+
+{ #category : #'instance creation' }
+Z3Sort class >> string [
+	^ Z3Context current mkStringSort
 ]
 
 { #category : #'instance creation' }
@@ -102,6 +108,13 @@ Z3Sort >> isBoolSort [
 { #category : #testing }
 Z3Sort >> isIntSort [
 	^ false
+]
+
+{ #category : #testing }
+Z3Sort >> isStringSort [
+	"In this case, we call the dedicated Z3 API,
+	 as opposed to isIntSort etc which have no such API."
+	^Z3Context current isStringSort: self
 ]
 
 { #category : #accessing }

--- a/src/Z3/Z3String.class.st
+++ b/src/Z3/Z3String.class.st
@@ -1,0 +1,22 @@
+Class {
+	#name : #Z3String,
+	#superclass : #Z3Node,
+	#category : #'Z3-Core'
+}
+
+{ #category : #'instance creation' }
+Z3String class >> mkString: aString [ 
+	^Z3Context current mkString: aString
+]
+
+{ #category : #types }
+Z3String class >> sort [
+	^Z3Sort string
+]
+
+{ #category : #accessing }
+Z3String >> getString [
+	"Caveat programmator:
+	 We do not begin to address the escaping issues in https://github.com/Z3Prover/z3/issues/2286"
+	^Z3Context current getString: self
+]

--- a/src/Z3/Z3StringSort.class.st
+++ b/src/Z3/Z3StringSort.class.st
@@ -1,0 +1,10 @@
+Class {
+	#name : #Z3StringSort,
+	#superclass : #Z3Sort,
+	#category : #'Z3-Core'
+}
+
+{ #category : #'type theory' }
+Z3StringSort >> nodeClass [
+	^Z3String
+]


### PR DESCRIPTION
This is the bare minimum necessary to implement the `symConstant` function; in particular, we are not paying any attention to [escaping](https://github.com/Z3Prover/z3/issues/2286) whatsoever.