### PR TITLE
Fix manifest of Z3-Tests

### DIFF
--- a/src/Z3-Tests/ManifestZ3Tests.class.st
+++ b/src/Z3-Tests/ManifestZ3Tests.class.st
@@ -37,6 +37,6 @@ ManifestZ3Tests class >> referencedPreRequisites [
 	 Please also take a look at the #mandatoryPreRequisites method"
 
 	^ #(
-		#MachineArithmetic    "BitVector - referenced by BitRelevanceTest>>test1KStores"
+		#Z3    "BitVector - referenced by BitRelevanceTest>>test1KStores"
 	)
 ]


### PR DESCRIPTION
Commit

    1885bebf Rename package "MachineArithmetic" to "Z3"

renamed package but forgot to update dependencies in Z3-Test's manifest. This does so.