### PR TITLE
[Sprite DSL] Reduce ST-application of Sprite expr to `ΛEApp`

### DIFF
--- a/src/SpriteLang/ΛExpression.class.st
+++ b/src/SpriteLang/ΛExpression.class.st
@@ -223,3 +223,16 @@ cf. Elaborate.hs
 
 	self subclassResponsibility.
 ]
+
+{ #category : #yoneda }
+ΛExpression >> value: arg [
+	| x |
+	x := (arg isKindOf: EImm) ifTrue: [ arg imm ] ifFalse: [ arg ]. "BOGUS HACK due to Issue#194"
+	^ΛEApp expr: self imm: x
+]
+
+{ #category : #yoneda }
+ΛExpression >> valueWithArguments: args [
+	args isEmpty ifTrue: [ ^self ].
+	^(self value: args first) valueWithArguments: (args allButFirst)
+]


### PR DESCRIPTION
In full consciousness of the danger of mixing the λ-calculus with the metatheory.