### PR TITLE
Implement Sprite "unparsing"

### DIFF
--- a/src/Metalanguage/Prog.class.st
+++ b/src/Metalanguage/Prog.class.st
@@ -19,3 +19,12 @@ Prog >> core [
 		data: data
 		options: options
 ]
+
+{ #category : #GT }
+Prog >> gtInspectorSpriteOfCoreIn: composite [
+	<gtInspectorPresentationOrder: 55>
+
+	^composite text
+		title: 'Source (core program)';
+		display: [ self core spriteString ]
+]

--- a/src/SpriteLang/ARef.class.st
+++ b/src/SpriteLang/ARef.class.st
@@ -70,6 +70,19 @@ ARef >> refactorAppR: anEvalEnv [
 		arPred: (arPred refactorAppR: amendedEnv)
 ]
 
+{ #category : #printing }
+ARef >> spriteOn: stream indent: level [
+	stream nextPut: $(.
+	arArgs 
+		do:[:nameAndRType | stream nextPutAll: nameAndRType key; nextPut: $:. nameAndRType value spriteOn: stream indent: level ]
+		separatedBy:[stream nextPutAll: ', '].
+	stream nextPutAll: ') => ['.
+	"This is really ugly but that's the price for parser doing
+	 stuff it should not (converting stuff too early)"
+	stream nextPutAll: arPred expr ps first expr conjuncts first text.
+	stream nextPut: $].
+]
+
 { #category : #'as yet unclassified' }
 ARef >> subsAR: p ar: anARef [
 	"bogus -- see Issue 62.  this one is especially screaming."

--- a/src/SpriteLang/Alt.class.st
+++ b/src/SpriteLang/Alt.class.st
@@ -98,6 +98,23 @@ Alt >> printOn: aStream [
 	self printStructOn: aStream
 ]
 
+{ #category : #printing }
+Alt >> spriteOn: aStream indent: level [
+	"Print receiver on `aStream` as SpriteLang source"
+
+	aStream next: level * 4 put: Character space.
+	aStream nextPutAll: '| '; nextPutAll: daCon.
+	binds notEmpty ifTrue:[
+		aStream nextPut:$(.
+		binds
+			do:[:bind | aStream nextPutAll: bind id ]
+			separatedBy: [ aStream nextPutAll: ', ' ].
+		aStream nextPut:$)
+	].
+	aStream nextPutAll: ' => '.
+	expr spriteOn: aStream indent: level + 1.
+]
+
 { #category : #'α-renaming' }
 Alt >> uniq2: α [
 	^self class

--- a/src/SpriteLang/CoreProg.class.st
+++ b/src/SpriteLang/CoreProg.class.st
@@ -50,10 +50,19 @@ CoreProg >> expr: anObject [
 
 { #category : #GT }
 CoreProg >> gtInspectorExprsIn: composite [
-	<gtInspectorPresentationOrder: 50>
+	<gtInspectorPresentationOrder: 60>
 
 	^(expr gtInspectorTreeIn: composite)
 		title: 'Expressions'
+]
+
+{ #category : #GT }
+CoreProg >> gtInspectorSpriteIn: composite [
+	<gtInspectorPresentationOrder: 50>
+
+	^composite text
+		title: 'Source';
+		display: [ self spriteString ]
 ]
 
 { #category : #accessing }
@@ -92,6 +101,32 @@ CoreProg >> solve [
 	core := self uniq2 core.
 	vc := [core vcgen] runReader: #checkTermination initialState: (self options includes: #'check-termination').
 	^vc solve
+]
+
+{ #category : #printing }
+CoreProg >> spriteOn: aStream [
+	self spriteOn: aStream indent: 0
+]
+
+{ #category : #printing }
+CoreProg >> spriteOn: aStream indent: level [
+	"Print receiver on `aStream` as SpriteLang source"
+
+	"
+	quals , meas , data do:[:each |
+		each unparseOn: aStream indent: level
+	] separatedBy: [ aStream cr; cr. ].
+	"
+	expr spriteOn: aStream indent: level
+
+]
+
+{ #category : #printing }
+CoreProg >> spriteString [
+	"Return a string representing the receiver as Sprite sourcea"
+
+	^ String streamContents:[:s| self spriteOn: s]
+
 ]
 
 { #category : #'α-renaming' }

--- a/src/SpriteLang/Data.class.st
+++ b/src/SpriteLang/Data.class.st
@@ -144,6 +144,11 @@ Data >> rvars: anObject [
 	rvars := anObject
 ]
 
+{ #category : #printing }
+Data >> spriteOn: aStream indent: level [
+	self halt.
+]
+
 { #category : #'α-renaming' }
 Data >> uniq2: α [
 	| α′ |

--- a/src/SpriteLang/EAnn.class.st
+++ b/src/SpriteLang/EAnn.class.st
@@ -65,6 +65,13 @@ EAnn >> isEAnn [
 	^ true
 ]
 
+{ #category : #printing }
+EAnn >> spriteOn: stream indent: level [
+	ann spriteOn: stream indent: level.
+	stream cr.
+	stream nextPutAll: 'let ...'
+]
+
 { #category : #'as yet unclassified' }
 EAnn >> synth: Γ [
 "

--- a/src/SpriteLang/ECase.class.st
+++ b/src/SpriteLang/ECase.class.st
@@ -58,6 +58,26 @@ ECase >> gtChildren [
 	^alts
 ]
 
+{ #category : #printing }
+ECase >> spriteOn: aStream indent: level [
+	"Print receiver on `aStream` as SpriteLang source"
+
+	aStream next: level * 4 put: Character space.
+	aStream nextPutAll: 'switch ('.
+	"x can ve either string or expr, sigh"
+	x isString ifTrue:[
+		aStream nextPutAll: x.
+	] ifFalse:[
+		x spriteOn: aStream indent: level.
+	].
+	aStream nextPutAll: ') {'.
+	alts do:[:alt|
+		alt spriteOn: aStream indent: level + 1
+	].
+	aStream next: level * 4 put: Character space.
+	aStream nextPutAll: '}'.
+]
+
 { #category : #'α-renaming' }
 ECase >> uniq2: α [
 	| x′ α′ alts′ |

--- a/src/SpriteLang/ECon.class.st
+++ b/src/SpriteLang/ECon.class.st
@@ -70,6 +70,13 @@ ECon >> prim: anObject [
 	prim := anObject
 ]
 
+{ #category : #printing }
+ECon >> spriteOn: aStream indent: level [
+	"Print receiver on `aStream` as SpriteLang source"
+	prim spriteOn: aStream indent: level
+
+]
+
 { #category : #substitution }
 ECon >> subst: θ [
 	^self

--- a/src/SpriteLang/EFun.class.st
+++ b/src/SpriteLang/EFun.class.st
@@ -93,6 +93,28 @@ EFun >> renameTy: ty metric: m [
 	^(TFun x: x s: s′ t: t′′) -> m′′
 ]
 
+{ #category : #printing }
+EFun >> spriteOn: stream indent: level [
+	| efun args body |
+
+	args := OrderedCollection new: 3.
+	efun := self.
+	[ efun isKindOf: EFun ] whileTrue:[
+		args add: efun bind id.
+		efun := efun expr.
+	].
+	body := efun.
+
+	stream nextPut:$(.
+	args do:[:arg|stream nextPutAll: arg] separatedBy:[stream nextPutAll:', '].
+	stream nextPut:$).
+
+	stream nextPutAll: ' => {'; cr.
+	stream next: (level + 1) * 4 put: Character space.
+	body spriteOn: stream indent: level + 1.
+	stream cr; nextPutAll: '}'.
+]
+
 { #category : #'α-renaming' }
 EFun >> uniq2: α [
 	| id id′ α′ |

--- a/src/SpriteLang/EIf.class.st
+++ b/src/SpriteLang/EIf.class.st
@@ -85,6 +85,24 @@ EIf >> gtChildren [
 
 ]
 
+{ #category : #printing }
+EIf >> spriteOn: stream indent: level [
+
+	stream nextPutAll:'if ('.
+	cond spriteOn: stream indent: level.
+	stream nextPutAll:') {'; cr.
+	stream next: level + 1 * 4 put: Character space.
+	trueE spriteOn: stream indent: level + 1.
+	stream cr.
+	stream next: level * 4 put: Character space.
+	stream nextPutAll:'} else {'; cr.
+	stream next: level + 1 * 4 put: Character space.
+	falseE spriteOn: stream indent: level + 1.
+	stream cr.
+	stream next: level * 4 put: Character space.
+	stream nextPutAll:'}'.
+]
+
 { #category : #accessing }
 EIf >> trueE [
 	^ trueE

--- a/src/SpriteLang/EImm.class.st
+++ b/src/SpriteLang/EImm.class.st
@@ -44,6 +44,13 @@ EImm >> immYourself [
 	^self
 ]
 
+{ #category : #printing }
+EImm >> spriteOn: aStream indent: level [
+	"Print receiver on `aStream` as SpriteLang source"
+
+	imm spriteOn: aStream indent: level
+]
+
 { #category : #'as yet unclassified' }
 EImm >> synth: Γ [
 "

--- a/src/SpriteLang/ELet.class.st
+++ b/src/SpriteLang/ELet.class.st
@@ -107,6 +107,15 @@ ELet >> isLet [
 	^true
 ]
 
+{ #category : #printing }
+ELet >> spriteOn: aStream indent: level [	
+	decl spriteOn: aStream indent: level.
+	aStream nextPut: $;.
+	aStream cr.
+	aStream next: level * 4 put: Character space.
+	expr spriteOn: aStream indent: level.
+]
+
 { #category : #'α-renaming' }
 ELet >> uniq2: α [
 	| id id′ α′ bind′ decl′ expr′ |

--- a/src/SpriteLang/EVar.extension.st
+++ b/src/SpriteLang/EVar.extension.st
@@ -57,6 +57,12 @@ rvarArgSymbol _ (F.EVar x) = x
 ]
 
 { #category : #'*SpriteLang' }
+EVar >> spriteOn: stream indent: level [
+	stream nextPutAll: sym.
+
+]
+
+{ #category : #'*SpriteLang' }
 EVar >> synthImm: Γ [
 "
 synthImm :: Env -> SrcImm -> CG RType

--- a/src/SpriteLang/KnownReft.class.st
+++ b/src/SpriteLang/KnownReft.class.st
@@ -111,6 +111,11 @@ can determine whether a DecidableRefinement is an RVar-application.
 	^KnownReft symbol: symbol expr: (expr refactorAppP: amendedEnv)
 ]
 
+{ #category : #printing }
+KnownReft >> spriteOn: stream indent: level [
+	self shouldBeImplemented 
+]
+
 { #category : #SubsARef }
 KnownReft >> subs: p ar: ar [
 "

--- a/src/SpriteLang/PBin.class.st
+++ b/src/SpriteLang/PBin.class.st
@@ -29,3 +29,8 @@ PBin >> primOp [
 PBin >> primOp: anObject [
 	primOp := anObject
 ]
+
+{ #category : #printing }
+PBin >> spriteOn: stream indent: level [
+	primOp spriteOn: stream indent: level
+]

--- a/src/SpriteLang/PBool.class.st
+++ b/src/SpriteLang/PBool.class.st
@@ -37,3 +37,8 @@ constTy _ (PBool False) = TBase TBool (known $ F.propReft F.PFalse)
 PBool >> immExprX [
 	^bool toBool
 ]
+
+{ #category : #printing }
+PBool >> spriteOn: aStream indent: level [
+	bool printOn: aStream
+]

--- a/src/SpriteLang/PInt.class.st
+++ b/src/SpriteLang/PInt.class.st
@@ -49,3 +49,8 @@ PInt >> integer [
 PInt >> integer: anObject [
 	integer := anObject
 ]
+
+{ #category : #printing }
+PInt >> spriteOn: aStream indent: level [
+	integer printOn: aStream
+]

--- a/src/SpriteLang/PUnknown.class.st
+++ b/src/SpriteLang/PUnknown.class.st
@@ -15,3 +15,8 @@ PUnknown >> constTy [
 		var: 'a'
 		type: (TVar symbol: 'a') bTrue
 ]
+
+{ #category : #printing }
+PUnknown >> spriteOn: stream indent: level [
+	stream nextPutAll: '□'
+]

--- a/src/SpriteLang/Qualifier.extension.st
+++ b/src/SpriteLang/Qualifier.extension.st
@@ -17,3 +17,17 @@ Qualifier class >> pappQual: n [
 		params: params
 		body: body
 ]
+
+{ #category : #'*SpriteLang' }
+Qualifier >> spriteOn: aStream indent: ident [
+	"
+	ΛκParser >> #qualBody
+	"
+	aStream nextPutAll: '⟦qualif '.
+	aStream nextPutAll: name.
+	aStream nextPutAll: ' ('.
+	params printOn: aStream delimiter: ', '.
+	aStream nextPutAll: ') '.
+	body printOn: aStream.
+	aStream nextPutAll: '⟧'
+]

--- a/src/SpriteLang/RType.class.st
+++ b/src/SpriteLang/RType.class.st
@@ -547,6 +547,11 @@ RType >> splitTAll [
 	^{ #() . self }
 ]
 
+{ #category : #printing }
+RType >> spriteOn: stream indent: level [
+	self subclassResponsibility
+]
+
 { #category : #polymorphism }
 RType >> strengthenTop: r [
 "strengthenTop :: RType -> Reft -> RType"

--- a/src/SpriteLang/RVar.class.st
+++ b/src/SpriteLang/RVar.class.st
@@ -110,6 +110,13 @@ RVar >> rvName: anObject [
 	rvName := anObject
 ]
 
+{ #category : #printing }
+RVar >> spriteOn: stream indent: level [
+	"⟦val maxInt : ∀ (p : int => bool"
+	
+	
+]
+
 { #category : #SubsTy }
 RVar >> subsTy: su [
 	| args′ |

--- a/src/SpriteLang/Refl.class.st
+++ b/src/SpriteLang/Refl.class.st
@@ -8,3 +8,12 @@ Class {
 Refl class >> reflect: equationName type: t expr: e [
 	^t reflect: equationName expr: e
 ]
+
+{ #category : #printing }
+Refl >> spriteOn: stream indent: level [
+	stream nextPutAll: '⟦reflect '.
+	stream nextPutAll: symbol.
+	stream nextPutAll: ' : '.
+	rtype spriteOn: stream indent: level.
+	stream nextPutAll: '⟧'.
+]

--- a/src/SpriteLang/SpriteAnn.class.st
+++ b/src/SpriteLang/SpriteAnn.class.st
@@ -114,6 +114,11 @@ SpriteAnn >> rtype: anObject [
 	rtype := anObject
 ]
 
+{ #category : #'as yet unclassified' }
+SpriteAnn >> spriteOn: aWriteStream indent: anInteger [
+	self subclassResponsibility
+]
+
 { #category : #accessing }
 SpriteAnn >> symbol [
 	^ symbol

--- a/src/SpriteLang/SpriteDecl.class.st
+++ b/src/SpriteLang/SpriteDecl.class.st
@@ -90,9 +90,36 @@ SpriteDecl >> isLet [
 	^false
 ]
 
+{ #category : #testing }
+SpriteDecl >> isRecursive [
+	^false
+]
+
 { #category : #printing }
 SpriteDecl >> printOn: aStream [
 	self printStructOn: aStream
+]
+
+{ #category : #printing }
+SpriteDecl >> spriteOn: aStream indent: level [
+	| body |
+
+	(expr isKindOf: EAnn) ifTrue:[
+		aStream cr;cr.
+		expr ann spriteOn: aStream indent: level.
+		aStream cr.
+
+		body := expr expr.
+	] ifFalse:[
+		body := expr.
+	].
+
+	aStream nextPutAll:'let '.
+	self isRecursive ifTrue:[	aStream nextPutAll:'rec ' ].
+	aStream nextPutAll:bind id.
+	aStream nextPutAll:' = '.
+	body spriteOn: aStream indent: level.
+
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/SpriteLang/TAll.class.st
+++ b/src/SpriteLang/TAll.class.st
@@ -128,6 +128,11 @@ TAll >> splitTAll [
 	^{ {var}, as . t }
 ]
 
+{ #category : #printing }
+TAll >> spriteOn: stream indent: level [
+	stream nextPutAll: var; nextPut: $'.
+]
+
 { #category : #polymorphism }
 TAll >> strengthenTop: _r [
 	^self

--- a/src/SpriteLang/TBase.class.st
+++ b/src/SpriteLang/TBase.class.st
@@ -160,6 +160,11 @@ cf. Constraints.hs
 	^{ self rTypeSort . p subst: v with: x }
 ]
 
+{ #category : #printing }
+TBase >> spriteOn: stream indent: level [
+	b spriteOn: stream indent: level
+]
+
 { #category : #polymorphism }
 TBase >> strengthenTop: r_ [
 	^TBase b: b r: r, r_

--- a/src/SpriteLang/TBool.class.st
+++ b/src/SpriteLang/TBool.class.st
@@ -23,6 +23,11 @@ TBool >> printOn: aStream [
 	aStream nextPutAll: 'TBool'
 ]
 
+{ #category : #printing }
+TBool >> spriteOn: stream indent: anInteger [
+	stream nextPutAll: 'bool'
+]
+
 { #category : #'α-renaming' }
 TBool >> uniq2: α [
 	"Nothing to do"

--- a/src/SpriteLang/TBvSize.class.st
+++ b/src/SpriteLang/TBvSize.class.st
@@ -34,6 +34,11 @@ TBvSize >> rebind [
 	^self
 ]
 
+{ #category : #printing }
+TBvSize >> spriteOn: stream indent: level [
+	ftycon printOn: stream
+]
+
 { #category : #polymorphism }
 TBvSize >> tsubstGo: t tVar: a [
 	^self

--- a/src/SpriteLang/TCon.class.st
+++ b/src/SpriteLang/TCon.class.st
@@ -163,6 +163,17 @@ sortPred x t@(TCon  _ _ (Known v p)) = Just (rTypeSort t, subst p v x)
 	^{ self rTypeSort . p subst: v with: x }
 ]
 
+{ #category : #printing }
+TCon >> spriteOn: stream indent: level [
+	stream nextPutAll: c.	
+	ts notEmpty ifTrue:[
+		stream nextPut:$(.
+		ts do:[:t | t spriteOn: stream indent: level ] separatedBy:[ stream nextPutAll: ', '].
+		stream nextPut:$).
+	].
+	ars do:[:ar | ar spriteOn: stream indent: level].
+]
+
 { #category : #polymorphism }
 TCon >> strengthenTop: r_ [ 
 	^self copy

--- a/src/SpriteLang/TFun.class.st
+++ b/src/SpriteLang/TFun.class.st
@@ -182,6 +182,17 @@ TFun >> s: anObject [
 	s := anObject
 ]
 
+{ #category : #printing }
+TFun >> spriteOn: stream indent: level [
+	x = '_' ifFalse:[
+		stream nextPutAll: x.
+		stream nextPut: $:.
+	].
+	s spriteOn: stream indent: level.
+	stream nextPutAll: ' => '.
+	t spriteOn: stream indent: level.
+]
+
 { #category : #polymorphism }
 TFun >> strengthenTop: _r [
 	^self

--- a/src/SpriteLang/TInt.class.st
+++ b/src/SpriteLang/TInt.class.st
@@ -23,6 +23,11 @@ TInt >> printOn: aStream [
 	aStream nextPutAll: 'TInt'
 ]
 
+{ #category : #printing }
+TInt >> spriteOn: stream indent: level [
+	stream nextPutAll: 'int'
+]
+
 { #category : #'α-renaming' }
 TInt >> uniq2: α [
 	"Nothing to do"

--- a/src/SpriteLang/TRAll.class.st
+++ b/src/SpriteLang/TRAll.class.st
@@ -121,6 +121,16 @@ cf. Check.hs
 	^t subsAR: p ar: ar
 ]
 
+{ #category : #printing }
+TRAll >> spriteOn: stream indent: level [
+	"⟦val maxInt : ∀ (p : int => bool). x:int[v|p value: v] => y:int[v|p value: v] => int[v|p value: v]⟧"
+	
+	stream nextPutAll: '∀ ('.
+	r spriteOn: stream indent: level.
+	stream nextPutAll: '). '.
+	t spriteOn: stream indent: level.
+]
+
 { #category : #polymorphism }
 TRAll >> strengthenTop: xxx [
 	self shouldBeImplemented

--- a/src/SpriteLang/UnknownReft.class.st
+++ b/src/SpriteLang/UnknownReft.class.st
@@ -37,6 +37,11 @@ UnknownReft >> printOn: aStream [
 	aStream nextPut: Character starOperator
 ]
 
+{ #category : #printing }
+UnknownReft >> spriteOn: stream indent: level [
+	self shouldBeImplemented 
+]
+
 { #category : #SubsARef }
 UnknownReft >> subs: p ar: ar [
 "

--- a/src/SpriteLang/Val.class.st
+++ b/src/SpriteLang/Val.class.st
@@ -8,3 +8,12 @@ Class {
 Val class >> reflect: equationName type: t expr: e [
 	^t
 ]
+
+{ #category : #'as yet unclassified' }
+Val >> spriteOn: stream indent: level [
+	stream nextPutAll: '⟦val '.
+	stream nextPutAll: symbol.
+	stream nextPutAll: ' : '.
+	rtype spriteOn: stream indent: level.
+	stream nextPutAll: '⟧'.
+]

--- a/src/SpriteLang/ΛBase.class.st
+++ b/src/SpriteLang/ΛBase.class.st
@@ -39,6 +39,11 @@ RType where r=Reft, here Reft meaning ΛReft.
 	^Set new
 ]
 
+{ #category : #printing }
+ΛBase >> spriteOn: stream indent: level [
+	self subclassResponsibility
+]
+
 { #category : #'α-renaming' }
 ΛBase >> uniq2: α [
 	"α-rename all variables. Returns a copy of receiver with all names unique."

--- a/src/SpriteLang/ΛEApp.class.st
+++ b/src/SpriteLang/ΛEApp.class.st
@@ -113,6 +113,25 @@ embedApp :: SrcExpr -> F.Expr
 	self error
 ]
 
+{ #category : #printing }
+ΛEApp >> spriteOn: stream indent: level [
+	| args eapp func |
+
+	args := OrderedCollection new:3.
+	eapp := self.
+	[ eapp isKindOf: ΛEApp ] whileTrue:[
+		args addFirst: eapp imm.
+		eapp := eapp expr.
+	].
+	func := eapp.
+
+	func spriteOn: stream indent: level.
+	stream nextPut: $(.
+	args do:[:arg | arg spriteOn: stream indent: level ] separatedBy:[stream nextPutAll:', '].
+	stream nextPut: $).
+
+]
+
 { #category : #'as yet unclassified' }
 ΛEApp >> synth: Γ [
 "

--- a/src/SpriteLang/ΛExpression.class.st
+++ b/src/SpriteLang/ΛExpression.class.st
@@ -121,6 +121,15 @@ elaborate   :: Env -> SrcExpr -> ElbExpr
 ]
 
 { #category : #GT }
+ΛExpression >> gtInspectorSpriteIn: composite [
+	<gtInspectorPresentationOrder: 55>
+
+	^composite text
+		title: 'Source';
+		display: [ String streamContents: [ :s| self spriteOn: s ] ]
+]
+
+{ #category : #GT }
 ΛExpression >> gtInspectorTreeIn: composite [
 	<gtInspectorPresentationOrder: 50>
 
@@ -193,6 +202,17 @@ renameTy :: SrcExpr -> RType -> Metric -> (RType, Metric)
 "
 	^t->m
 
+]
+
+{ #category : #printing }
+ΛExpression >> spriteOn: aStream [
+	self spriteOn: aStream indent: 0.
+]
+
+{ #category : #printing }
+ΛExpression >> spriteOn: aStream indent: level [
+	"Print receiver on `aStream` as SpriteLang source"
+	self subclassResponsibility
 ]
 
 { #category : #polymorphism }

--- a/src/SpriteLang/ΛPrim.class.st
+++ b/src/SpriteLang/ΛPrim.class.st
@@ -29,6 +29,12 @@ Cf. Prims.hs
 	self printStructOn: aStream
 ]
 
+{ #category : #printing }
+ΛPrim >> spriteOn: aStream indent: level [
+	"Print receiver on `aStream` as SpriteLang source"
+	self subclassResponsibility
+]
+
 { #category : #substitution }
 ΛPrim >> subst: θ [
 	^self

--- a/src/SpriteLang/ΛPrimOp.class.st
+++ b/src/SpriteLang/ΛPrimOp.class.st
@@ -52,3 +52,8 @@ Cf. L₈ Reflect.hs
 ΛPrimOp >> rTypeSrc [
 	^self class rTypeSrc
 ]
+
+{ #category : #printing }
+ΛPrimOp >> spriteOn: stream indent: level [
+	stream space; nextPutAll: self class operator; space.
+]

--- a/src/SpriteLang/ΛReft.class.st
+++ b/src/SpriteLang/ΛReft.class.st
@@ -41,6 +41,11 @@ freshR :: F.SrcSpan -> Env -> F.Sort -> Reft -> CG Reft
 	^self
 ]
 
+{ #category : #printing }
+ΛReft >> spriteOn: stream indent: level [
+	self subclassResponsibility 
+]
+
 { #category : #SubARef }
 ΛReft >> subsAR: p ar: ar [
 	^self


### PR DESCRIPTION
This commit implement `#spriteOn:indent:` on various classes that print receiver as Sprite expression. I find it easier to read than going through expression tree. It also adds GT inspector tabs showing the "unparsed" source.

This is mainly a debugging aid, especially useful when debugging transformation from meta-language to core.

As of now, it only prints program's expression(s) and *not* qualifiers, measures and datatypes. This is left as future work as it is not that simple (mainly because extensive use of associations and transformations done right when parsing, not later in some "pass").