### PR TITLE
Allow "exponent" notation for homsets between RTypes

### DIFF
--- a/src/PreSmalltalks/Object.extension.st
+++ b/src/PreSmalltalks/Object.extension.st
@@ -73,6 +73,11 @@ Object >> printStructOn: aStream [
 ]
 
 { #category : #'*PreSmalltalks' }
+Object >> raisedTo: power [
+	^power ==> self
+]
+
+{ #category : #'*PreSmalltalks' }
 Object >> replicate: times [
 	"Answer an Array of @times@ elements;
 	 every element of the array is @self@."

--- a/src/SpriteLang/RType.class.st
+++ b/src/SpriteLang/RType.class.st
@@ -53,6 +53,17 @@ RType class >> unifysNonEmpty: coll1 with: coll2 [
 
 ]
 
+{ #category : #'type theory' }
+RType >> ==> rhs [
+	"If s and t are RTypes, then the homset tˢ is the function type s→t.
+	 By Curry–Howard isomorphism this homset is the proposition 's implies t'.
+	"
+	^TFun
+		x: String junkSymbol
+		s: self
+		t: rhs
+]
+
 { #category : #polymorphism }
 RType >> assign: tVar [
 	ElabState current updSub: tVar rtype: self

--- a/src/Z3/Z3Sort.class.st
+++ b/src/Z3/Z3Sort.class.st
@@ -175,11 +175,6 @@ Z3Sort >> numeralFrom: aString [
 
 ]
 
-{ #category : #'type theory' }
-Z3Sort >> raisedTo: B [
-	^B ==> self
-]
-
 { #category : #'recursive adt' }
 Z3Sort >> sort_index: _ [ 
 	^{self . 0}


### PR DESCRIPTION
If _s_ and _t_ are RTypes, then the homset _tˢ_ is the function type _s→t_.  By Curry–Howard isomorphism this homset is the proposition "_s_ implies _t_".