### PR TITLE
Split Core Metalanguage from full Metalanguage

### DIFF
--- a/pharo/GNUmakefile
+++ b/pharo/GNUmakefile
@@ -39,6 +39,7 @@ test: $(PROJECT).image $(PHARO_VM)
 		'Refinements-Tests' \
 		'SpriteLang-Tests' \
 		'PLE-Tests' \
+		'Metalanguage-Tests' \
 		'Collections-Homogeneous-Tests'
 
 ifndef Z3_SOURCE_DIR

--- a/src/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
+++ b/src/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
@@ -125,6 +125,13 @@ BaselineOfMachineArithmetic >> baseline: spec [
 				package: #'PLE-Tests' with:
 					[spec requires: 'PLE'];
 
+				package: #'Metalanguage' with:
+					[spec requires: 'SpriteLang'];
+
+				package: #'Metalanguage-Tests' with:
+					[spec requires: 'Metalanguage'.
+					 spec requires: 'SpriteLang-Tests'];
+
 				yourself.
 
 			"Groups"

--- a/src/Metalanguage-Tests/ReflectInlineNegTest.class.st
+++ b/src/Metalanguage-Tests/ReflectInlineNegTest.class.st
@@ -1,8 +1,13 @@
 Class {
 	#name : #ReflectInlineNegTest,
 	#superclass : #SpriteLangNegTest,
-	#category : #'SpriteLang-Tests-Simple'
+	#category : #'Metalanguage-Tests'
 }
+
+{ #category : #running }
+ReflectInlineNegTest >> parserClass [
+	^ΛοParser
+]
 
 { #category : #tests }
 ReflectInlineNegTest >> test_42 [

--- a/src/Metalanguage-Tests/ReflectInlinePosTest.class.st
+++ b/src/Metalanguage-Tests/ReflectInlinePosTest.class.st
@@ -1,8 +1,13 @@
 Class {
 	#name : #ReflectInlinePosTest,
 	#superclass : #SpriteLangPosTest,
-	#category : #'SpriteLang-Tests-Simple'
+	#category : #'Metalanguage-Tests'
 }
+
+{ #category : #running }
+ReflectInlinePosTest >> parserClass [
+	^ΛοParser
+]
 
 { #category : #'tests-integer' }
 ReflectInlinePosTest >> test_42 [
@@ -34,6 +39,30 @@ let fortyTwo = (x) => {
 
 ⟦reflect fortyTwoX : int => int⟧
 let fortyTwoX = (x) => {
+  fortyTwo(x)
+};
+
+⟦val main : int => int[v | v===42]⟧
+let main = (a) => {
+  let z = fortyTwoX(a);
+  z
+};
+'
+]
+
+{ #category : #'tests-integer' }
+ReflectInlinePosTest >> test_42_chain2 [
+"Chain PLE with inline"
+	self processString: '
+[--check-termination]
+
+⟦reflect fortyTwo : int => int⟧
+let fortyTwo = (x) => {
+  42
+};
+
+⟦reflect fortyTwoX : int => int / [0 toInt]⟧
+let rec fortyTwoX = (x) => {
   fortyTwo(x)
 };
 

--- a/src/Metalanguage-Tests/SpriteANFTest.class.st
+++ b/src/Metalanguage-Tests/SpriteANFTest.class.st
@@ -1,0 +1,52 @@
+Class {
+	#name : #SpriteANFTest,
+	#superclass : #SpriteLangTest,
+	#category : #'Metalanguage-Tests'
+}
+
+{ #category : #running }
+SpriteANFTest >> parserClass [
+	^ΛοParser
+]
+
+{ #category : #tests }
+SpriteANFTest >> test_ANF_01 [
+	self proveSafe: '
+⟦val f : x:int => int[v|v === (x+1)]⟧
+let f = (x) => {
+  x + 1
+};
+
+⟦val g : x:int => int[v|v === (x+1)]⟧
+let g = (x) => {
+  x + 1
+};
+
+⟦val main : x:int => int[v|v === (x+2)]⟧
+let main = (x) => {
+  let result = f(g(x));
+  result
+};
+'
+]
+
+{ #category : #tests }
+SpriteANFTest >> test_ANF_02 [
+	self proveSafe: '
+⟦val f : x:int => int[v|v === (x+1)]⟧
+let f = (x) => {
+  x + 1
+};
+
+⟦val g : x:int => int[v|v === (x+x)]⟧
+let g = (x) => {
+  x + x
+};
+
+⟦val main : x:int => int[v|v === (x*2+3)]⟧
+let main = (x) => {
+  let result = f(g(f(x)));
+  result
+};
+'
+]

--- a/src/Metalanguage-Tests/package.st
+++ b/src/Metalanguage-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : #'Metalanguage-Tests' }

--- a/src/Metalanguage/EAnn.extension.st
+++ b/src/Metalanguage/EAnn.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #EAnn }
+
+{ #category : #'*Metalanguage' }
+EAnn >> toANF [
+	^EAnn
+		expr: expr toANF
+		ann: ann
+]
+
+{ #category : #'*Metalanguage' }
+EAnn >> toMIF [
+	^EAnn
+		expr: expr toMIF
+		ann: ann
+]

--- a/src/Metalanguage/EAnn.extension.st
+++ b/src/Metalanguage/EAnn.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #EAnn }
 
 { #category : #'*Metalanguage' }
+EAnn >> macroExpandEVar: f to: aΛExpr [
+	^EAnn
+		expr: (expr macroExpandEVar: f to: aΛExpr)
+		ann: ann "BOGUS, would be much better to allow inlining in refinements"
+]
+
+{ #category : #'*Metalanguage' }
 EAnn >> toANF [
 	^EAnn
 		expr: expr toANF

--- a/src/Metalanguage/ECon.extension.st
+++ b/src/Metalanguage/ECon.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #ECon }
+
+{ #category : #'*Metalanguage' }
+ECon >> mifApp: e [ 
+	^ΛEApp
+		expr: e "halt"
+		imm: self
+]

--- a/src/Metalanguage/EFun.extension.st
+++ b/src/Metalanguage/EFun.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : #EFun }
 
 { #category : #'*Metalanguage' }
+EFun >> macroExpandEVar: f to: aΛExpr [
+	f = bind id ifTrue: [ self error: 'α-collision!!!' ].
+	^EFun
+		bind: bind
+		expr: (expr macroExpandEVar: f to: aΛExpr)
+]
+
+{ #category : #'*Metalanguage' }
 EFun >> toANF [
 	^EFun
 		bind: bind

--- a/src/Metalanguage/EFun.extension.st
+++ b/src/Metalanguage/EFun.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #EFun }
+
+{ #category : #'*Metalanguage' }
+EFun >> toANF [
+	^EFun
+		bind: bind
+		expr: expr toANF
+]
+
+{ #category : #'*Metalanguage' }
+EFun >> toMIF [
+	^EFun
+		bind: bind
+		expr: expr toMIF
+]

--- a/src/Metalanguage/EIf.extension.st
+++ b/src/Metalanguage/EIf.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : #EIf }
 
 { #category : #'*Metalanguage' }
+EIf >> macroExpandEVar: f to: aΛExpr [
+	^EIf
+		cond: cond "this can only be an EVar, and at least for now we aren't considering reflecting on value-Bools"
+		trueE: (trueE macroExpandEVar: f to: aΛExpr)
+		falseE: (falseE macroExpandEVar: f to: aΛExpr)
+]
+
+{ #category : #'*Metalanguage' }
 EIf >> toANF [
 	^EIf
 		cond: cond toANF

--- a/src/Metalanguage/EIf.extension.st
+++ b/src/Metalanguage/EIf.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #EIf }
+
+{ #category : #'*Metalanguage' }
+EIf >> toANF [
+	^EIf
+		cond: cond toANF
+		trueE: trueE toANF
+		falseE: falseE toANF
+]
+
+{ #category : #'*Metalanguage' }
+EIf >> toMIF [
+	^EIf
+		cond: cond toMIF
+		trueE: trueE toMIF
+		falseE: falseE toMIF
+]

--- a/src/Metalanguage/EImm.extension.st
+++ b/src/Metalanguage/EImm.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #EImm }
+
+{ #category : #'*Metalanguage' }
+EImm >> toANF [
+	^self
+]
+
+{ #category : #'*Metalanguage' }
+EImm >> toMIF [
+	^self
+]

--- a/src/Metalanguage/EImm.extension.st
+++ b/src/Metalanguage/EImm.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #EImm }
 
 { #category : #'*Metalanguage' }
+EImm >> macroExpandEVar: x to: aΛExpr [
+	^EImm imm: (imm macroExpandEVar: x to: aΛExpr)
+]
+
+{ #category : #'*Metalanguage' }
 EImm >> toANF [
 	^self
 ]

--- a/src/Metalanguage/ELet.extension.st
+++ b/src/Metalanguage/ELet.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : #ELet }
 
 { #category : #'*Metalanguage' }
+ELet >> macroExpandEVar: x to: aΛExpr [
+	^(ELet
+		decl: (decl macroExpandEVar: x to: aΛExpr)
+		expr: (expr macroExpandEVar: x to: aΛExpr))
+	toANF inlineNonRecursiveReflects
+]
+
+{ #category : #'*Metalanguage' }
 ELet >> toANF [
 	"
 	let x = (let y=a in b)

--- a/src/Metalanguage/ELet.extension.st
+++ b/src/Metalanguage/ELet.extension.st
@@ -1,0 +1,40 @@
+Extension { #name : #ELet }
+
+{ #category : #'*Metalanguage' }
+ELet >> toANF [
+	"
+	let x = (let y=a in b)
+	in c
+	
+	is normalized to:
+	
+	let y=a
+	in let x=b
+	in c
+	"
+	| innerLet |
+	innerLet := decl expr.
+	(innerLet isKindOf: ELet) ifTrue: [
+		^(ELet
+			decl: innerLet decl toANF
+			expr: (ELet
+		         decl: (SpriteDecl bind: decl bind expr: innerLet expr)
+		         expr: expr) toANF) toANF
+	].
+	(innerLet isKindOf: EIf) ifTrue: [
+		^EIf
+			cond: innerLet cond
+			trueE:  (ELet decl: (SpriteDecl bind: decl bind expr: innerLet trueE)  expr: expr)
+			falseE: (ELet decl: (SpriteDecl bind: decl bind expr: innerLet falseE) expr: expr)
+	].
+	^ELet
+		decl: decl toANF
+		expr: expr toANF
+]
+
+{ #category : #'*Metalanguage' }
+ELet >> toMIF [
+	^ELet
+		decl: decl toMIF
+		expr: expr toMIF
+]

--- a/src/Metalanguage/EVar.extension.st
+++ b/src/Metalanguage/EVar.extension.st
@@ -1,0 +1,18 @@
+Extension { #name : #EVar }
+
+{ #category : #'*Metalanguage' }
+EVar >> mifApp: e [ 
+	^ΛEApp
+		expr: e "halt"
+		imm: self
+]
+
+{ #category : #'*Metalanguage' }
+EVar >> toANF [
+	^self
+]
+
+{ #category : #'*Metalanguage' }
+EVar >> toMIF [
+	^self
+]

--- a/src/Metalanguage/Prog.class.st
+++ b/src/Metalanguage/Prog.class.st
@@ -1,0 +1,20 @@
+"
+I represent a program in the Enriched Metalanguage.
+"
+Class {
+	#name : #Prog,
+	#superclass : #CoreProg,
+	#category : #Metalanguage
+}
+
+{ #category : #'reduction to core' }
+Prog >> core [
+	| mifExpr |
+	mifExpr := [expr toMIF] runReader: #tempVarNo initialState: {0}.
+	^CoreProg
+		quals: quals
+		meas: meas
+		expr: mifExpr toANF
+		data: data
+		options: options
+]

--- a/src/Metalanguage/Prog.class.st
+++ b/src/Metalanguage/Prog.class.st
@@ -9,8 +9,9 @@ Class {
 
 { #category : #'reduction to core' }
 Prog >> core [
-	| mifExpr |
-	mifExpr := [expr toMIF] runReader: #tempVarNo initialState: {0}.
+	| exprWithInlinedNonrecursiveReflects mifExpr |
+	exprWithInlinedNonrecursiveReflects := expr inlineNonRecursiveReflects.
+	mifExpr := [exprWithInlinedNonrecursiveReflects toMIF] runReader: #tempVarNo initialState: {0}.
 	^CoreProg
 		quals: quals
 		meas: meas

--- a/src/Metalanguage/SpriteDecl.extension.st
+++ b/src/Metalanguage/SpriteDecl.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #SpriteDecl }
 
 { #category : #'*Metalanguage' }
+SpriteDecl >> macroExpandEVar: x to: aΛExpr [
+	^self class
+		bind: bind
+		expr: (expr macroExpandEVar: x to: aΛExpr)
+]
+
+{ #category : #'*Metalanguage' }
 SpriteDecl >> toANF [
 	^SpriteDecl
 		bind: bind

--- a/src/Metalanguage/SpriteDecl.extension.st
+++ b/src/Metalanguage/SpriteDecl.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : #SpriteDecl }
+
+{ #category : #'*Metalanguage' }
+SpriteDecl >> toANF [
+	^SpriteDecl
+		bind: bind
+		expr: expr toANF
+]
+
+{ #category : #'*Metalanguage' }
+SpriteDecl >> toMIF [
+	^self class
+		bind: bind
+		expr: expr toMIF
+]

--- a/src/Metalanguage/SpriteImm.extension.st
+++ b/src/Metalanguage/SpriteImm.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #SpriteImm }
+
+{ #category : #'*Metalanguage' }
+SpriteImm >> toANF [
+	^self
+]

--- a/src/Metalanguage/package.st
+++ b/src/Metalanguage/package.st
@@ -1,0 +1,1 @@
+Package { #name : #Metalanguage }

--- a/src/Metalanguage/ΛEApp.extension.st
+++ b/src/Metalanguage/ΛEApp.extension.st
@@ -1,0 +1,26 @@
+Extension { #name : #'ΛEApp' }
+
+{ #category : #'*Metalanguage' }
+ΛEApp >> mifApp: f [
+	| tempVarNoCell freshTempName |
+	tempVarNoCell := Context readState: #tempVarNo.
+	freshTempName := 'anf_temp_var' intSymbol: tempVarNoCell first.
+	tempVarNoCell at: 1 put: tempVarNoCell first + 1.
+	^ELet
+		decl: (SpriteDecl
+			bind: (SpriteBind id: freshTempName)
+			expr: self toMIF)
+		expr: (ΛEApp expr: f imm: (EVar of: freshTempName))
+]
+
+{ #category : #'*Metalanguage' }
+ΛEApp >> toANF [
+	^ΛEApp
+		expr: expr toANF
+		imm: imm toANF
+]
+
+{ #category : #'*Metalanguage' }
+ΛEApp >> toMIF [
+	^imm mifApp: expr
+]

--- a/src/Metalanguage/ΛEApp.extension.st
+++ b/src/Metalanguage/ΛEApp.extension.st
@@ -1,6 +1,30 @@
 Extension { #name : #'ΛEApp' }
 
 { #category : #'*Metalanguage' }
+ΛEApp >> macroExpandEVar: f to: aΛExpr [
+	| arityOrFalse appThisTime args argNames argValues body |
+	arityOrFalse := self isApplicationOf: f.
+	arityOrFalse isNil ifTrue: [
+		"Not me.  Pass along..."
+		^ΛEApp
+			expr: (expr macroExpandEVar: f to: aΛExpr)
+			imm: (imm macroExpandEVar: f to: aΛExpr)
+	].
+
+	appThisTime := self.
+	args := OrderedCollection new.
+	body := aΛExpr.
+	arityOrFalse timesRepeat: [ 
+		args add: body bind id -> appThisTime imm.
+		body := body expr.
+		appThisTime := appThisTime expr.
+	].
+	argNames := args collect: #key.
+	argValues := (args collect: #value) reversed.
+	^(argNames zip: argValues) inject: body into: [ :accum :thisArg | accum macroExpandEVar: thisArg key to: thisArg value ]
+]
+
+{ #category : #'*Metalanguage' }
 ΛEApp >> mifApp: f [
 	| tempVarNoCell freshTempName |
 	tempVarNoCell := Context readState: #tempVarNo.

--- a/src/Metalanguage/ΛExpression.extension.st
+++ b/src/Metalanguage/ΛExpression.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #'ΛExpression' }
+
+{ #category : #'*Metalanguage' }
+ΛExpression >> toANF [
+	"Assuming the receiver has already been converted to Monadic form,
+	 flatten it to Flanagan–Sabry–Felleisen Administrative Normal Form
+	 ('The Essence of Compiling with Continuations', PLDI'93, see
+	  https://dl.acm.org/doi/10.1145/155090.155113 "
+	^self subclassResponsibility
+]
+
+{ #category : #'*Metalanguage' }
+ΛExpression >> toMIF [
+	"Answer the receiver normalized to MIF."
+	^self subclassResponsibility
+]

--- a/src/Metalanguage/ΛοParser.class.st
+++ b/src/Metalanguage/ΛοParser.class.st
@@ -1,0 +1,17 @@
+Class {
+	#name : #'ΛοParser',
+	#superclass : #'ΛκParser',
+	#category : #'Metalanguage-Parsing'
+}
+
+{ #category : #grammar }
+ΛοParser >> appExpr [
+	^ immExpr, (appExpr / imm) commaList
+	==> [ :f_args |
+		ΛEApp mkEApp: f_args first args: f_args second ]
+]
+
+{ #category : #accessing }
+ΛοParser >> progClass [
+	^Prog
+]

--- a/src/SpriteLang-Tests/ReflectPLEPosTest.class.st
+++ b/src/SpriteLang-Tests/ReflectPLEPosTest.class.st
@@ -62,30 +62,6 @@ let main = (a) => {
 ]
 
 { #category : #'tests-integer' }
-ReflectPLEPosTest >> test_42_chain2 [
-"Chain PLE with inline"
-	self processString: '
-[--check-termination]
-
-⟦reflect fortyTwo : int => int⟧
-let fortyTwo = (x) => {
-  42
-};
-
-⟦reflect fortyTwoX : int => int / [0 toInt]⟧
-let rec fortyTwoX = (x) => {
-  fortyTwo(x)
-};
-
-⟦val main : int => int[v | v===42]⟧
-let main = (a) => {
-  let z = fortyTwoX(a);
-  z
-};
-'
-]
-
-{ #category : #'tests-integer' }
 ReflectPLEPosTest >> test_42pos [
 	self processString: '
 [--check-termination]

--- a/src/SpriteLang/CoreProg.class.st
+++ b/src/SpriteLang/CoreProg.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : #Prog,
+	#name : #CoreProg,
 	#superclass : #Object,
 	#instVars : [
 		'options',
@@ -12,39 +12,44 @@ Class {
 }
 
 { #category : #'instance creation' }
-Prog class >> new [
+CoreProg class >> new [
 	self shouldNotImplement
 ]
 
 { #category : #'instance creation' }
-Prog class >> quals: quals meas: meas expr: expr data: data options: options [
+CoreProg class >> quals: quals meas: meas expr: expr data: data options: options [
 	^self basicNew
 		quals: quals; meas: meas; expr: expr; data: data; options: options;
 		yourself
 ]
 
+{ #category : #'reduction to core' }
+CoreProg >> core [
+	^self
+]
+
 { #category : #accessing }
-Prog >> data [
+CoreProg >> data [
 	^ data
 ]
 
 { #category : #accessing }
-Prog >> data: anObject [
+CoreProg >> data: anObject [
 	data := anObject
 ]
 
 { #category : #accessing }
-Prog >> expr [
+CoreProg >> expr [
 	^ expr
 ]
 
 { #category : #accessing }
-Prog >> expr: anObject [
+CoreProg >> expr: anObject [
 	expr := anObject
 ]
 
 { #category : #GT }
-Prog >> gtInspectorExprsIn: composite [
+CoreProg >> gtInspectorExprsIn: composite [
 	<gtInspectorPresentationOrder: 50>
 
 	^(expr gtInspectorTreeIn: composite)
@@ -52,47 +57,44 @@ Prog >> gtInspectorExprsIn: composite [
 ]
 
 { #category : #accessing }
-Prog >> meas [
+CoreProg >> meas [
 	^ meas
 ]
 
 { #category : #accessing }
-Prog >> meas: anObject [
+CoreProg >> meas: anObject [
 	meas := anObject
 ]
 
 { #category : #accessing }
-Prog >> options [
+CoreProg >> options [
 	^ options
 ]
 
 { #category : #accessing }
-Prog >> options: anObject [
+CoreProg >> options: anObject [
 	options := anObject
 ]
 
 { #category : #accessing }
-Prog >> quals [
+CoreProg >> quals [
 	^ quals
 ]
 
 { #category : #accessing }
-Prog >> quals: anObject [
+CoreProg >> quals: anObject [
 	quals := anObject
 ]
 
 { #category : #verification }
-Prog >> solve [
+CoreProg >> solve [
 	| vc |
-	
-	expr := expr inlineNonRecursiveReflects.
-	
-	vc := [self vcgen] runReader: #checkTermination initialState: (self options includes: #'check-termination').
+	vc := [self core vcgen] runReader: #checkTermination initialState: (self options includes: #'check-termination').
 	^vc solve
 ]
 
 { #category : #verification }
-Prog >> vcgen [
+CoreProg >> vcgen [
 	| expr′ env eL ps pqs cI c_cgi c cgi rfls syms c′ decs |
 	expr′ := expr uniq2.
 	env := ΓContext empEnv: meas typs: data.

--- a/src/SpriteLang/EAnn.class.st
+++ b/src/SpriteLang/EAnn.class.st
@@ -60,13 +60,6 @@ EAnn >> gtChildren [
 	^{ expr . ann }
 ]
 
-{ #category : #inlining }
-EAnn >> macroExpandEVar: f to: aΛExpr [
-	^EAnn
-		expr: (expr macroExpandEVar: f to: aΛExpr)
-		ann: ann "BOGUS, would be much better to allow inlining in refinements"
-]
-
 { #category : #'as yet unclassified' }
 EAnn >> synth: Γ [
 "

--- a/src/SpriteLang/EFun.class.st
+++ b/src/SpriteLang/EFun.class.st
@@ -80,14 +80,6 @@ EFun >> gtChildren [
 	^ { expr }
 ]
 
-{ #category : #inlining }
-EFun >> macroExpandEVar: f to: aΛExpr [
-	f = bind id ifTrue: [ self error: 'α-collision!!!' ].
-	^EFun
-		bind: bind
-		expr: (expr macroExpandEVar: f to: aΛExpr)
-]
-
 { #category : #'as yet unclassified' }
 EFun >> renameTy: ty metric: m [
 	| x y s′ t′ m′ t′′_m′′ t′′ m′′ |

--- a/src/SpriteLang/EIf.class.st
+++ b/src/SpriteLang/EIf.class.st
@@ -85,14 +85,6 @@ EIf >> gtChildren [
 
 ]
 
-{ #category : #inlining }
-EIf >> macroExpandEVar: f to: aΛExpr [
-	^EIf
-		cond: cond "this can only be an EVar, and at least for now we aren't considering reflecting on value-Bools"
-		trueE: (trueE macroExpandEVar: f to: aΛExpr)
-		falseE: (falseE macroExpandEVar: f to: aΛExpr)
-]
-
 { #category : #accessing }
 EIf >> trueE [
 	^ trueE

--- a/src/SpriteLang/EImm.class.st
+++ b/src/SpriteLang/EImm.class.st
@@ -44,11 +44,6 @@ EImm >> immYourself [
 	^self
 ]
 
-{ #category : #inlining }
-EImm >> macroExpandEVar: x to: aΛExpr [
-	^EImm imm: (imm macroExpandEVar: x to: aΛExpr)
-]
-
 { #category : #'as yet unclassified' }
 EImm >> synth: Γ [
 "

--- a/src/SpriteLang/ELet.class.st
+++ b/src/SpriteLang/ELet.class.st
@@ -98,6 +98,7 @@ ELet >> gtExpr [
 
 { #category : #'as yet unclassified' }
 ELet >> inlineNonRecursiveReflects [
+self halt.
 	^decl inlineInto: expr	
 
 ]
@@ -105,44 +106,6 @@ ELet >> inlineNonRecursiveReflects [
 { #category : #testing }
 ELet >> isLet [
 	^true
-]
-
-{ #category : #inlining }
-ELet >> macroExpandEVar: x to: aΛExpr [
-	^(ELet
-		decl: (decl macroExpandEVar: x to: aΛExpr)
-		expr: (expr macroExpandEVar: x to: aΛExpr))
-	normalizeLetOnLet inlineNonRecursiveReflects
-]
-
-{ #category : #inlining }
-ELet >> normalizeLetOnLet [
-	"
-	let x = (let y=a in b)
-	in c
-	
-	is normalized to:
-	
-	let y=a
-	in let x=b
-	in c
-	"
-	| innerLet |
-	innerLet := decl expr.
-	(innerLet isKindOf: ELet) ifTrue: [
-		^ELet
-			decl: innerLet decl
-			expr: (ELet
-		         decl: (SpriteDecl bind: decl bind expr: innerLet expr)
-		         expr: expr) normalizeLetOnLet
-	].
-	(innerLet isKindOf: EIf) ifTrue: [
-		^EIf
-			cond: innerLet cond
-			trueE:  (ELet decl: (SpriteDecl bind: decl bind expr: innerLet trueE)  expr: expr)
-			falseE: (ELet decl: (SpriteDecl bind: decl bind expr: innerLet falseE) expr: expr)
-	].
-	^self
 ]
 
 { #category : #'α-renaming' }

--- a/src/SpriteLang/ELet.class.st
+++ b/src/SpriteLang/ELet.class.st
@@ -98,7 +98,6 @@ ELet >> gtExpr [
 
 { #category : #'as yet unclassified' }
 ELet >> inlineNonRecursiveReflects [
-self halt.
 	^decl inlineInto: expr	
 
 ]

--- a/src/SpriteLang/SpriteDecl.class.st
+++ b/src/SpriteLang/SpriteDecl.class.st
@@ -88,10 +88,10 @@ SpriteDecl >> gtExpr [
 { #category : #inlining }
 SpriteDecl >> inlineInto: e [
 	"Inline exactly the non-recursive Refls"
-	((expr isKindOf: EAnn) and: [expr ann isKindOf: Refl]) ifFalse: [ ^ELet decl: self expr: e  ].
+	"((expr isKindOf: EAnn) and: [expr ann isKindOf: Refl]) ifFalse: [ ^ELet decl: self expr: e  ].
 	^(e
 		macroExpandEVar: bind id
-		to: expr expr) inlineNonRecursiveReflects
+		to: expr expr) inlineNonRecursiveReflects"
 ]
 
 { #category : #testing }

--- a/src/SpriteLang/SpriteDecl.class.st
+++ b/src/SpriteLang/SpriteDecl.class.st
@@ -88,22 +88,15 @@ SpriteDecl >> gtExpr [
 { #category : #inlining }
 SpriteDecl >> inlineInto: e [
 	"Inline exactly the non-recursive Refls"
-	"((expr isKindOf: EAnn) and: [expr ann isKindOf: Refl]) ifFalse: [ ^ELet decl: self expr: e  ].
+	((expr isKindOf: EAnn) and: [expr ann isKindOf: Refl]) ifFalse: [ ^ELet decl: self expr: e  ].
 	^(e
 		macroExpandEVar: bind id
-		to: expr expr) inlineNonRecursiveReflects"
+		to: expr expr) inlineNonRecursiveReflects
 ]
 
 { #category : #testing }
 SpriteDecl >> isLet [
 	^false
-]
-
-{ #category : #inlining }
-SpriteDecl >> macroExpandEVar: x to: aΛExpr [
-	^self class
-		bind: bind
-		expr: (expr macroExpandEVar: x to: aΛExpr)
 ]
 
 { #category : #printing }

--- a/src/SpriteLang/ΛEApp.class.st
+++ b/src/SpriteLang/ΛEApp.class.st
@@ -113,30 +113,6 @@ embedApp :: SrcExpr -> F.Expr
 	self error
 ]
 
-{ #category : #inlining }
-ΛEApp >> macroExpandEVar: f to: aΛExpr [
-	| arityOrFalse appThisTime args argNames argValues body |
-	arityOrFalse := self isApplicationOf: f.
-	arityOrFalse isNil ifTrue: [
-		"Not me.  Pass along..."
-		^ΛEApp
-			expr: (expr macroExpandEVar: f to: aΛExpr)
-			imm: (imm macroExpandEVar: f to: aΛExpr)
-	].
-
-	appThisTime := self.
-	args := OrderedCollection new.
-	body := aΛExpr.
-	arityOrFalse timesRepeat: [ 
-		args add: body bind id -> appThisTime imm.
-		body := body expr.
-		appThisTime := appThisTime expr.
-	].
-	argNames := args collect: #key.
-	argValues := (args collect: #value) reversed.
-	^(argNames zip: argValues) inject: body into: [ :accum :thisArg | accum macroExpandEVar: thisArg key to: thisArg value ]
-]
-
 { #category : #'as yet unclassified' }
 ΛEApp >> synth: Γ [
 "

--- a/src/SpriteLang/ΛκParser.class.st
+++ b/src/SpriteLang/ΛκParser.class.st
@@ -244,12 +244,17 @@ Class {
 ΛκParser >> prog [
 	^ self options, qual star, measure star, self typs, decl plus
 	==> [ :x |
-			Prog
+			self progClass
 				quals: x second
 				meas: x third
 				expr: (ΛExpression fromDecls: x last)
 				data: x fourth
 				options: x first ]
+]
+
+{ #category : #accessing }
+ΛκParser >> progClass [
+	^CoreProg
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Alas, today is the day when we can no longer stealthily sne8ak enriched ML in and normalize in an ad-hoc fashion.

This PR implements normalization of arbitrarily-nested Λ-expressions to MIF and further to ANF.  (See X.Leroy's "Functional programming languages: Part V: functional intermediate representations" for an outline of the main idea).