### PR TITLE
Make `Query` "debugger save"

### DIFF
--- a/src/PreSmalltalks-Pharo/Query.class.st
+++ b/src/PreSmalltalks-Pharo/Query.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #Query,
 	#superclass : #Notification,
+	#classVars : [
+		'DebuggingSupportEnabled'
+	],
 	#category : #'PreSmalltalks-Pharo'
 }
 
@@ -19,6 +22,31 @@ Query class >> answer: value do: block [
 		Transcript show: 'Hello ' , Query query , '!'; cr.
 	]
 	"
+]
+
+{ #category : #accessing }
+Query class >> debuggingSupportEnabled: aBoolean [
+	"Enables/disables support in debugger. See comment in Query >> #defaultAction."
+	
+	DebuggingSupportEnabled := aBoolean.
+	
+	"
+	Query debuggingSupportEnabled: true.
+	Query debuggingSupportEnabled: false.
+	"
+
+]
+
+{ #category : #initialization }
+Query class >> initialize [
+	DebuggingSupportEnabled := false.
+	
+	"
+	Query debuggingSupportEnabled: true.
+	Query debuggingSupportEnabled: false.
+	"
+
+
 ]
 
 { #category : #asking }
@@ -42,6 +70,57 @@ Query class >> query [
 Query >> defaultAction [
 	"The default action taken if the exception is signaled."
 
+	"Control flow arrives here in case query's value is not supplied
+	 anywhere in current call chain. This is also the case when code
+	 is evaluated within debugger since debugger runs in its own thread,
+	 separately from debugee.
+
+	 This leads to confusing situation that one may get different results
+	 from query when executed by debugee and when executed by evaluating code
+	 in debugger.
+
+	 To mitigate this, the code below tries to detect whether control flow
+	 came here due to evaluating in code in debugger and if so, manually
+	 walks debugee's stack to find query's value.
+
+	 Dangerous hackery for sure. This is why this mitigation (hackery) is
+	 guarded and needs to be enabled by the user.
+	"
+	DebuggingSupportEnabled ifTrue:[
+		| ctx |
+
+		ctx := thisContext findContextSuchThat: [ :c | c selector == #DoItIn: and:[ (c tempAt: 1) isContext ] ].
+		ctx notNil ifTrue:[
+			"`ctx` is the context of do-it method activation. The only parameter is
+			  the (original, debugee's) context in which the do-it is evaluated.
+			  Walk debugee's stack starting with that context and search for
+			  handler providing query's value (if any).
+	
+			  Implementation note: one may be very tempted to do just
+	
+				    self signalIn: (ctx tempAt: 1)
+	
+			  Don't try! This may cause debugee's context to return and
+		    leaves smalltalk environment in inconsistent weird state
+		    where nothing work. This is why we do it 'manually'.
+			 "
+
+			| handler |
+
+			handler := (ctx tempAt: 1) nextHandlerContext.
+			[ handler notNil ] whileTrue:[
+				(handler exceptionClass handles: self) ifTrue:[
+					"We found the handler context. Evaluate handler
+					 block for receiver (the query instance in debuffer
+					 thread!)"
+					handler exceptionHandlerBlock cull: self.
+				].
+				handler := handler nextHandlerContext.
+			].
+		].
+	].
+
+	"Otherwise, return the query's default value."
 	^self defaultResumeValue
 ]
 

--- a/src/PreSmalltalks-Pharo/Query.class.st
+++ b/src/PreSmalltalks-Pharo/Query.class.st
@@ -24,6 +24,31 @@ Query class >> answer: value do: block [
 	"
 ]
 
+{ #category : #setting }
+Query class >> debugSettingsOn: aBuilder [
+	<systemsettings>
+
+	(aBuilder setting: #debuggingSupportEnabled)
+		label: 'Support for Query in debugger';
+		target: self;
+		default: false;
+		parent: #debugging;
+		description:
+				'Enabled/disables support for Query in debugger do-its. See See comment in Query >> #defaultAction'.
+
+]
+
+{ #category : #accessing }
+Query class >> debuggingSupportEnabled [
+	^ DebuggingSupportEnabled
+	
+	"
+	Query debuggingSupportEnabled: true.
+	Query debuggingSupportEnabled: false.
+	"
+
+]
+
 { #category : #accessing }
 Query class >> debuggingSupportEnabled: aBoolean [
 	"Enables/disables support in debugger. See comment in Query >> #defaultAction."

--- a/src/Z3-Tests/Z3CAPITest.class.st
+++ b/src/Z3-Tests/Z3CAPITest.class.st
@@ -217,6 +217,20 @@ Z3CAPITest >> testBitvector2d [
 ]
 
 { #category : #tests }
+Z3CAPITest >> testDebugger [
+	| c t |
+
+	c := Z3Context current.
+	t := Bool true.
+
+	self assert: c == Z3Context current.
+	self assert: t == Bool true.
+	self assert: t = Bool true.
+
+	1 + 1.
+]
+
+{ #category : #tests }
 Z3CAPITest >> testDemorgan [
 	"Demonstration of how Z3 can be used to prove validity of
 	 De Morgan's Duality Law: {e not(x and y) <-> (not x) or ( not y) }"


### PR DESCRIPTION
This PR is an evolution of earlier attempt to make query working in the debugger. 

The concern was the code to make it work is too much of a "dangerous hackery". To address that, in this version  user must explicitly enable the "hackery".