### PR TITLE
Increase time limit for `BVTest >> testBvViaInt` to 15 minutes

### DIFF
--- a/src/Z3-Tests/BVTest.class.st
+++ b/src/Z3-Tests/BVTest.class.st
@@ -75,6 +75,11 @@ BVTest >> testBvEF [
 BVTest >> testBvViaInt [
 	"bv -> Int -> bv"
 	| bv bvS bvU |
+	
+	"Starting with Z3 4.15.1, this test started to take a long time (~5mins on Intel i7-1355U).
+	 So adjust the time limit."
+	self timeLimit: 15 minutes.
+	
 	bv := 'bv' toBitVector: 8.
 	
 	bvS := bv toSignedInt toBitVector: 8.


### PR DESCRIPTION
Starting with Z3 4.15.1, this test started to take a long time. On (my) Intel i7-1355U it takes ~5mins. This commit increases time limit to 15 minutes (considering the fact that CI is run in a cloud and not on dedicated machine so the physical machine may be running other workloads too).

Hopefully fixes #562.