### PR TITLE
[Z3]: Simplify `Z3CAPITest >> #testFindModel0`

### DIFF
--- a/src/Z3-Tests/Z3CAPITest.class.st
+++ b/src/Z3-Tests/Z3CAPITest.class.st
@@ -452,11 +452,7 @@ Z3CAPITest >> testEval [
 Z3CAPITest >> testFindModel0 [
 	"Find a model for
 		x "
-	| x y solver sat model ass |
-
-	((Smalltalk respondsTo: #isSmalltalkX) and:[Smalltalk isSmalltalkX]) ifTrue:[
-		self skip: 'Not supported on Smalltalk/X, uses Pharo compiler API'
-	].
+	| x y solver sat model |
 
 	x := Bool var: 'x'.
 	y := Bool var: 'y'.
@@ -468,9 +464,7 @@ Z3CAPITest >> testFindModel0 [
 	"this is the test for now; this is part of void check() in test_capi.c"
 	self assert: sat.
 	model := solver getModel.
-	ass := Smalltalk compiler source: (model toString); environment: (Dictionary new at: 'x' put: 'XXX'; yourself); evaluate.
-	self assert: ass key equals: 'XXX'.
-	self assert: ass value equals: true.
+	self assert: (model at: x) equals: true.
 ]
 
 { #category : #tests }
@@ -488,7 +482,7 @@ Z3CAPITest >> testFindModel1 [
 	"this is the test for now; this is part of void check() in test_capi.c"
 	self assert: sat.
 	model := solver getModel.
-	Transcript cr; show: model toString
+	self assert: ((model at: x) = true or: [ (model at: y) = true])
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Test `Z3CAPITest >> #testFindModel0` used rather convoluted method to get the value of bool variable `x` from Z3 model using Smalltalk compiler.

Apart of being rather difficult to understand what is doing and why, using compiler this way is really dialect-specific and only works on Pharo (8).

This commit rewrites the assertion using `Z3Model >> at:`, making it simpler and more portable at the same time.

While at it, add an assertion to `Z3CAPITest >> #testFindModel1` in a similar fashion.