### PR TITLE
[Z3] Initial support for Z3 Strings (v2)

### DIFF
--- a/src/Z3-Tests/SimpleZ3Test.class.st
+++ b/src/Z3-Tests/SimpleZ3Test.class.st
@@ -239,6 +239,15 @@ SimpleZ3Test >> testCreateArray [
 ]
 
 { #category : #tests }
+SimpleZ3Test >> testCreateString [
+	| s |
+	s := 'abc' toZ3String.
+	self assert: s sort isStringSort.
+	self assert: s isZ3String.
+	self assert: s getString = 'abc'
+]
+
+{ #category : #tests }
 SimpleZ3Test >> testEmptySymbolHasNullPointer [
 	| emptySymbol |
 	emptySymbol := Z3Symbol new.

--- a/src/Z3/Object.extension.st
+++ b/src/Z3/Object.extension.st
@@ -102,6 +102,11 @@ Object >> isReal [
 ]
 
 { #category : #'*Z3' }
+Object >> isZ3String [
+	^ false
+]
+
+{ #category : #'*Z3' }
 Object >> isZ3Symbol [
 	^ false
 ]
@@ -124,6 +129,11 @@ Object >> toInt [
 { #category : #'*Z3' }
 Object >> toReal [
 	self error: 'No automatic coerction to Real, please coerce manually'
+]
+
+{ #category : #'*Z3' }
+Object >> toZ3String [
+	self error: 'No automatic coerction to Z3String, please coerce manually'
 ]
 
 { #category : #'*Z3' }

--- a/src/Z3/String.extension.st
+++ b/src/Z3/String.extension.st
@@ -57,3 +57,8 @@ String >> toSort [
 String >> toZ3Sort: s [
 	^s mkConst: self
 ]
+
+{ #category : #'*Z3' }
+String >> toZ3String [
+	^Z3String mkString: self
+]

--- a/src/Z3/Z3AST.class.st
+++ b/src/Z3/Z3AST.class.st
@@ -172,6 +172,11 @@ Z3AST >> isSymbolic [
 	^self simplify isNumeral not
 ]
 
+{ #category : #testing }
+Z3AST >> isZ3String [
+	^ Z3 is_string: ctx _: self
+]
+
 { #category : #accessing }
 Z3AST >> kind [
 	^ self subclassResponsibility

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -322,6 +322,16 @@ Z3Context >> mkSolverForLogic: logic [
 ]
 
 { #category : #'API wrappers' }
+Z3Context >> mkString: aString [ 
+	^Z3 mk_string: self _: aString
+]
+
+{ #category : #'API wrappers' }
+Z3Context >> mkStringSort [
+	^Z3 mk_string_sort: self
+]
+
+{ #category : #'API wrappers' }
 Z3Context >> mkSymbol [
 	"The empty symbol (a special symbol in Z3).
 	 By analogy with other monoids such as String, Array etc,

--- a/src/Z3/Z3Sort.class.st
+++ b/src/Z3/Z3Sort.class.st
@@ -28,6 +28,7 @@ Z3Sort class >> classForSortKind: sortKind [
 	sortKind = BV_SORT ifTrue: [ ^ Z3BitVectorSort ].
 	sortKind = ARRAY_SORT ifTrue: [ ^ Z3ArraySort ].
 	sortKind = DATATYPE_SORT ifTrue: [ ^ Z3DatatypeSort ].
+	sortKind = SEQ_SORT ifTrue: [ ^ Z3StringSort ].
 
 	self error: '(Yet) unsupported sort kind: ' , sortKind printString             
 
@@ -55,6 +56,11 @@ Z3Sort class >> int [
 { #category : #'instance creation' }
 Z3Sort class >> real [
 	^ Z3Context current mkRealSort
+]
+
+{ #category : #'instance creation' }
+Z3Sort class >> string [
+	^ Z3Context current mkStringSort
 ]
 
 { #category : #'instance creation' }
@@ -102,6 +108,13 @@ Z3Sort >> isBoolSort [
 { #category : #testing }
 Z3Sort >> isIntSort [
 	^ false
+]
+
+{ #category : #testing }
+Z3Sort >> isStringSort [
+	"In this case, we call the dedicated Z3 API,
+	 as opposed to isIntSort etc which have no such API."
+	^ Z3 is_string_sort: ctx _: self
 ]
 
 { #category : #accessing }

--- a/src/Z3/Z3String.class.st
+++ b/src/Z3/Z3String.class.st
@@ -1,0 +1,32 @@
+Class {
+	#name : #Z3String,
+	#superclass : #Z3Node,
+	#category : #'Z3-Core'
+}
+
+{ #category : #'instance creation' }
+Z3String class >> mkString: aString [ 
+	^Z3Context current mkString: aString
+]
+
+{ #category : #types }
+Z3String class >> sort [
+	^Z3Sort string
+]
+
+{ #category : #converting }
+Z3String >> asString [
+	^ self getString
+]
+
+{ #category : #API }
+Z3String >> getString [
+	"Caveat programmator:
+	 We do not begin to address the escaping issues in https://github.com/Z3Prover/z3/issues/2286"
+	^Z3 get_string: ctx _: self
+]
+
+{ #category : #converting }
+Z3String >> toZ3String [
+	^self
+]

--- a/src/Z3/Z3StringSort.class.st
+++ b/src/Z3/Z3StringSort.class.st
@@ -1,0 +1,15 @@
+Class {
+	#name : #Z3StringSort,
+	#superclass : #Z3Sort,
+	#category : #'Z3-Core'
+}
+
+{ #category : #'type theory' }
+Z3StringSort >> cast: value [
+	^ value toZ3String
+]
+
+{ #category : #'type theory' }
+Z3StringSort >> nodeClass [
+	^Z3String
+]


### PR DESCRIPTION
This PR is my evolution of PR #512 that fixes few issues I had with the original version. Nothing major though:

 * Removes `#isZ3String:` and alike from `Z3Context`. There's only one sender at the moment and - more importantly - none of the other nodes use this style. Instead, call to `Z3` API was moved to instance side of `Z3String`.
 * `Z3Context current` should not be used in instance methods of `Z3ContextedObject` subclasses. Such objects know their context and should use it. Again, that's consistent with other nodes.
 * Added some conversion / testing methods (`#toZ3String`, `#asString`, `#cast:` and so on). 