### PR TITLE
Remove dependency of Z3 proper on PreSmalltalks

### DIFF
--- a/pharo/check-deps.st
+++ b/pharo/check-deps.st
@@ -24,8 +24,7 @@ cycleDetector cycles do:[:cycle|
 3. Ensure Z3 has no unwanted dependencies, namely:
 
    i)   PreSmalltalks has no dependencies within MA except 'PreSmalltalks-Pharo'
-   ii)  Z3 has no dependencies within MA except 'PreSmalltalks' and its
-        dependencies
+   ii)  Z3 has no dependencies within MA.
 "
 depChecker := DADependencyChecker new.
 visited := Set new.
@@ -38,8 +37,7 @@ unwanted notEmpty ifTrue:[
 	Transcript show: 'ERROR: Unwanted dependencies of PreSmalltalks: '; show: unwanted printString; cr.
 ].
 "ii)"
-unwanted := packages & (depChecker dependenciesOf: 'Z3')
-						\ #('Z3-FFI-Pharo' 'PreSmalltalks' 'PreSmalltalks-Pharo').
+unwanted := packages & (depChecker dependenciesOf: 'Z3') \ #('Z3-FFI-Pharo').
 unwanted notEmpty ifTrue:[
 	error := true.
 	Transcript show: 'ERROR: Unwanted dependencies of Z3: '; show: unwanted printString; cr.

--- a/src/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
+++ b/src/BaselineOfMachineArithmetic/BaselineOfMachineArithmetic.class.st
@@ -10,7 +10,7 @@ BaselineOfMachineArithmetic >> baseline: spec [
 	spec
 		for: #common
 		do: [
-			spec postLoadDoIt: #'postLoad'.
+
 			spec baseline: 'PetitParser' with: [
 				spec loads: 'Core'.
 				spec loads: 'Analyzer'.
@@ -175,11 +175,4 @@ BaselineOfMachineArithmetic >> baseline: spec [
 				[ spec requires: 'DepthFirstSearch' ].
 		].
 
-]
-
-{ #category : #baselines }
-BaselineOfMachineArithmetic >> postLoad [
-	[( Symbol >> #value: ) removeFromSystem]
-		on: KeyNotFound
-		do: []
 ]

--- a/src/PreSmalltalks-Pharo/Symbol.extension.st
+++ b/src/PreSmalltalks-Pharo/Symbol.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : #Symbol }
 
 { #category : #'*PreSmalltalks-Pharo' }
+Symbol >> value: anObject [
+	"This method is an override. Do not remove!
+	 We want `Object >> value:` behavior."
+
+	^ super value: anObject
+]
+
+{ #category : #'*PreSmalltalks-Pharo' }
 Symbol >> valueWithArguments: args [
 	args isEmpty ifTrue: [
 		"If there is no object to serve as the receiver,

--- a/src/Z3-FFI-Pharo/Z3Query.class.st
+++ b/src/Z3-FFI-Pharo/Z3Query.class.st
@@ -1,0 +1,175 @@
+"
+Class Z3Query is a copy of class Query from package PreSmalltalks-Pharo.
+
+In an ideal world we won't need it an could just use Query. Alas, we don't live
+in an ideal world. 
+
+We want to reduce dependency of Z3 package (aka. 'Z3-proper') on PreSmalltalks. 
+Hence this hack.
+"
+Class {
+	#name : #Z3Query,
+	#superclass : #Notification,
+	#classVars : [
+		'DebuggingSupportEnabled'
+	],
+	#category : #'Z3-FFI-Pharo'
+}
+
+{ #category : #answering }
+Z3Query class >> answer: value do: block [
+	"Evaluate `block` answering `value` to queries made within the block.
+	 Returns the value of `block`.
+
+	 See `Query class >> #query`"
+
+	^block on: self do: [:q | q resume: value ]
+
+
+	"
+	Query answer: 'kitty' do:[
+		Transcript show: 'Hello ' , Query query , '!'; cr.
+	]
+	"
+]
+
+{ #category : #accessing }
+Z3Query class >> debuggingSupportEnabled [
+	"Return if debugging of Z3Query is supported."
+	
+	^ DebuggingSupportEnabled
+	
+	"
+	Z3Query debuggingSupportEnabled: true.
+	Z3Query debuggingSupportEnabled: false.
+	Z3Query debuggingSupportEnabled.
+	"
+
+]
+
+{ #category : #accessing }
+Z3Query class >> debuggingSupportEnabled: aBoolean [
+	"Enables/disables support in debugger. See comment in Z3Query >> #defaultAction."
+	
+	DebuggingSupportEnabled := aBoolean.
+	
+	"
+	Z3Query debuggingSupportEnabled: true.
+	Z3Query debuggingSupportEnabled: false.
+	"
+
+]
+
+{ #category : #initialization }
+Z3Query class >> initialize [
+	DebuggingSupportEnabled := false.
+	
+	"
+	Z3Query debuggingSupportEnabled: true.
+	Z3Query debuggingSupportEnabled: false.
+	  Query debuggingSupportEnabled
+	"
+
+
+]
+
+{ #category : #asking }
+Z3Query class >> query [
+	"Raise the query. Return the answer or default value.
+
+	 See `Query class >> #answer:do:` and `Query >> #defaultResumeValue`"
+
+	^self signal
+
+
+	"
+	Query answer: 'world' do:[
+		Transcript show: 'Hello ' , Query query , '!'; cr.
+		1
+	]
+	"
+]
+
+{ #category : #accessing }
+Z3Query >> defaultAction [
+	"The default action taken if the exception is signaled."
+
+	"Control flow arrives here in case query's value is not supplied
+	 anywhere in current call chain. This is also the case when code
+	 is evaluated within debugger since debugger runs in its own thread,
+	 separately from debugee.
+
+	 This leads to confusing situation that one may get different results
+	 from query when executed by debugee and when executed by evaluating code
+	 in debugger.
+
+	 To mitigate this, the code below tries to detect whether control flow
+	 came here due to evaluating in code in debugger and if so, manually
+	 walks debugee's stack to find query's value.
+
+	 Dangerous hackery for sure. This is why this mitigation (hackery) is
+	 guarded and needs to be enabled by the user.
+	"
+	self class debuggingSupportEnabled ifTrue:[
+		| ctx |
+
+		ctx := thisContext findContextSuchThat: [ :c | c selector == #DoItIn: and:[ (c tempAt: 1) isContext ] ].
+		ctx notNil ifTrue:[
+			"`ctx` is the context of do-it method activation. The only parameter is
+			  the (original, debugee's) context in which the do-it is evaluated.
+			  Walk debugee's stack starting with that context and search for
+			  handler providing query's value (if any).
+	
+			  Implementation note: one may be very tempted to do just
+	
+				    self signalIn: (ctx tempAt: 1)
+	
+			  Don't try! This may cause debugee's context to return and
+		    leaves smalltalk environment in inconsistent weird state
+		    where nothing work. This is why we do it 'manually'.
+			 "
+
+			| handler |
+
+			handler := (ctx tempAt: 1) nextHandlerContext.
+			[ handler notNil ] whileTrue:[
+				(handler exceptionClass handles: self) ifTrue:[
+					"We found the handler context. Evaluate handler
+					 block for receiver (the query instance in debuffer
+					 thread!)"
+					handler exceptionHandlerBlock cull: self.
+				].
+				handler := handler nextHandlerContext.
+			].
+		].
+	].
+
+	"Otherwise, return the query's default value."
+	^self defaultResumeValue
+]
+
+{ #category : #accessing }
+Z3Query >> defaultResumeValue [
+	"Default answer to this query. This value is used if nobody
+	 provided 'better' answer using `#answer:do:`.
+
+   By default an error is raised. Subclasses may override this
+   to provide a suitable default."
+
+	self error: 'No suitable default answer!'
+]
+
+{ #category : #asking }
+Z3Query >> query [
+	"Raise the query. Return the answer or default value.
+	 Defined for compatibility with Smalltalk/X."
+
+	^self signal
+
+	"
+	Query answer: 'world' do:[
+		Transcript show: 'Hello ' , Query new query , '!'; cr.
+		1
+	]
+	"
+]

--- a/src/Z3-FFI-SmalltalkX/Z3Query.class.st
+++ b/src/Z3-FFI-SmalltalkX/Z3Query.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #Z3Query,
+	#superclass : #Query,
+	#category : #'Z3-FFI-SmalltalkX'
+}

--- a/src/Z3/Z3ContextQuery.class.st
+++ b/src/Z3/Z3ContextQuery.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #Z3ContextQuery,
-	#superclass : #Query,
+	#superclass : #Z3Query,
 	#category : #'Z3-Core'
 }
 

--- a/src/Z3/Z3Node.class.st
+++ b/src/Z3/Z3Node.class.st
@@ -7,6 +7,7 @@ Class {
 	],
 	#pools : [
 		'Z3ASTKind',
+		'Z3ErrorCode',
 		'Z3FuncDeclKind',
 		'Z3SortKind'
 	],
@@ -454,7 +455,12 @@ Z3Node >> toSingletonZ3Set [
 
 { #category : #'as yet unclassified' }
 Z3Node >> toZ3Sort: s [ 
-	self sort == s ifFalse: [ Incompatible signal ].
+	self sort == s ifFalse: [ 
+		Z3Error new 
+			code: SORT_ERROR; 
+			messageText: 'Cannot convert ', sort name , ' to ' , s name;
+			signal.
+	].
 	^self
 ]
 


### PR DESCRIPTION
This PR removes dependency of "Z3 proper" on PreSmalltalks. 

The idea is to make Z3 proper usable and loadable outside a context of MA. Over time PreSmalltalks accumulated
a lot of changes into the core of Smalltalk 80 system (auto-currying, bunch of classes like `Left`, `Cell`, `Visitor` or `Trie`) which may not always be  wanted. 

It would also make supporting Z3 proper (to begin with) on later versions of Pharo easier. 

The price we pay for it is  eaceced . I'm ready to pay it.
