### PR TITLE
Fix α-renaming nested annotated lets

### DIFF
--- a/src/SpriteLang-Tests/SpriteSimplePosTest.class.st
+++ b/src/SpriteLang-Tests/SpriteSimplePosTest.class.st
@@ -85,3 +85,21 @@ let main = (x) => {
 };
 '
 ]
+
+{ #category : #tests }
+SpriteSimplePosTest >> test_let_overwrite_2 [
+	self processString: '
+⟦val main: i:int => int[v| v === (i + i) ]⟧
+let main = (x) => {
+	⟦val x: int[v| v === (x + x)]⟧
+	let x = x + x;
+	
+	⟦val y: int[v|v === x]⟧
+	let y = x;
+	
+	⟦val x: int[v| v === y]⟧
+	let x = y;
+	x
+};
+'
+]

--- a/src/SpriteLang/EAnn.class.st
+++ b/src/SpriteLang/EAnn.class.st
@@ -60,6 +60,11 @@ EAnn >> gtChildren [
 	^{ expr . ann }
 ]
 
+{ #category : #testing }
+EAnn >> isEAnn [
+	^ true
+]
+
 { #category : #'as yet unclassified' }
 EAnn >> synth: Γ [
 "
@@ -75,10 +80,13 @@ EAnn >> synth: Γ [
 
 { #category : #'α-renaming' }
 EAnn >> uniq2: α [
+	self shouldNotImplement. "Use uniq2:symbol: instead. See `ELet >> uniq2: why." 
+]
 
+{ #category : #'α-renaming' }
+EAnn >> uniq2: α symbol: symbol [
 	^self class
 		expr: (expr uniq2: α)
-		ann:  (ann uniq2: α)
-
+		ann:  (ann uniq2: α symbol: symbol)
 
 ]

--- a/src/SpriteLang/ELet.class.st
+++ b/src/SpriteLang/ELet.class.st
@@ -109,13 +109,34 @@ ELet >> isLet [
 
 { #category : #'α-renaming' }
 ELet >> uniq2: α [
-	| id id′ α′ decl′ expr′ |
+	| id id′ α′ bind′ decl′ expr′ |
 
 	id := decl bind id.
 	id′:= α makeUnique: id.
 	α′ := α extMap: id to: id′.
-
-	decl′ := decl class bind: (decl bind uniq2: α′) expr: (decl expr uniq2: α)."<-- CERTAINLY NOT α′!!!"
+	
+	bind′ := SpriteBind id: id′.
+	
+	decl expr isEAnn ifTrue:[
+		"This is an annotated ELet, for example:
+		
+			⟦val x: int[v| v === (x + x)]⟧
+			let x = x + x;
+		
+		In this case we *HAVE TO* rename x in both, decl's bind and val's bind
+		but *NOT* in decl's expression and val's rtype! Hence the code below:
+		"
+		decl′ := decl class
+		           bind: bind′
+		           expr: (decl expr uniq2: α symbol: id′)."<-- CERTAINLY NOT α′!!!"		
+	] ifFalse:[
+		"This is an unannotated ELet, for example."
+		
+		decl′ := decl class
+		           bind: bind′
+		           expr: (decl expr uniq2: α)."<-- CERTAINLY NOT α′!!!"		
+	].
+	
 	expr′ := expr uniq2: α′.
 
 	^self class decl: decl′ expr: expr′

--- a/src/SpriteLang/SpriteAnn.class.st
+++ b/src/SpriteLang/SpriteAnn.class.st
@@ -125,8 +125,9 @@ SpriteAnn >> symbol: anObject [
 ]
 
 { #category : #'α-renaming' }
-SpriteAnn >> uniq2: α [
-	"α-rename all variables. Returns a copy of receiver with all names unique."
+SpriteAnn >> uniq2: α symbol: symbol′ [
+	"α-rename all variables. Returns a copy of receiver with all names unique
+	 ans with symbol set to symbol′ (See `ELet >> uniq2` on why this is needed)"
 
 	"Sigh, this is stupid. Ideally, we could do something like
 
@@ -146,7 +147,7 @@ SpriteAnn >> uniq2: α [
 
 	α′	:= rtype collectαRenames: α.
 	^self class
-			symbol: symbol
+			symbol: symbol′
 			rtype: (rtype uniq2: α′)
 			metric: (metric uniq2: α′)
 

--- a/src/SpriteLang/ΛExpression.class.st
+++ b/src/SpriteLang/ΛExpression.class.st
@@ -150,6 +150,11 @@ elaborate   :: Env -> SrcExpr -> ElbExpr
 ]
 
 { #category : #testing }
+ΛExpression >> isEAnn [
+	^ false
+]
+
+{ #category : #testing }
 ΛExpression >> isLet [
 	^false
 ]


### PR DESCRIPTION
Consider following fragment:

    let x = 42;
    ⟦val x: int[v| v === (x + x)]⟧
    let x = x + x;

When α-renaming we have to rename the second `x` (in second let) to (say) `x_2` resulting in (say):

    let x = 42;
    ⟦val x_2: int[v| v === (x + x)]⟧
    let x_2 = x + x;

In other words, we have to rename the symbol `x` in `Val` to `x_2` but not those `x` in `Val`'s refined type!