### PR TITLE
For fully-SMTed sorts, implement `#isUndef` as always false

### DIFF
--- a/src/Refinements/Z3Sort.extension.st
+++ b/src/Refinements/Z3Sort.extension.st
@@ -89,6 +89,11 @@ Z3Sort >> isMono [
 ]
 
 { #category : #'*Refinements' }
+Z3Sort >> isUndef [
+	^false
+]
+
+{ #category : #'*Refinements' }
 Z3Sort >> mapSort: f [ 
 	^self
 ]


### PR DESCRIPTION
A Fixpoint Sort can only be undef when there are FAbs.