### PR TITLE
Refactor the knowledge of `junkName` out of `funArgP`

### DIFF
--- a/src/SpriteLang/FunArg.class.st
+++ b/src/SpriteLang/FunArg.class.st
@@ -1,0 +1,9 @@
+"
+type FunArg = (F.Symbol, RType)
+Cf. Parse.hs
+"
+Class {
+	#name : #FunArg,
+	#superclass : #Association,
+	#category : #SpriteLang
+}

--- a/src/SpriteLang/RType.class.st
+++ b/src/SpriteLang/RType.class.st
@@ -167,6 +167,13 @@ fresh :: F.SrcSpan -> Env -> RType -> CG RType
 	self subclassResponsibility
 ]
 
+{ #category : #names }
+RType >> funArgAssoc: argName [
+	^(argName ifNil: [ String junkSymbol ])
+	 -> self
+	as: FunArg
+]
+
 { #category : #reflect }
 RType >> funSig [
 "

--- a/src/SpriteLang/RefinementParser.class.st
+++ b/src/SpriteLang/RefinementParser.class.st
@@ -79,10 +79,16 @@ RefinementParser >> forall [
 
 { #category : #grammar }
 RefinementParser >> funArg [
-	^ (NNFParser lowerId, $: asParser, rtype0
-	==> [ :x | x first -> x third ])
-	/ (rtype0
-	==> [ :x | String junkSymbol -> x ])
+"
+funArgP :: FP.Parser FunArg
+funArgP = try ((,) <$> FP.lowerIdP <*> (FP.colon *> rtype0))
+      <|> ((junkSymbol,) <$> rtype0)
+"
+	^ ((NNFParser lowerId, $: asParser) optional, rtype0
+	map: [ :argName__ :rt |
+		| argName |
+		argName := argName__ ifNil: [ nil ] ifNotNil: [ argName__ first ]. "TODO: rewrite over monadic nil"
+		rt funArgAssoc: argName ])
 ]
 
 { #category : #grammar }


### PR DESCRIPTION
This is needed so that funArgs can be created by clients other than parser.