### PR TITLE
[Metalanguage/ANF] Fix α-renaming of switch

### DIFF
--- a/src/Metalanguage-Tests/SpriteANFTest.class.st
+++ b/src/Metalanguage-Tests/SpriteANFTest.class.st
@@ -264,3 +264,23 @@ let is_a = (x) => {
 };
 '
 ]
+
+{ #category : #tests }
+SpriteANFTest >> test_switch_03 [
+	self proveSafe: '
+type i_or_b =
+  | I (x:int)     => [v| v === (I value: x) ]
+  | B (a:bool)    => [v| v === (B value: a) ]
+  ;
+
+⟦val main: x:int => int[v|v === (x+x)]⟧
+let main = (x) => {
+	let x = x + x;
+	switch (I(x)) {
+    | I(x) => x
+    | B(x) => 0
+	}
+};
+'
+
+]

--- a/src/SpriteLang/ECase.class.st
+++ b/src/SpriteLang/ECase.class.st
@@ -61,7 +61,14 @@ ECase >> gtChildren [
 { #category : #'α-renaming' }
 ECase >> uniq2: α [
 	| x′ α′ alts′ |
-	x′ := α at: x ifAbsent:[x].
+	
+	"Sigh, in Sprite ('Core') `x` is plain string but in Metalanguage ('Extended')
+	 `x` may be arbitrarily complex ΛExpression. Hence this ugly `isString` test."
+	x isString ifTrue:[
+		x′ := α at: x ifAbsent:[x].
+	] ifFalse:[
+		x′ := x uniq2: α 
+	].
 	
 	α′ := alts inject: α into:[:renamesSoFar :alt | alt collectαRenames: renamesSoFar ].
 	


### PR DESCRIPTION
Since α-renaming is not performed before core-reduction (commit `1a0145`), `ECase >> uniq2:` has to allow for `ECase`'s expression to be arbitrarily complex (and rename it). This commit does that and adds a test.