### PR TITLE
Fix Z3 package manifests

### DIFF
--- a/src/Z3-FFI-SmalltalkX/ManifestZ3FFISmalltalkX.class.st
+++ b/src/Z3-FFI-SmalltalkX/ManifestZ3FFISmalltalkX.class.st
@@ -1,14 +1,11 @@
-"
-I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
-"
 Class {
-	#name : #ManifestMachineArithmetic,
+	#name : #ManifestZ3FFISmalltalkX,
 	#superclass : #PackageManifest,
-	#category : #'Z3-Manifest'
+	#category : #'Z3-FFI-SmalltalkX-Manifest'
 }
 
 { #category : #'stx - description' }
-ManifestMachineArithmetic class >> mandatoryPreRequisites [
+ManifestZ3FFISmalltalkX class >> mandatoryPreRequisites [
 	"list packages which are mandatory as a prerequisite.
 	 This are packages containing superclasses of my classes and classes which
 	 are extended by myself.
@@ -18,15 +15,14 @@ ManifestMachineArithmetic class >> mandatoryPreRequisites [
 	 Please take a look at the #referencedPreRequisites method as well."
 
 	^ #(
-		#'PreSmalltalks'
-		#'MachineArithmetic-FFI-SmalltalkX'    "Z3Object - superclass of BitVector"
-		#'stx:libbasic'    "Error - superclass of MustBeConcrete"
-		#'stx:libcompat'    "PackageManifest - superclass of ManifestMachineArithmetic"
+		#'stx:libbasic'    "ExternalAddress - superclass of Z3Object"
+		#'stx:libcompat'    "PackageManifest - superclass of ManifestMachineArithmeticFFISmalltalkX"
 	)
+
 ]
 
 { #category : #'stx - description' }
-ManifestMachineArithmetic class >> referencedPreRequisites [
+ManifestZ3FFISmalltalkX class >> referencedPreRequisites [
 	"list packages which are a prerequisite, because they contain
 	 classes which are referenced by my classes.
 	 These packages are NOT needed as a prerequisite for compiling or loading,
@@ -39,4 +35,5 @@ ManifestMachineArithmetic class >> referencedPreRequisites [
 
 	^ #(
 	)
+
 ]

--- a/src/Z3-Tests/ManifestZ3Tests.class.st
+++ b/src/Z3-Tests/ManifestZ3Tests.class.st
@@ -2,13 +2,13 @@
 I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
 "
 Class {
-	#name : #ManifestMachineArithmeticTests,
+	#name : #ManifestZ3Tests,
 	#superclass : #PackageManifest,
 	#category : #'Z3-Tests-Manifest'
 }
 
 { #category : #'stx - description' }
-ManifestMachineArithmeticTests class >> mandatoryPreRequisites [
+ManifestZ3Tests class >> mandatoryPreRequisites [
 	"list packages which are mandatory as a prerequisite.
 	 This are packages containing superclasses of my classes and classes which
 	 are extended by myself.
@@ -25,7 +25,7 @@ ManifestMachineArithmeticTests class >> mandatoryPreRequisites [
 ]
 
 { #category : #'stx - description' }
-ManifestMachineArithmeticTests class >> referencedPreRequisites [
+ManifestZ3Tests class >> referencedPreRequisites [
 	"list packages which are a prerequisite, because they contain
 	 classes which are referenced by my classes.
 	 These packages are NOT needed as a prerequisite for compiling or loading,

--- a/src/Z3/ManifestZ3.class.st
+++ b/src/Z3/ManifestZ3.class.st
@@ -1,11 +1,14 @@
+"
+I store metadata for this package. These meta data are used by other tools such as the SmalllintManifestChecker and the critics Browser
+"
 Class {
-	#name : #ManifestMachineArithmeticFFISmalltalkX,
+	#name : #ManifestZ3,
 	#superclass : #PackageManifest,
-	#category : #'Z3-FFI-SmalltalkX-Manifest'
+	#category : #'Z3-Manifest'
 }
 
 { #category : #'stx - description' }
-ManifestMachineArithmeticFFISmalltalkX class >> mandatoryPreRequisites [
+ManifestZ3 class >> mandatoryPreRequisites [
 	"list packages which are mandatory as a prerequisite.
 	 This are packages containing superclasses of my classes and classes which
 	 are extended by myself.
@@ -15,14 +18,15 @@ ManifestMachineArithmeticFFISmalltalkX class >> mandatoryPreRequisites [
 	 Please take a look at the #referencedPreRequisites method as well."
 
 	^ #(
-		#'stx:libbasic'    "ExternalAddress - superclass of Z3Object"
-		#'stx:libcompat'    "PackageManifest - superclass of ManifestMachineArithmeticFFISmalltalkX"
+		#'PreSmalltalks'
+		#'MachineArithmetic-FFI-SmalltalkX'    "Z3Object - superclass of BitVector"
+		#'stx:libbasic'    "Error - superclass of MustBeConcrete"
+		#'stx:libcompat'    "PackageManifest - superclass of ManifestMachineArithmetic"
 	)
-
 ]
 
 { #category : #'stx - description' }
-ManifestMachineArithmeticFFISmalltalkX class >> referencedPreRequisites [
+ManifestZ3 class >> referencedPreRequisites [
 	"list packages which are a prerequisite, because they contain
 	 classes which are referenced by my classes.
 	 These packages are NOT needed as a prerequisite for compiling or loading,
@@ -35,5 +39,4 @@ ManifestMachineArithmeticFFISmalltalkX class >> referencedPreRequisites [
 
 	^ #(
 	)
-
 ]


### PR DESCRIPTION
Commit

    1885bebf Rename package "MachineArithmetic" to "Z3"

renamed package but forgot to rename package manifests. This does so.