### PR TITLE
[Pre-Smalltalks] Implement `#assume:` and `#assume:description:`

### DIFF
--- a/src/PreSmalltalks-Pharo/AssumptionFailure.class.st
+++ b/src/PreSmalltalks-Pharo/AssumptionFailure.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #AssumptionFailure,
+	#superclass : #AssertionFailure,
+	#category : #'PreSmalltalks-Pharo'
+}

--- a/src/PreSmalltalks-Pharo/Object.extension.st
+++ b/src/PreSmalltalks-Pharo/Object.extension.st
@@ -1,6 +1,58 @@
 Extension { #name : #Object }
 
 { #category : #'*PreSmalltalks-Pharo' }
+Object >> assume: aBlock [
+	"Throw an assumption error if aBlock does not evaluates to true.
+	
+	 This is much like `Object >> #assert:`, see comment in `Object >> #assume:description:` for
+	 further explanation of the difference.
+	"
+	<debuggerCompleteToSender>
+	self assume: aBlock description: 'Assumption failed'.
+]
+
+{ #category : #'*PreSmalltalks-Pharo' }
+Object >> assume: aBlock description: aStringOrBlock [
+	"Throw an assumption error if aBlock does not evaluates to true.
+	
+	This is much like `Object >> #assume:description:` - both will throw an exception
+	at runtime if check fails. The difference is that assume is meant express and
+	check method's preconditions whereas assert is to check method's interrim state
+	and postcondition.
+
+	In another words - if assume fails then it means it is caller's fault: the caller
+	has called the method with wrong arguments or when the receiver is in inappropriate
+	state.
+	If assert fails then it is method's fault: unexpected internal state or situation
+	at some point if it's execution.
+
+	In yet another words (from LH slack):
+
+	> Just like
+	>
+	> ```
+	> cAssert b
+	> ```
+	>
+	> requires b as a precondition,
+	>
+	> ```
+	> cAssume b
+	> ```
+	>
+	> “Ensures” b as a postcondition!!
+	> In a strict language you can write
+	> ```
+	> cAssume :: b:Bool -> {v:() | b}
+	> cAssume b = if b then () else diverge()
+	> ```
+	"
+	<debuggerCompleteToSender>
+	aBlock value == true
+		ifFalse: [ AssumptionFailure signal: aStringOrBlock value ]
+]
+
+{ #category : #'*PreSmalltalks-Pharo' }
 Object >> perform: aSymbol [ 
 	^ self perform: aSymbol withArguments: #()
 ]

--- a/src/PreSmalltalks/Object.extension.st
+++ b/src/PreSmalltalks/Object.extension.st
@@ -6,27 +6,6 @@ Object >> K [
 ]
 
 { #category : #'*PreSmalltalks' }
-Object >> assume: aBlock [
-	"From LH slack:
-	
-	Just like
-	
-```	cAssert b
-	
-	requires b as a precondition,
-	
-```	cAssume b
-	
-	“Ensures” b as a postcondition!
-	In a strict language you can write
-```
-	cAssume :: b:Bool -> {v:() | b}
-	cAssume b = if b then () else diverge()
-	"
-	self shouldBeImplemented
-]
-
-{ #category : #'*PreSmalltalks' }
 Object >> at: index nonDestructivePut: value [
 	^self copy
 		at: index put: value;


### PR DESCRIPTION
This commit implements `#assume:` and `#assume:description:` so it can be used in the code. It places the implementation to package `PreSmalltalks-Pharo` because on Smalltalk/X, these methods made it to its core class library.