### PR TITLE
Check that ASTs belong to the same context

### DIFF
--- a/apigen.py
+++ b/apigen.py
@@ -661,7 +661,8 @@ class Generator:
             body = f"| {' '.join(temps)} |\n\n    " + str(body)
 
             return body
-
+        except AssertionError as ae:
+            raise ae
         except Exception as e:
             return f"^ self error: 'API not (yet) supported: {str(e)}'"
 

--- a/apigen.py
+++ b/apigen.py
@@ -547,17 +547,21 @@ class Generator:
             for arg in api.args:
                 if arg.type.is_z3_type() and not self.arg_passed_as_raw_pointer(api, arg):
                     if arg.type.is_z3ast_sub_type():
-                        body += f"{arg.name} ensureValidZ3ASTOfKind: {arg.type.name}_AST.\n"
+                        assert api.has_context_arg()
+                        body += f"{arg.name} ensureValidZ3ASTInContext: {api.context_arg_name()} ofKind: {arg.type.name}_AST.\n"
                     elif arg.type.is_z3ast_type():
-                        body += f"{arg.name} ensureValidZ3AST.\n"
+                        assert api.has_context_arg()
+                        body += f"{arg.name} ensureValidZ3ASTInContext: {api.context_arg_name()}.\n"
                     else:
                         body += f"{arg.name} ensureValidZ3Object.\n"
                 elif arg.type.is_array_type() and arg.flags != ArgumentType.OUT and api.cname not in ['Z3_mk_constructor']:
                     eltype = arg.type.element_type
                     if eltype.is_z3ast_sub_type():
-                        body += f"{arg.name} ensureValidZ3ASTArrayOfKind: {arg.type.name}_AST.\n"
+                        assert api.has_context_arg()
+                        body += f"{arg.name} ensureValidZ3ASTArrayInContext: {api.context_arg_name()} ofKind: {arg.type.name}_AST.\n"
                     elif eltype.is_z3ast_type():
-                        body += f"{arg.name} ensureValidZ3ASTArray.\n"
+                        assert api.has_context_arg()
+                        body += f"{arg.name} ensureValidZ3ASTArrayInContext: {api.context_arg_name()}.\n"
                     elif eltype.is_z3_type():
                         body += f"{arg.name} ensureValidZ3ObjectArray.\n"
 

--- a/src/Z3-FFI-Pharo/Z3Object.class.st
+++ b/src/Z3-FFI-Pharo/Z3Object.class.st
@@ -77,11 +77,12 @@ Z3Object >> delete [
 ]
 
 { #category : #utilities }
-Z3Object >> ensureValidZ3AST [
-	"This method is no-op if the object appears to be valid
-	 (based on the pointer value) and if it's an AST (based
-	 on receiver's class)."
+Z3Object >> ensureValidZ3ASTInContext: context [
+	self error:'Invalid Z3 AST (not an Z3AST instance)!'
+]
 
+{ #category : #utilities }
+Z3Object >> ensureValidZ3ASTOfInContext: context ofKind: kind [
 	self error:'Invalid Z3 AST (not an Z3AST instance)!'
 ]
 

--- a/src/Z3-FFI-SmalltalkX/Z3Object.class.st
+++ b/src/Z3-FFI-SmalltalkX/Z3Object.class.st
@@ -99,20 +99,12 @@ Z3Object >> delete [
 ]
 
 { #category : #utilities }
-Z3Object >> ensureValidZ3AST [
-	"This method is no-op if the object appears to be valid
-	 (based on the pointer value) and if it's an AST (based
-	 on receiver's class)."
-
+Z3Object >> ensureValidZ3ASTInContext: context [ 
 	self error:'Invalid Z3 AST (not an Z3AST instance)!'
 ]
 
 { #category : #utilities }
-Z3Object >> ensureValidZ3ASTOfKind: kind [
-	"This method is no-op if the object appears to be valid
-	 (based on the pointer value) and if it's an AST of given
-	 kind (based on receiver's kind)."
-
+Z3Object >> ensureValidZ3ASTInContext:kind ofKind:anObject [ 
 	self error:'Invalid Z3 AST (not an Z3AST instance)!'
 ]
 

--- a/src/Z3/Object.extension.st
+++ b/src/Z3/Object.extension.st
@@ -21,36 +21,38 @@ Object >> adaptToReal: receiver andSend: selector [
 ]
 
 { #category : #'*Z3' }
-Object >> ensureValidZ3AST [
+Object >> ensureValidZ3ASTArrayInContext: context [ 
 	"This method is no-op if the object appears to be valid
-	 (based on the pointer value) and if it's an AST (based
-	 on receiver's class)."
+	 array of valid Z3 ASTs in given Z3 context. 
+	 Throws an error otherwise."
+	
+	self error:'Invalid Z3 AST array (not an array)!'
+]
 
+{ #category : #'*Z3' }
+Object >> ensureValidZ3ASTArrayInContext:kind ofKind:anObject [ 
+	"This method is no-op if the object appears to be valid
+	 array of valid Z3 ASTs of given kind in given Z3 context.
+	 Throws an error otherwise."
+	
+	self error:'Invalid Z3 AST array (not an array)!'
+]
+
+{ #category : #'*Z3' }
+Object >> ensureValidZ3ASTInContext: context [ 
+	"This method is no-op if the object appears to be valid
+	 (based on the pointer value) and it's an AST (based
+	 on receiver's class) and belongs to given Z3 context."
+	
 	self error:'Invalid Z3 AST (not an Z3AST instance)!'
 ]
 
 { #category : #'*Z3' }
-Object >> ensureValidZ3ASTArray [
-	"This method is no-op if the object appears to be valid
-	 array of valid Z3 ASTs. Throws an error otherwise."
-
-	self error:'Invalid Z3 AST array (not an array)!'
-]
-
-{ #category : #'*Z3' }
-Object >> ensureValidZ3ASTArrayOfKind: kind [
-	"This method is no-op if the object appears to be valid
-	 array of valid Z3 ASTs of given kind. Throws an error otherwise."
-
-	self error:'Invalid Z3 AST array (not an array)!'
-]
-
-{ #category : #'*Z3' }
-Object >> ensureValidZ3ASTOfKind: kind [
+Object >> ensureValidZ3ASTInContext:kind ofKind:anObject [ 
 	"This method is no-op if the object appears to be valid
 	 (based on the pointer value) and if it's an AST of given
 	 kind (based on receiver's kind)."
-
+	
 	self error:'Invalid Z3 AST (not an Z3AST instance)!'
 ]
 

--- a/src/Z3/SequenceableCollection.extension.st
+++ b/src/Z3/SequenceableCollection.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #SequenceableCollection }
 
 { #category : #'*Z3' }
-SequenceableCollection >> ensureValidZ3ASTArray [
-	self do:[:each | each ensureValidZ3AST ]
+SequenceableCollection >> ensureValidZ3ASTArrayInContext: context [ 
+	self do:[:each | each ensureValidZ3ASTInContext: context ]
 ]
 
 { #category : #'*Z3' }
-SequenceableCollection >> ensureValidZ3ASTArrayOfKind: kind [
-	self do:[:each | each ensureValidZ3ASTOfKind: kind ]
+SequenceableCollection >> ensureValidZ3ASTArrayInContext: context ofKind: kind [
+	self do:[:each | each ensureValidZ3ASTInContext: context ofKind: kind ]
 ]
 
 { #category : #'*Z3' }

--- a/src/Z3/Z3.class.st
+++ b/src/Z3/Z3.class.st
@@ -24,8 +24,8 @@ Z3 class >> add_const_interp: c _: m _: f _: a [
 
 	c ensureValidZ3Object.
 	m ensureValidZ3Object.
-	f ensureValidZ3ASTOfKind: FUNC_DECL_AST.
-	a ensureValidZ3AST.
+	f ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _add_const_interp: c _: m _: f _: a.
 	c errorCheck.
 	^ retval
@@ -65,7 +65,7 @@ Z3 class >> add_rec_def: c _: f _: n _: args _: body [
 	   \param args constants that are used as arguments to the recursive function in the definition.
 	   \param body body of the recursive function
 
-	   After declaring a recursive function or a collection of mutually recursive functions, use
+	   After declaring a recursive function or a collection of mutually recursive functions, use 
 	   this function to provide the definition for the recursive function.
 
 	   \sa Z3_mk_rec_func_decl
@@ -78,9 +78,9 @@ Z3 class >> add_rec_def: c _: f _: n _: args _: body [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	f ensureValidZ3ASTOfKind: FUNC_DECL_AST.
-	args ensureValidZ3ASTArray.
-	body ensureValidZ3AST.
+	f ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
+	args ensureValidZ3ASTArrayInContext: c.
+	body ensureValidZ3ASTInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _add_rec_def: c _: f _: n _: argsExt _: body.
 	[
@@ -110,8 +110,8 @@ Z3 class >> algebraic_add: c _: a _: b [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	b ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	b ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_add: c _: a _: b.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -137,8 +137,8 @@ Z3 class >> algebraic_div: c _: a _: b [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	b ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	b ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_div: c _: a _: b.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -162,8 +162,8 @@ Z3 class >> algebraic_eq: c _: a _: b [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	b ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	b ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_eq: c _: a _: b.
 	c errorCheck.
 	^ retval
@@ -188,8 +188,8 @@ Z3 class >> algebraic_eval: c _: p _: n _: a [
 	| retval aExt |
 
 	c ensureValidZ3Object.
-	p ensureValidZ3AST.
-	a ensureValidZ3ASTArray.
+	p ensureValidZ3ASTInContext: c.
+	a ensureValidZ3ASTArrayInContext: c.
 	aExt := self externalArrayFrom: a.
 	retval := lib _algebraic_eval: c _: p _: n _: aExt.
 	[
@@ -218,8 +218,8 @@ Z3 class >> algebraic_ge: c _: a _: b [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	b ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	b ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_ge: c _: a _: b.
 	c errorCheck.
 	^ retval
@@ -242,7 +242,7 @@ Z3 class >> algebraic_get_i: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_get_i: c _: a.
 	c errorCheck.
 	^ retval
@@ -265,7 +265,7 @@ Z3 class >> algebraic_get_poly: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_get_poly: c _: a.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -289,8 +289,8 @@ Z3 class >> algebraic_gt: c _: a _: b [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	b ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	b ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_gt: c _: a _: b.
 	c errorCheck.
 	^ retval
@@ -313,7 +313,7 @@ Z3 class >> algebraic_is_neg: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_is_neg: c _: a.
 	c errorCheck.
 	^ retval
@@ -336,7 +336,7 @@ Z3 class >> algebraic_is_pos: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_is_pos: c _: a.
 	c errorCheck.
 	^ retval
@@ -358,7 +358,7 @@ Z3 class >> algebraic_is_value: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_is_value: c _: a.
 	c errorCheck.
 	^ retval
@@ -381,7 +381,7 @@ Z3 class >> algebraic_is_zero: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_is_zero: c _: a.
 	c errorCheck.
 	^ retval
@@ -405,8 +405,8 @@ Z3 class >> algebraic_le: c _: a _: b [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	b ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	b ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_le: c _: a _: b.
 	c errorCheck.
 	^ retval
@@ -430,8 +430,8 @@ Z3 class >> algebraic_lt: c _: a _: b [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	b ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	b ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_lt: c _: a _: b.
 	c errorCheck.
 	^ retval
@@ -456,8 +456,8 @@ Z3 class >> algebraic_mul: c _: a _: b [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	b ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	b ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_mul: c _: a _: b.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -481,8 +481,8 @@ Z3 class >> algebraic_neq: c _: a _: b [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	b ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	b ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_neq: c _: a _: b.
 	c errorCheck.
 	^ retval
@@ -506,7 +506,7 @@ Z3 class >> algebraic_power: c _: a _: k [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_power: c _: a _: k.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -531,7 +531,7 @@ Z3 class >> algebraic_root: c _: a _: k [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_root: c _: a _: k.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -557,8 +557,8 @@ Z3 class >> algebraic_roots: c _: p _: n _: a [
 	| retval aExt |
 
 	c ensureValidZ3Object.
-	p ensureValidZ3AST.
-	a ensureValidZ3ASTArray.
+	p ensureValidZ3ASTInContext: c.
+	a ensureValidZ3ASTArrayInContext: c.
 	aExt := self externalArrayFrom: a.
 	retval := lib _algebraic_roots: c _: p _: n _: aExt.
 	[
@@ -586,7 +586,7 @@ Z3 class >> algebraic_sign: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_sign: c _: a.
 	c errorCheck.
 	^ retval
@@ -611,8 +611,8 @@ Z3 class >> algebraic_sub: c _: a _: b [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	b ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	b ensureValidZ3ASTInContext: c.
 	retval := lib _algebraic_sub: c _: a _: b.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -633,7 +633,7 @@ Z3 class >> app_to_ast: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _app_to_ast: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -894,7 +894,7 @@ Z3 class >> ast_to_string: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _ast_to_string: c _: a.
 	c errorCheck.
 	^ retval
@@ -981,7 +981,7 @@ Z3 class >> ast_vector_push: c _: v _: a [
 
 	c ensureValidZ3Object.
 	v ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _ast_vector_push: c _: v _: a.
 	c errorCheck.
 	^ retval
@@ -1026,7 +1026,7 @@ Z3 class >> ast_vector_set: c _: v _: i _: a [
 
 	c ensureValidZ3Object.
 	v ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _ast_vector_set: c _: v _: i _: a.
 	c errorCheck.
 	^ retval
@@ -1124,8 +1124,8 @@ Z3 class >> benchmark_to_smtlib_string: c _: name _: logic _: status _: attribut
 	| retval assumptionsExt |
 
 	c ensureValidZ3Object.
-	assumptions ensureValidZ3ASTArray.
-	formula ensureValidZ3AST.
+	assumptions ensureValidZ3ASTArrayInContext: c.
+	formula ensureValidZ3ASTInContext: c.
 	assumptionsExt := self externalArrayFrom: assumptions.
 	retval := lib _benchmark_to_smtlib_string: c _: name _: logic _: status _: attributes _: num_assumptions _: assumptionsExt _: formula.
 	[
@@ -1147,7 +1147,7 @@ Z3 class >> constructor_num_fields: c _: constr [
 	   \param constr constructor.
 
 	   def_API('Z3_constructor_num_fields', UINT, (_in(CONTEXT), _in(CONSTRUCTOR)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -1189,9 +1189,9 @@ Z3 class >> datatype_update_field: c _: field_access _: t _: value [
 	| retval |
 
 	c ensureValidZ3Object.
-	field_access ensureValidZ3ASTOfKind: FUNC_DECL_AST.
-	t ensureValidZ3AST.
-	value ensureValidZ3AST.
+	field_access ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
+	t ensureValidZ3ASTInContext: c.
+	value ensureValidZ3ASTInContext: c.
 	retval := lib _datatype_update_field: c _: field_access _: t _: value.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -1214,7 +1214,7 @@ Z3 class >> dec_ref: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _dec_ref: c _: a.
 	c errorCheck.
 	^ retval
@@ -1342,12 +1342,12 @@ Z3 class >> disable_trace: tag [
 { #category : #API }
 Z3 class >> enable_concurrent_dec_ref: c [
 	"
-	   \brief use concurrency control for dec-ref.
-	   Reference counting decrements are allowed in separate threads from the context.
+	   \brief use concurrency control for dec-ref. 
+	   Reference counting decrements are allowed in separate threads from the context. 
 	   If this setting is not invoked, reference counting decrements are not going to be thread safe.
 
 	   def_API('Z3_enable_concurrent_dec_ref', VOID, (_in(CONTEXT),))
-
+	 
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -1453,8 +1453,8 @@ Z3 class >> fixedpoint_add_cover: c _: d _: level _: pred _: property [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	pred ensureValidZ3ASTOfKind: FUNC_DECL_AST.
-	property ensureValidZ3AST.
+	pred ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
+	property ensureValidZ3ASTInContext: c.
 	retval := lib _fixedpoint_add_cover: c _: d _: level _: pred _: property.
 	c errorCheck.
 	^ retval
@@ -1488,7 +1488,7 @@ Z3 class >> fixedpoint_add_fact: c _: d _: r _: num_args _: args [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	r ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	r ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	argsExt := Z3Object externalU32ArrayFrom: args.
 	retval := lib _fixedpoint_add_fact: c _: d _: r _: num_args _: argsExt.
 	[
@@ -1518,8 +1518,8 @@ Z3 class >> fixedpoint_add_invariant: c _: d _: pred _: property [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	pred ensureValidZ3ASTOfKind: FUNC_DECL_AST.
-	property ensureValidZ3AST.
+	pred ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
+	property ensureValidZ3ASTInContext: c.
 	retval := lib _fixedpoint_add_invariant: c _: d _: pred _: property.
 	c errorCheck.
 	^ retval
@@ -1548,7 +1548,7 @@ Z3 class >> fixedpoint_add_rule: c _: d _: rule _: name [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	rule ensureValidZ3AST.
+	rule ensureValidZ3ASTInContext: c.
 	name ensureValidZ3Object.
 	retval := lib _fixedpoint_add_rule: c _: d _: rule _: name.
 	c errorCheck.
@@ -1574,7 +1574,7 @@ Z3 class >> fixedpoint_assert: c _: d _: axiom [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	axiom ensureValidZ3AST.
+	axiom ensureValidZ3ASTInContext: c.
 	retval := lib _fixedpoint_assert: c _: d _: axiom.
 	c errorCheck.
 	^ retval
@@ -1732,7 +1732,7 @@ Z3 class >> fixedpoint_get_cover_delta: c _: d _: level _: pred [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	pred ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	pred ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _fixedpoint_get_cover_delta: c _: d _: level _: pred.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -1805,7 +1805,7 @@ Z3 class >> fixedpoint_get_num_levels: c _: d _: pred [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	pred ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	pred ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _fixedpoint_get_num_levels: c _: d _: pred.
 	c errorCheck.
 	^ retval
@@ -1852,7 +1852,7 @@ Z3 class >> fixedpoint_get_reachable: c _: d _: pred [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	pred ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	pred ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _fixedpoint_get_reachable: c _: d _: pred.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2006,7 +2006,7 @@ Z3 class >> fixedpoint_query: c _: d _: query [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	query ensureValidZ3AST.
+	query ensureValidZ3ASTInContext: c.
 	retval := lib _fixedpoint_query: c _: d _: query.
 	c errorCheck.
 	^ retval
@@ -2038,7 +2038,7 @@ Z3 class >> fixedpoint_query_from_lvl: c _: d _: query _: lvl [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	query ensureValidZ3AST.
+	query ensureValidZ3ASTInContext: c.
 	retval := lib _fixedpoint_query_from_lvl: c _: d _: query _: lvl.
 	c errorCheck.
 	^ retval
@@ -2067,7 +2067,7 @@ Z3 class >> fixedpoint_query_relations: c _: d _: num_relations _: relations [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	relations ensureValidZ3ASTArrayOfKind: FUNC_DECL_AST.
+	relations ensureValidZ3ASTArrayInContext: c ofKind: FUNC_DECL_AST.
 	relationsExt := self externalArrayFrom: relations.
 	retval := lib _fixedpoint_query_relations: c _: d _: num_relations _: relationsExt.
 	[
@@ -2097,7 +2097,7 @@ Z3 class >> fixedpoint_register_relation: c _: d _: f [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	f ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	f ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _fixedpoint_register_relation: c _: d _: f.
 	c errorCheck.
 	^ retval
@@ -2148,7 +2148,7 @@ Z3 class >> fixedpoint_set_predicate_representation: c _: d _: f _: num_relation
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	f ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	f ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	relation_kinds ensureValidZ3ObjectArray.
 	relation_kindsExt := self externalArrayFrom: relation_kinds.
 	retval := lib _fixedpoint_set_predicate_representation: c _: d _: f _: num_relations _: relation_kindsExt.
@@ -2183,7 +2183,7 @@ Z3 class >> fixedpoint_to_string: c _: f _: num_queries _: queries [
 
 	c ensureValidZ3Object.
 	f ensureValidZ3Object.
-	queries ensureValidZ3ASTArray.
+	queries ensureValidZ3ASTArrayInContext: c.
 	queriesExt := self externalArrayFrom: queries.
 	retval := lib _fixedpoint_to_string: c _: f _: num_queries _: queriesExt.
 	[
@@ -2211,7 +2211,7 @@ Z3 class >> fixedpoint_update_rule: c _: d _: a _: name [
 
 	c ensureValidZ3Object.
 	d ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	name ensureValidZ3Object.
 	retval := lib _fixedpoint_update_rule: c _: d _: a _: name.
 	c errorCheck.
@@ -2238,7 +2238,7 @@ Z3 class >> fpa_get_ebits: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _fpa_get_ebits: c _: s.
 	c errorCheck.
 	^ retval
@@ -2266,7 +2266,7 @@ Z3 class >> fpa_get_numeral_exponent_bv: c _: t _: biased [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _fpa_get_numeral_exponent_bv: c _: t _: biased.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2319,7 +2319,7 @@ Z3 class >> fpa_get_numeral_exponent_string: c _: t _: biased [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _fpa_get_numeral_exponent_string: c _: t _: biased.
 	c errorCheck.
 	^ retval
@@ -2368,7 +2368,7 @@ Z3 class >> fpa_get_numeral_sign_bv: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _fpa_get_numeral_sign_bv: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2394,7 +2394,7 @@ Z3 class >> fpa_get_numeral_significand_bv: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _fpa_get_numeral_significand_bv: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2422,7 +2422,7 @@ Z3 class >> fpa_get_numeral_significand_string: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _fpa_get_numeral_significand_string: c _: t.
 	c errorCheck.
 	^ retval
@@ -2471,7 +2471,7 @@ Z3 class >> fpa_get_sbits: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _fpa_get_sbits: c _: s.
 	c errorCheck.
 	^ retval
@@ -2500,7 +2500,7 @@ Z3 class >> fpa_is_numeral_inf: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _fpa_is_numeral_inf: c _: t.
 	c errorCheck.
 	^ retval
@@ -2529,7 +2529,7 @@ Z3 class >> fpa_is_numeral_nan: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _fpa_is_numeral_nan: c _: t.
 	c errorCheck.
 	^ retval
@@ -2555,7 +2555,7 @@ Z3 class >> fpa_is_numeral_negative: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _fpa_is_numeral_negative: c _: t.
 	c errorCheck.
 	^ retval
@@ -2584,7 +2584,7 @@ Z3 class >> fpa_is_numeral_normal: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _fpa_is_numeral_normal: c _: t.
 	c errorCheck.
 	^ retval
@@ -2610,7 +2610,7 @@ Z3 class >> fpa_is_numeral_positive: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _fpa_is_numeral_positive: c _: t.
 	c errorCheck.
 	^ retval
@@ -2639,7 +2639,7 @@ Z3 class >> fpa_is_numeral_subnormal: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _fpa_is_numeral_subnormal: c _: t.
 	c errorCheck.
 	^ retval
@@ -2668,7 +2668,7 @@ Z3 class >> fpa_is_numeral_zero: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _fpa_is_numeral_zero: c _: t.
 	c errorCheck.
 	^ retval
@@ -2689,7 +2689,7 @@ Z3 class >> func_decl_to_ast: c _: f [
 	| retval |
 
 	c ensureValidZ3Object.
-	f ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	f ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _func_decl_to_ast: c _: f.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -2708,7 +2708,7 @@ Z3 class >> func_decl_to_string: c _: d [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _func_decl_to_string: c _: d.
 	c errorCheck.
 	^ retval
@@ -2983,7 +2983,7 @@ Z3 class >> get_algebraic_number_lower: c _: a _: precision [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_algebraic_number_lower: c _: a _: precision.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3008,7 +3008,7 @@ Z3 class >> get_algebraic_number_upper: c _: a _: precision [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_algebraic_number_upper: c _: a _: precision.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3033,7 +3033,7 @@ Z3 class >> get_app_arg: c _: a _: i [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_app_arg: c _: a _: i.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3054,7 +3054,7 @@ Z3 class >> get_app_decl: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_app_decl: c _: a.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -3078,7 +3078,7 @@ Z3 class >> get_app_num_args: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_app_num_args: c _: a.
 	c errorCheck.
 	^ retval
@@ -3101,7 +3101,7 @@ Z3 class >> get_arity: c _: d [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_arity: c _: d.
 	c errorCheck.
 	^ retval
@@ -3129,7 +3129,7 @@ Z3 class >> get_array_sort_domain: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3ASTOfKind: SORT_AST.
+	t ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_array_sort_domain: c _: t.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -3157,7 +3157,7 @@ Z3 class >> get_array_sort_domain_n: c _: t _: idx [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3ASTOfKind: SORT_AST.
+	t ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_array_sort_domain_n: c _: t _: idx.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -3183,7 +3183,7 @@ Z3 class >> get_array_sort_range: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3ASTOfKind: SORT_AST.
+	t ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_array_sort_range: c _: t.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -3206,7 +3206,7 @@ Z3 class >> get_as_array_func_decl: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_as_array_func_decl: c _: a.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -3219,7 +3219,7 @@ Z3 class >> get_ast_hash: c _: a [
 	"
 	   \brief Return a hash code for the given AST.
 	   The hash code is structural but two different AST objects can map to the same hash.
-	   The result of \c Z3_get_ast_id returns an identifier that is unique over the
+	   The result of \c Z3_get_ast_id returns an identifier that is unique over the 
 	   set of live AST objects.
 
 	   def_API('Z3_get_ast_hash', UINT, (_in(CONTEXT), _in(AST)))
@@ -3230,7 +3230,7 @@ Z3 class >> get_ast_hash: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_ast_hash: c _: a.
 	c errorCheck.
 	^ retval
@@ -3257,7 +3257,7 @@ Z3 class >> get_ast_id: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _get_ast_id: c _: t.
 	c errorCheck.
 	^ retval
@@ -3298,7 +3298,7 @@ Z3 class >> get_bool_value: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_bool_value: c _: a.
 	c errorCheck.
 	^ retval
@@ -3324,7 +3324,7 @@ Z3 class >> get_bv_sort_size: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3ASTOfKind: SORT_AST.
+	t ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_bv_sort_size: c _: t.
 	c errorCheck.
 	^ retval
@@ -3352,7 +3352,7 @@ Z3 class >> get_datatype_sort_constructor: c _: t _: idx [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3ASTOfKind: SORT_AST.
+	t ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_datatype_sort_constructor: c _: t _: idx.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -3381,7 +3381,7 @@ Z3 class >> get_datatype_sort_constructor_accessor: c _: t _: idx_c _: idx_a [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3ASTOfKind: SORT_AST.
+	t ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_datatype_sort_constructor_accessor: c _: t _: idx_c _: idx_a.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -3408,7 +3408,7 @@ Z3 class >> get_datatype_sort_num_constructors: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3ASTOfKind: SORT_AST.
+	t ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_datatype_sort_num_constructors: c _: t.
 	c errorCheck.
 	^ retval
@@ -3436,7 +3436,7 @@ Z3 class >> get_datatype_sort_recognizer: c _: t _: idx [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3ASTOfKind: SORT_AST.
+	t ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_datatype_sort_recognizer: c _: t _: idx.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -3459,7 +3459,7 @@ Z3 class >> get_decl_ast_parameter: c _: d _: idx [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_decl_ast_parameter: c _: d _: idx.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3482,7 +3482,7 @@ Z3 class >> get_decl_double_parameter: c _: d _: idx [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_decl_double_parameter: c _: d _: idx.
 	c errorCheck.
 	^ retval
@@ -3505,7 +3505,7 @@ Z3 class >> get_decl_func_decl_parameter: c _: d _: idx [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_decl_func_decl_parameter: c _: d _: idx.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -3528,7 +3528,7 @@ Z3 class >> get_decl_int_parameter: c _: d _: idx [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_decl_int_parameter: c _: d _: idx.
 	c errorCheck.
 	^ retval
@@ -3549,7 +3549,7 @@ Z3 class >> get_decl_kind: c _: d [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_decl_kind: c _: d.
 	c errorCheck.
 	^ retval
@@ -3570,7 +3570,7 @@ Z3 class >> get_decl_name: c _: d [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_decl_name: c _: d.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -3591,7 +3591,7 @@ Z3 class >> get_decl_num_parameters: c _: d [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_decl_num_parameters: c _: d.
 	c errorCheck.
 	^ retval
@@ -3616,7 +3616,7 @@ Z3 class >> get_decl_parameter_kind: c _: d _: idx [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_decl_parameter_kind: c _: d _: idx.
 	c errorCheck.
 	^ retval
@@ -3639,7 +3639,7 @@ Z3 class >> get_decl_rational_parameter: c _: d _: idx [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_decl_rational_parameter: c _: d _: idx.
 	c errorCheck.
 	^ retval
@@ -3662,7 +3662,7 @@ Z3 class >> get_decl_sort_parameter: c _: d _: idx [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_decl_sort_parameter: c _: d _: idx.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -3685,7 +3685,7 @@ Z3 class >> get_decl_symbol_parameter: c _: d _: idx [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_decl_symbol_parameter: c _: d _: idx.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -3708,7 +3708,7 @@ Z3 class >> get_denominator: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_denominator: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -3733,7 +3733,7 @@ Z3 class >> get_domain: c _: d _: i [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_domain: c _: d _: i.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -3756,7 +3756,7 @@ Z3 class >> get_domain_size: c _: d [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_domain_size: c _: d.
 	c errorCheck.
 	^ retval
@@ -3874,7 +3874,7 @@ Z3 class >> get_func_decl_id: c _: f [
 	| retval |
 
 	c ensureValidZ3Object.
-	f ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	f ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_func_decl_id: c _: f.
 	c errorCheck.
 	^ retval
@@ -3888,7 +3888,7 @@ Z3 class >> get_global_param_descrs: c [
 	   \brief Retrieve description of global parameters.
 
 	   def_API('Z3_get_global_param_descrs', PARAM_DESCRS, (_in(CONTEXT),))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -3929,7 +3929,7 @@ Z3 class >> get_implied_equalities: c _: s _: num_terms _: terms _: class_ids [
 
 	c ensureValidZ3Object.
 	s ensureValidZ3Object.
-	terms ensureValidZ3ASTArray.
+	terms ensureValidZ3ASTArrayInContext: c.
 	termsExt := self externalArrayFrom: terms.
 	class_idsExt := Z3Object externalU32ArrayFrom: class_ids.
 	retval := lib _get_implied_equalities: c _: s _: num_terms _: termsExt _: class_idsExt.
@@ -3965,7 +3965,7 @@ Z3 class >> get_index_value: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_index_value: c _: a.
 	c errorCheck.
 	^ retval
@@ -3990,7 +3990,7 @@ Z3 class >> get_lstring: c _: s _: length [
 	| retval lengthExt |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
 	lengthExt := Z3Object externalU32ArrayFrom: length.
 	retval := lib _get_lstring: c _: s _: lengthExt.
 	[
@@ -4039,7 +4039,7 @@ Z3 class >> get_num_simplifiers: c [
 	   \sa Z3_get_simplifier_name
 
 	   def_API('Z3_get_num_simplifiers', UINT, (_in(CONTEXT),))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -4091,7 +4091,7 @@ Z3 class >> get_numeral_binary_string: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_numeral_binary_string: c _: a.
 	c errorCheck.
 	^ retval
@@ -4115,7 +4115,7 @@ Z3 class >> get_numeral_decimal_string: c _: a _: precision [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_numeral_decimal_string: c _: a _: precision.
 	c errorCheck.
 	^ retval
@@ -4138,7 +4138,7 @@ Z3 class >> get_numeral_double: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_numeral_double: c _: a.
 	c errorCheck.
 	^ retval
@@ -4245,7 +4245,7 @@ Z3 class >> get_numeral_string: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_numeral_string: c _: a.
 	c errorCheck.
 	^ retval
@@ -4291,7 +4291,7 @@ Z3 class >> get_numeral_uint: c _: v _: u [
 	| retval uExt |
 
 	c ensureValidZ3Object.
-	v ensureValidZ3AST.
+	v ensureValidZ3ASTInContext: c.
 	uExt := Z3Object externalU32ArrayFrom: u.
 	retval := lib _get_numeral_uint: c _: v _: uExt.
 	[
@@ -4325,7 +4325,7 @@ Z3 class >> get_numerator: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_numerator: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -4414,7 +4414,7 @@ Z3 class >> get_quantifier_body: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_quantifier_body: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -4437,7 +4437,7 @@ Z3 class >> get_quantifier_bound_name: c _: a _: i [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_quantifier_bound_name: c _: a _: i.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -4460,7 +4460,7 @@ Z3 class >> get_quantifier_bound_sort: c _: a _: i [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_quantifier_bound_sort: c _: a _: i.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -4476,14 +4476,14 @@ Z3 class >> get_quantifier_id: c _: a [
 	   \pre Z3_get_ast_kind(a) == Z3_QUANTIFIER_AST
 
 	   def_API('Z3_get_quantifier_id', SYMBOL, (_in(CONTEXT), _in(AST)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_quantifier_id: c _: a.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -4506,7 +4506,7 @@ Z3 class >> get_quantifier_no_pattern_ast: c _: a _: i [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_quantifier_no_pattern_ast: c _: a _: i.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -4529,7 +4529,7 @@ Z3 class >> get_quantifier_num_bound: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_quantifier_num_bound: c _: a.
 	c errorCheck.
 	^ retval
@@ -4552,7 +4552,7 @@ Z3 class >> get_quantifier_num_no_patterns: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_quantifier_num_no_patterns: c _: a.
 	c errorCheck.
 	^ retval
@@ -4575,7 +4575,7 @@ Z3 class >> get_quantifier_num_patterns: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_quantifier_num_patterns: c _: a.
 	c errorCheck.
 	^ retval
@@ -4598,7 +4598,7 @@ Z3 class >> get_quantifier_pattern_ast: c _: a _: i [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_quantifier_pattern_ast: c _: a _: i.
 	c errorCheck.
 	^ Z3Pattern fromExternalAddress: retval inContext: c.
@@ -4614,14 +4614,14 @@ Z3 class >> get_quantifier_skolem_id: c _: a [
 	   \pre Z3_get_ast_kind(a) == Z3_QUANTIFIER_AST
 
 	   def_API('Z3_get_quantifier_skolem_id', SYMBOL, (_in(CONTEXT), _in(AST)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_quantifier_skolem_id: c _: a.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -4644,7 +4644,7 @@ Z3 class >> get_quantifier_weight: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _get_quantifier_weight: c _: a.
 	c errorCheck.
 	^ retval
@@ -4668,7 +4668,7 @@ Z3 class >> get_range: c _: d [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _get_range: c _: d.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -4689,7 +4689,7 @@ Z3 class >> get_re_sort_basis: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_re_sort_basis: c _: s.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -4714,7 +4714,7 @@ Z3 class >> get_relation_arity: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_relation_arity: c _: s.
 	c errorCheck.
 	^ retval
@@ -4740,7 +4740,7 @@ Z3 class >> get_relation_column: c _: s _: col [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_relation_column: c _: s _: col.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -4761,7 +4761,7 @@ Z3 class >> get_seq_sort_basis: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_seq_sort_basis: c _: s.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -4779,7 +4779,7 @@ Z3 class >> get_simplifier_name: c _: i [
 	   \sa Z3_get_num_simplifiers
 
 	   def_API('Z3_get_simplifier_name', STRING, (_in(CONTEXT), _in(UINT)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -4828,7 +4828,7 @@ Z3 class >> get_sort_id: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_sort_id: c _: s.
 	c errorCheck.
 	^ retval
@@ -4871,7 +4871,7 @@ Z3 class >> get_sort_name: c _: d [
 	| retval |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: SORT_AST.
+	d ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_sort_name: c _: d.
 	c errorCheck.
 	^ Z3Symbol fromExternalAddress: retval inContext: c.
@@ -4895,7 +4895,7 @@ Z3 class >> get_string: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
 	retval := lib _get_string: c _: s.
 	c errorCheck.
 	^ retval
@@ -4920,7 +4920,7 @@ Z3 class >> get_string_contents: c _: s _: length _: contents [
 	| retval contentsExt |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
 	contentsExt := Z3Object externalU32ArrayFrom: contents.
 	retval := lib _get_string_contents: c _: s _: length _: contentsExt.
 	[
@@ -4954,7 +4954,7 @@ Z3 class >> get_string_length: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
 	retval := lib _get_string_length: c _: s.
 	c errorCheck.
 	^ retval
@@ -5083,7 +5083,7 @@ Z3 class >> get_tuple_sort_field_decl: c _: t _: i [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3ASTOfKind: SORT_AST.
+	t ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_tuple_sort_field_decl: c _: t _: i.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -5110,7 +5110,7 @@ Z3 class >> get_tuple_sort_mk_decl: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3ASTOfKind: SORT_AST.
+	t ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_tuple_sort_mk_decl: c _: t.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -5136,7 +5136,7 @@ Z3 class >> get_tuple_sort_num_fields: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3ASTOfKind: SORT_AST.
+	t ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _get_tuple_sort_num_fields: c _: t.
 	c errorCheck.
 	^ retval
@@ -5551,7 +5551,7 @@ Z3 class >> inc_ref: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _inc_ref: c _: a.
 	c errorCheck.
 	^ retval
@@ -5614,7 +5614,7 @@ Z3 class >> is_algebraic_number: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _is_algebraic_number: c _: a.
 	c errorCheck.
 	^ retval
@@ -5633,7 +5633,7 @@ Z3 class >> is_app: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _is_app: c _: a.
 	c errorCheck.
 	^ retval
@@ -5660,7 +5660,7 @@ Z3 class >> is_as_array: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _is_as_array: c _: a.
 	c errorCheck.
 	^ retval
@@ -5681,7 +5681,7 @@ Z3 class >> is_char_sort: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _is_char_sort: c _: s.
 	c errorCheck.
 	^ retval
@@ -5702,8 +5702,8 @@ Z3 class >> is_eq_ast: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _is_eq_ast: c _: t1 _: t2.
 	c errorCheck.
 	^ retval
@@ -5724,8 +5724,8 @@ Z3 class >> is_eq_func_decl: c _: f1 _: f2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	f1 ensureValidZ3ASTOfKind: FUNC_DECL_AST.
-	f2 ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	f1 ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
+	f2 ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _is_eq_func_decl: c _: f1 _: f2.
 	c errorCheck.
 	^ retval
@@ -5746,8 +5746,8 @@ Z3 class >> is_eq_sort: c _: s1 _: s2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	s1 ensureValidZ3ASTOfKind: SORT_AST.
-	s2 ensureValidZ3ASTOfKind: SORT_AST.
+	s1 ensureValidZ3ASTInContext: c ofKind: SORT_AST.
+	s2 ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _is_eq_sort: c _: s1 _: s2.
 	c errorCheck.
 	^ retval
@@ -5770,7 +5770,7 @@ Z3 class >> is_lambda: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _is_lambda: c _: a.
 	c errorCheck.
 	^ retval
@@ -5789,7 +5789,7 @@ Z3 class >> is_numeral_ast: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _is_numeral_ast: c _: a.
 	c errorCheck.
 	^ retval
@@ -5811,7 +5811,7 @@ Z3 class >> is_quantifier_exists: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _is_quantifier_exists: c _: a.
 	c errorCheck.
 	^ retval
@@ -5832,7 +5832,7 @@ Z3 class >> is_quantifier_forall: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _is_quantifier_forall: c _: a.
 	c errorCheck.
 	^ retval
@@ -5853,7 +5853,7 @@ Z3 class >> is_re_sort: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _is_re_sort: c _: s.
 	c errorCheck.
 	^ retval
@@ -5874,7 +5874,7 @@ Z3 class >> is_seq_sort: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _is_seq_sort: c _: s.
 	c errorCheck.
 	^ retval
@@ -5895,7 +5895,7 @@ Z3 class >> is_string: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
 	retval := lib _is_string: c _: s.
 	c errorCheck.
 	^ retval
@@ -5916,7 +5916,7 @@ Z3 class >> is_string_sort: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _is_string_sort: c _: s.
 	c errorCheck.
 	^ retval
@@ -5937,7 +5937,7 @@ Z3 class >> is_well_sorted: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _is_well_sorted: c _: t.
 	c errorCheck.
 	^ retval
@@ -5963,7 +5963,7 @@ Z3 class >> mk_add: c _: num_args _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_add: c _: num_args _: argsExt.
 	[
@@ -5994,7 +5994,7 @@ Z3 class >> mk_and: c _: num_args _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_and: c _: num_args _: argsExt.
 	[
@@ -6024,8 +6024,8 @@ Z3 class >> mk_app: c _: d _: num_args _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	d ensureValidZ3ASTOfKind: FUNC_DECL_AST.
-	args ensureValidZ3ASTArray.
+	d ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_app: c _: d _: num_args _: argsExt.
 	[
@@ -6056,7 +6056,7 @@ Z3 class >> mk_array_default: c _: array [
 	| retval |
 
 	c ensureValidZ3Object.
-	array ensureValidZ3AST.
+	array ensureValidZ3ASTInContext: c.
 	retval := lib _mk_array_default: c _: array.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6079,8 +6079,8 @@ Z3 class >> mk_array_ext: c _: arg1 _: arg2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	arg1 ensureValidZ3AST.
-	arg2 ensureValidZ3AST.
+	arg1 ensureValidZ3ASTInContext: c.
+	arg2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_array_ext: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6107,8 +6107,8 @@ Z3 class >> mk_array_sort: c _: domain _: range [
 	| retval |
 
 	c ensureValidZ3Object.
-	domain ensureValidZ3ASTOfKind: SORT_AST.
-	range ensureValidZ3ASTOfKind: SORT_AST.
+	domain ensureValidZ3ASTInContext: c ofKind: SORT_AST.
+	range ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_array_sort: c _: domain _: range.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -6132,8 +6132,8 @@ Z3 class >> mk_array_sort_n: c _: n _: domain _: range [
 	| retval domainExt |
 
 	c ensureValidZ3Object.
-	domain ensureValidZ3ASTArrayOfKind: SORT_AST.
-	range ensureValidZ3ASTOfKind: SORT_AST.
+	domain ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
+	range ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	domainExt := self externalArrayFrom: domain.
 	retval := lib _mk_array_sort_n: c _: n _: domainExt _: range.
 	[
@@ -6161,7 +6161,7 @@ Z3 class >> mk_as_array: c _: f [
 	| retval |
 
 	c ensureValidZ3Object.
-	f ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	f ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _mk_as_array: c _: f.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6225,7 +6225,7 @@ Z3 class >> mk_atleast: c _: num_args _: args _: k [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_atleast: c _: num_args _: argsExt _: k.
 	[
@@ -6253,7 +6253,7 @@ Z3 class >> mk_atmost: c _: num_args _: args _: k [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_atmost: c _: num_args _: argsExt _: k.
 	[
@@ -6282,7 +6282,7 @@ Z3 class >> mk_bit2bool: c _: i _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bit2bool: c _: i _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6315,7 +6315,7 @@ Z3 class >> mk_bool_sort: c [
 { #category : #API }
 Z3 class >> mk_bound: c _: index _: ty [
 	"
-	   \brief Create a variable.
+	   \brief Create a variable. 
 
 	   Variables are intended to be bound by a scope created by a quantifier. So we call them bound variables
 	   even if they appear as free variables in the expression produced by \c Z3_mk_bound.
@@ -6352,7 +6352,7 @@ Z3 class >> mk_bound: c _: index _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_bound: c _: index _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6380,7 +6380,7 @@ Z3 class >> mk_bv2int: c _: t1 _: is_signed [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bv2int: c _: t1 _: is_signed.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6443,8 +6443,8 @@ Z3 class >> mk_bvadd: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvadd: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6469,8 +6469,8 @@ Z3 class >> mk_bvadd_no_overflow: c _: t1 _: t2 _: is_signed [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvadd_no_overflow: c _: t1 _: t2 _: is_signed.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6495,8 +6495,8 @@ Z3 class >> mk_bvadd_no_underflow: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvadd_no_underflow: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6519,8 +6519,8 @@ Z3 class >> mk_bvand: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvand: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6551,8 +6551,8 @@ Z3 class >> mk_bvashr: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvashr: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6582,8 +6582,8 @@ Z3 class >> mk_bvlshr: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvlshr: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6606,8 +6606,8 @@ Z3 class >> mk_bvmul: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvmul: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6632,8 +6632,8 @@ Z3 class >> mk_bvmul_no_overflow: c _: t1 _: t2 _: is_signed [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvmul_no_overflow: c _: t1 _: t2 _: is_signed.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6658,8 +6658,8 @@ Z3 class >> mk_bvmul_no_underflow: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvmul_no_underflow: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6682,8 +6682,8 @@ Z3 class >> mk_bvnand: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvnand: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6706,7 +6706,7 @@ Z3 class >> mk_bvneg: c _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvneg: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6731,7 +6731,7 @@ Z3 class >> mk_bvneg_no_overflow: c _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvneg_no_overflow: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6754,8 +6754,8 @@ Z3 class >> mk_bvnor: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvnor: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6778,7 +6778,7 @@ Z3 class >> mk_bvnot: c _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvnot: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6801,8 +6801,8 @@ Z3 class >> mk_bvor: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvor: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6825,7 +6825,7 @@ Z3 class >> mk_bvredand: c _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvredand: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6848,7 +6848,7 @@ Z3 class >> mk_bvredor: c _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvredor: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6879,8 +6879,8 @@ Z3 class >> mk_bvsdiv: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvsdiv: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6905,8 +6905,8 @@ Z3 class >> mk_bvsdiv_no_overflow: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvsdiv_no_overflow: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6929,8 +6929,8 @@ Z3 class >> mk_bvsge: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvsge: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6953,8 +6953,8 @@ Z3 class >> mk_bvsgt: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvsgt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -6984,8 +6984,8 @@ Z3 class >> mk_bvshl: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvshl: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7008,8 +7008,8 @@ Z3 class >> mk_bvsle: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvsle: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7040,8 +7040,8 @@ Z3 class >> mk_bvslt: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvslt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7068,8 +7068,8 @@ Z3 class >> mk_bvsmod: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvsmod: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7099,8 +7099,8 @@ Z3 class >> mk_bvsrem: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvsrem: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7123,8 +7123,8 @@ Z3 class >> mk_bvsub: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvsub: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7149,8 +7149,8 @@ Z3 class >> mk_bvsub_no_overflow: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvsub_no_overflow: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7175,8 +7175,8 @@ Z3 class >> mk_bvsub_no_underflow: c _: t1 _: t2 _: is_signed [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvsub_no_underflow: c _: t1 _: t2 _: is_signed.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7203,8 +7203,8 @@ Z3 class >> mk_bvudiv: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvudiv: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7227,8 +7227,8 @@ Z3 class >> mk_bvuge: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvuge: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7251,8 +7251,8 @@ Z3 class >> mk_bvugt: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvugt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7275,8 +7275,8 @@ Z3 class >> mk_bvule: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvule: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7299,8 +7299,8 @@ Z3 class >> mk_bvult: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvult: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7327,8 +7327,8 @@ Z3 class >> mk_bvurem: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvurem: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7351,8 +7351,8 @@ Z3 class >> mk_bvxnor: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvxnor: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7375,8 +7375,8 @@ Z3 class >> mk_bvxor: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_bvxor: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7416,7 +7416,7 @@ Z3 class >> mk_char_from_bv: c _: bv [
 	| retval |
 
 	c ensureValidZ3Object.
-	bv ensureValidZ3AST.
+	bv ensureValidZ3ASTInContext: c.
 	retval := lib _mk_char_from_bv: c _: bv.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7437,7 +7437,7 @@ Z3 class >> mk_char_is_digit: c _: ch [
 	| retval |
 
 	c ensureValidZ3Object.
-	ch ensureValidZ3AST.
+	ch ensureValidZ3ASTInContext: c.
 	retval := lib _mk_char_is_digit: c _: ch.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7458,8 +7458,8 @@ Z3 class >> mk_char_le: c _: ch1 _: ch2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	ch1 ensureValidZ3AST.
-	ch2 ensureValidZ3AST.
+	ch1 ensureValidZ3ASTInContext: c.
+	ch2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_char_le: c _: ch1 _: ch2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7504,7 +7504,7 @@ Z3 class >> mk_char_to_bv: c _: ch [
 	| retval |
 
 	c ensureValidZ3Object.
-	ch ensureValidZ3AST.
+	ch ensureValidZ3ASTInContext: c.
 	retval := lib _mk_char_to_bv: c _: ch.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7525,7 +7525,7 @@ Z3 class >> mk_char_to_int: c _: ch [
 	| retval |
 
 	c ensureValidZ3Object.
-	ch ensureValidZ3AST.
+	ch ensureValidZ3ASTInContext: c.
 	retval := lib _mk_char_to_int: c _: ch.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7551,8 +7551,8 @@ Z3 class >> mk_concat: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_concat: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7628,7 +7628,7 @@ Z3 class >> mk_const: c _: s _: ty [
 
 	c ensureValidZ3Object.
 	s ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_const: c _: s _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7656,8 +7656,8 @@ Z3 class >> mk_const_array: c _: domain _: v [
 	| retval |
 
 	c ensureValidZ3Object.
-	domain ensureValidZ3ASTOfKind: SORT_AST.
-	v ensureValidZ3AST.
+	domain ensureValidZ3ASTInContext: c ofKind: SORT_AST.
+	v ensureValidZ3ASTInContext: c.
 	retval := lib _mk_const_array: c _: domain _: v.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -7969,7 +7969,7 @@ Z3 class >> mk_distinct: c _: num_args _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_distinct: c _: num_args _: argsExt.
 	[
@@ -7999,8 +7999,8 @@ Z3 class >> mk_div: c _: arg1 _: arg2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	arg1 ensureValidZ3AST.
-	arg2 ensureValidZ3AST.
+	arg1 ensureValidZ3ASTInContext: c.
+	arg2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_div: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8025,8 +8025,8 @@ Z3 class >> mk_divides: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_divides: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8047,7 +8047,7 @@ Z3 class >> mk_empty_set: c _: domain [
 	| retval |
 
 	c ensureValidZ3Object.
-	domain ensureValidZ3ASTOfKind: SORT_AST.
+	domain ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_empty_set: c _: domain.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8129,8 +8129,8 @@ Z3 class >> mk_eq: c _: l _: r [
 	| retval |
 
 	c ensureValidZ3Object.
-	l ensureValidZ3AST.
-	r ensureValidZ3AST.
+	l ensureValidZ3ASTInContext: c.
+	r ensureValidZ3ASTInContext: c.
 	retval := lib _mk_eq: c _: l _: r.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8157,9 +8157,9 @@ Z3 class >> mk_exists: c _: weight _: num_patterns _: patterns _: num_decls _: s
 
 	c ensureValidZ3Object.
 	patterns ensureValidZ3ObjectArray.
-	sorts ensureValidZ3ASTArrayOfKind: SORT_AST.
+	sorts ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
 	decl_names ensureValidZ3ObjectArray.
-	body ensureValidZ3AST.
+	body ensureValidZ3ASTInContext: c.
 	patternsExt := self externalArrayFrom: patterns.
 	sortsExt := self externalArrayFrom: sorts.
 	decl_namesExt := self externalArrayFrom: decl_names.
@@ -8204,9 +8204,9 @@ Z3 class >> mk_exists_const: c _: weight _: num_bound _: bound _: num_patterns _
 	| retval boundExt patternsExt |
 
 	c ensureValidZ3Object.
-	bound ensureValidZ3ASTArray.
+	bound ensureValidZ3ASTArrayInContext: c.
 	patterns ensureValidZ3ObjectArray.
-	body ensureValidZ3AST.
+	body ensureValidZ3ASTInContext: c.
 	boundExt := self externalArrayFrom: bound.
 	patternsExt := self externalArrayFrom: patterns.
 	retval := lib _mk_exists_const: c _: weight _: num_bound _: boundExt _: num_patterns _: patternsExt _: body.
@@ -8236,8 +8236,8 @@ Z3 class >> mk_ext_rotate_left: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_ext_rotate_left: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8260,8 +8260,8 @@ Z3 class >> mk_ext_rotate_right: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_ext_rotate_right: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8285,7 +8285,7 @@ Z3 class >> mk_extract: c _: high _: low _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_extract: c _: high _: low _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8397,9 +8397,9 @@ Z3 class >> mk_forall: c _: weight _: num_patterns _: patterns _: num_decls _: s
 
 	c ensureValidZ3Object.
 	patterns ensureValidZ3ObjectArray.
-	sorts ensureValidZ3ASTArrayOfKind: SORT_AST.
+	sorts ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
 	decl_names ensureValidZ3ObjectArray.
-	body ensureValidZ3AST.
+	body ensureValidZ3ASTInContext: c.
 	patternsExt := self externalArrayFrom: patterns.
 	sortsExt := self externalArrayFrom: sorts.
 	decl_namesExt := self externalArrayFrom: decl_names.
@@ -8442,9 +8442,9 @@ Z3 class >> mk_forall_const: c _: weight _: num_bound _: bound _: num_patterns _
 	| retval boundExt patternsExt |
 
 	c ensureValidZ3Object.
-	bound ensureValidZ3ASTArray.
+	bound ensureValidZ3ASTArrayInContext: c.
 	patterns ensureValidZ3ObjectArray.
-	body ensureValidZ3AST.
+	body ensureValidZ3ASTInContext: c.
 	boundExt := self externalArrayFrom: bound.
 	patternsExt := self externalArrayFrom: patterns.
 	retval := lib _mk_forall_const: c _: weight _: num_bound _: boundExt _: num_patterns _: patternsExt _: body.
@@ -8479,7 +8479,7 @@ Z3 class >> mk_fpa_abs: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_abs: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8507,9 +8507,9 @@ Z3 class >> mk_fpa_add: c _: rm _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	rm ensureValidZ3ASTInContext: c.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_add: c _: rm _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8537,9 +8537,9 @@ Z3 class >> mk_fpa_div: c _: rm _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	rm ensureValidZ3ASTInContext: c.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_div: c _: rm _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8573,8 +8573,8 @@ Z3 class >> mk_fpa_eq: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_eq: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8605,10 +8605,10 @@ Z3 class >> mk_fpa_fma: c _: rm _: t1 _: t2 _: t3 [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
-	t3 ensureValidZ3AST.
+	rm ensureValidZ3ASTInContext: c.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
+	t3 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_fma: c _: rm _: t1 _: t2 _: t3.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8647,9 +8647,9 @@ Z3 class >> mk_fpa_fp: c _: sgn _: exp _: sig [
 	| retval |
 
 	c ensureValidZ3Object.
-	sgn ensureValidZ3AST.
-	exp ensureValidZ3AST.
-	sig ensureValidZ3AST.
+	sgn ensureValidZ3ASTInContext: c.
+	exp ensureValidZ3ASTInContext: c.
+	sig ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_fp: c _: sgn _: exp _: sig.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8681,8 +8681,8 @@ Z3 class >> mk_fpa_geq: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_geq: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8714,8 +8714,8 @@ Z3 class >> mk_fpa_gt: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_gt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8746,7 +8746,7 @@ Z3 class >> mk_fpa_inf: c _: s _: negative [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_inf: c _: s _: negative.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8778,7 +8778,7 @@ Z3 class >> mk_fpa_is_infinite: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_is_infinite: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8810,7 +8810,7 @@ Z3 class >> mk_fpa_is_nan: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_is_nan: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8840,7 +8840,7 @@ Z3 class >> mk_fpa_is_negative: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_is_negative: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8871,7 +8871,7 @@ Z3 class >> mk_fpa_is_normal: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_is_normal: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8901,7 +8901,7 @@ Z3 class >> mk_fpa_is_positive: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_is_positive: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8932,7 +8932,7 @@ Z3 class >> mk_fpa_is_subnormal: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_is_subnormal: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8964,7 +8964,7 @@ Z3 class >> mk_fpa_is_zero: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_is_zero: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -8996,8 +8996,8 @@ Z3 class >> mk_fpa_leq: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_leq: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9029,8 +9029,8 @@ Z3 class >> mk_fpa_lt: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_lt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9059,8 +9059,8 @@ Z3 class >> mk_fpa_max: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_max: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9089,8 +9089,8 @@ Z3 class >> mk_fpa_min: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_min: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9118,9 +9118,9 @@ Z3 class >> mk_fpa_mul: c _: rm _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	rm ensureValidZ3ASTInContext: c.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_mul: c _: rm _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9148,7 +9148,7 @@ Z3 class >> mk_fpa_nan: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_nan: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9176,7 +9176,7 @@ Z3 class >> mk_fpa_neg: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_neg: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9213,7 +9213,7 @@ Z3 class >> mk_fpa_numeral_double: c _: v _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_numeral_double: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9250,7 +9250,7 @@ Z3 class >> mk_fpa_numeral_float: c _: v _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_numeral_float: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9286,7 +9286,7 @@ Z3 class >> mk_fpa_numeral_int64_uint64: c _: sgn _: exp _: sig _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_numeral_int64_uint64: c _: sgn _: exp _: sig _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9320,7 +9320,7 @@ Z3 class >> mk_fpa_numeral_int: c _: v _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_numeral_int: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9356,7 +9356,7 @@ Z3 class >> mk_fpa_numeral_int_uint: c _: sgn _: exp _: sig _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_numeral_int_uint: c _: sgn _: exp _: sig _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9383,8 +9383,8 @@ Z3 class >> mk_fpa_rem: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_rem: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -9532,8 +9532,8 @@ Z3 class >> mk_fpa_round_to_integral: c _: rm _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t ensureValidZ3AST.
+	rm ensureValidZ3ASTInContext: c.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_round_to_integral: c _: rm _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10031,8 +10031,8 @@ Z3 class >> mk_fpa_sqrt: c _: rm _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t ensureValidZ3AST.
+	rm ensureValidZ3ASTInContext: c.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_sqrt: c _: rm _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10060,9 +10060,9 @@ Z3 class >> mk_fpa_sub: c _: rm _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	rm ensureValidZ3ASTInContext: c.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_sub: c _: rm _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10094,8 +10094,8 @@ Z3 class >> mk_fpa_to_fp_bv: c _: bv _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	bv ensureValidZ3AST.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	bv ensureValidZ3ASTInContext: c.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_to_fp_bv: c _: bv _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10127,9 +10127,9 @@ Z3 class >> mk_fpa_to_fp_float: c _: rm _: t _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t ensureValidZ3AST.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	rm ensureValidZ3ASTInContext: c.
+	t ensureValidZ3ASTInContext: c.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_to_fp_float: c _: rm _: t _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10162,10 +10162,10 @@ Z3 class >> mk_fpa_to_fp_int_real: c _: rm _: exp _: sig _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	exp ensureValidZ3AST.
-	sig ensureValidZ3AST.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	rm ensureValidZ3ASTInContext: c.
+	exp ensureValidZ3ASTInContext: c.
+	sig ensureValidZ3ASTInContext: c.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_to_fp_int_real: c _: rm _: exp _: sig _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10197,9 +10197,9 @@ Z3 class >> mk_fpa_to_fp_real: c _: rm _: t _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t ensureValidZ3AST.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	rm ensureValidZ3ASTInContext: c.
+	t ensureValidZ3ASTInContext: c.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_to_fp_real: c _: rm _: t _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10232,9 +10232,9 @@ Z3 class >> mk_fpa_to_fp_signed: c _: rm _: t _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t ensureValidZ3AST.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	rm ensureValidZ3ASTInContext: c.
+	t ensureValidZ3ASTInContext: c.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_to_fp_signed: c _: rm _: t _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10267,9 +10267,9 @@ Z3 class >> mk_fpa_to_fp_unsigned: c _: rm _: t _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t ensureValidZ3AST.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	rm ensureValidZ3ASTInContext: c.
+	t ensureValidZ3ASTInContext: c.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_to_fp_unsigned: c _: rm _: t _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10300,7 +10300,7 @@ Z3 class >> mk_fpa_to_ieee_bv: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_to_ieee_bv: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10328,7 +10328,7 @@ Z3 class >> mk_fpa_to_real: c _: t [
 	| retval |
 
 	c ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_to_real: c _: t.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10358,8 +10358,8 @@ Z3 class >> mk_fpa_to_sbv: c _: rm _: t _: sz [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t ensureValidZ3AST.
+	rm ensureValidZ3ASTInContext: c.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_to_sbv: c _: rm _: t _: sz.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10389,8 +10389,8 @@ Z3 class >> mk_fpa_to_ubv: c _: rm _: t _: sz [
 	| retval |
 
 	c ensureValidZ3Object.
-	rm ensureValidZ3AST.
-	t ensureValidZ3AST.
+	rm ensureValidZ3ASTInContext: c.
+	t ensureValidZ3ASTInContext: c.
 	retval := lib _mk_fpa_to_ubv: c _: rm _: t _: sz.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10421,7 +10421,7 @@ Z3 class >> mk_fpa_zero: c _: s _: negative [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fpa_zero: c _: s _: negative.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10452,7 +10452,7 @@ Z3 class >> mk_fresh_const: c _: prefix _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_fresh_const: c _: prefix _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10480,8 +10480,8 @@ Z3 class >> mk_fresh_func_decl: c _: prefix _: domain_size _: domain _: range [
 	| retval domainExt |
 
 	c ensureValidZ3Object.
-	domain ensureValidZ3ASTArrayOfKind: SORT_AST.
-	range ensureValidZ3ASTOfKind: SORT_AST.
+	domain ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
+	range ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	domainExt := self externalArrayFrom: domain.
 	retval := lib _mk_fresh_func_decl: c _: prefix _: domain_size _: domainExt _: range.
 	[
@@ -10507,7 +10507,7 @@ Z3 class >> mk_full_set: c _: domain [
 	| retval |
 
 	c ensureValidZ3Object.
-	domain ensureValidZ3ASTOfKind: SORT_AST.
+	domain ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_full_set: c _: domain.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10543,8 +10543,8 @@ Z3 class >> mk_func_decl: c _: s _: domain_size _: domain _: range [
 
 	c ensureValidZ3Object.
 	s ensureValidZ3Object.
-	domain ensureValidZ3ASTArrayOfKind: SORT_AST.
-	range ensureValidZ3ASTOfKind: SORT_AST.
+	domain ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
+	range ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	domainExt := self externalArrayFrom: domain.
 	retval := lib _mk_func_decl: c _: s _: domain_size _: domainExt _: range.
 	[
@@ -10572,8 +10572,8 @@ Z3 class >> mk_ge: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_ge: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10623,8 +10623,8 @@ Z3 class >> mk_gt: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_gt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10647,8 +10647,8 @@ Z3 class >> mk_iff: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_iff: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10671,8 +10671,8 @@ Z3 class >> mk_implies: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_implies: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10698,7 +10698,7 @@ Z3 class >> mk_int2bv: c _: n _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_int2bv: c _: n _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10731,7 +10731,7 @@ Z3 class >> mk_int2real: c _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_int2real: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10757,7 +10757,7 @@ Z3 class >> mk_int64: c _: v _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_int64: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10783,7 +10783,7 @@ Z3 class >> mk_int: c _: v _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_int: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10858,7 +10858,7 @@ Z3 class >> mk_int_to_str: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
 	retval := lib _mk_int_to_str: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10882,7 +10882,7 @@ Z3 class >> mk_is_int: c _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_is_int: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10906,9 +10906,9 @@ Z3 class >> mk_ite: c _: t1 _: t2 _: t3 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
-	t3 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
+	t3 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_ite: c _: t1 _: t2 _: t3.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -10947,9 +10947,9 @@ Z3 class >> mk_lambda: c _: num_decls _: sorts _: decl_names _: body [
 	| retval sortsExt decl_namesExt |
 
 	c ensureValidZ3Object.
-	sorts ensureValidZ3ASTArrayOfKind: SORT_AST.
+	sorts ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
 	decl_names ensureValidZ3ObjectArray.
-	body ensureValidZ3AST.
+	body ensureValidZ3ASTInContext: c.
 	sortsExt := self externalArrayFrom: sorts.
 	decl_namesExt := self externalArrayFrom: decl_names.
 	retval := lib _mk_lambda: c _: num_decls _: sortsExt _: decl_namesExt _: body.
@@ -10987,8 +10987,8 @@ Z3 class >> mk_lambda_const: c _: num_bound _: bound _: body [
 	| retval boundExt |
 
 	c ensureValidZ3Object.
-	bound ensureValidZ3ASTArray.
-	body ensureValidZ3AST.
+	bound ensureValidZ3ASTArrayInContext: c.
+	body ensureValidZ3ASTInContext: c.
 	boundExt := self externalArrayFrom: bound.
 	retval := lib _mk_lambda_const: c _: num_bound _: boundExt _: body.
 	[
@@ -11016,8 +11016,8 @@ Z3 class >> mk_le: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_le: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11039,7 +11039,7 @@ Z3 class >> mk_linear_order: c _: a _: id [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3ASTOfKind: SORT_AST.
+	a ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_linear_order: c _: a _: id.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -11074,7 +11074,7 @@ Z3 class >> mk_list_sort: c _: name _: elem_sort _: nil_decl _: is_nil_decl _: c
 
 	c ensureValidZ3Object.
 	name ensureValidZ3Object.
-	elem_sort ensureValidZ3ASTOfKind: SORT_AST.
+	elem_sort ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	nil_declExt := self externalArrayFrom: nil_decl.
 	is_nil_declExt := self externalArrayFrom: is_nil_decl.
 	cons_declExt := self externalArrayFrom: cons_decl.
@@ -11171,8 +11171,8 @@ Z3 class >> mk_lt: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_lt: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11201,8 +11201,8 @@ Z3 class >> mk_map: c _: f _: n _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	f ensureValidZ3ASTOfKind: FUNC_DECL_AST.
-	args ensureValidZ3ASTArray.
+	f ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_map: c _: f _: n _: argsExt.
 	[
@@ -11230,8 +11230,8 @@ Z3 class >> mk_mod: c _: arg1 _: arg2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	arg1 ensureValidZ3AST.
-	arg2 ensureValidZ3AST.
+	arg1 ensureValidZ3ASTInContext: c.
+	arg2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_mod: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11278,7 +11278,7 @@ Z3 class >> mk_mul: c _: num_args _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_mul: c _: num_args _: argsExt.
 	[
@@ -11306,7 +11306,7 @@ Z3 class >> mk_not: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _mk_not: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11335,7 +11335,7 @@ Z3 class >> mk_numeral: c _: numeral _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_numeral: c _: numeral _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11379,7 +11379,7 @@ Z3 class >> mk_or: c _: num_args _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_or: c _: num_args _: argsExt.
 	[
@@ -11430,7 +11430,7 @@ Z3 class >> mk_partial_order: c _: a _: id [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3ASTOfKind: SORT_AST.
+	a ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_partial_order: c _: a _: id.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -11466,7 +11466,7 @@ Z3 class >> mk_pattern: c _: num_patterns _: terms [
 	| retval termsExt |
 
 	c ensureValidZ3Object.
-	terms ensureValidZ3ASTArray.
+	terms ensureValidZ3ASTArrayInContext: c.
 	termsExt := self externalArrayFrom: terms.
 	retval := lib _mk_pattern: c _: num_patterns _: termsExt.
 	[
@@ -11543,7 +11543,7 @@ Z3 class >> mk_piecewise_linear_order: c _: a _: id [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3ASTOfKind: SORT_AST.
+	a ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_piecewise_linear_order: c _: a _: id.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -11566,8 +11566,8 @@ Z3 class >> mk_power: c _: arg1 _: arg2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	arg1 ensureValidZ3AST.
-	arg2 ensureValidZ3AST.
+	arg1 ensureValidZ3ASTInContext: c.
+	arg2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_power: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11625,9 +11625,9 @@ Z3 class >> mk_quantifier: c _: is_forall _: weight _: num_patterns _: patterns 
 
 	c ensureValidZ3Object.
 	patterns ensureValidZ3ObjectArray.
-	sorts ensureValidZ3ASTArrayOfKind: SORT_AST.
+	sorts ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
 	decl_names ensureValidZ3ObjectArray.
-	body ensureValidZ3AST.
+	body ensureValidZ3ASTInContext: c.
 	patternsExt := self externalArrayFrom: patterns.
 	sortsExt := self externalArrayFrom: sorts.
 	decl_namesExt := self externalArrayFrom: decl_names.
@@ -11658,9 +11658,9 @@ Z3 class >> mk_quantifier_const: c _: is_forall _: weight _: num_bound _: bound 
 	| retval boundExt patternsExt |
 
 	c ensureValidZ3Object.
-	bound ensureValidZ3ASTArray.
+	bound ensureValidZ3ASTArrayInContext: c.
 	patterns ensureValidZ3ObjectArray.
-	body ensureValidZ3AST.
+	body ensureValidZ3ASTInContext: c.
 	boundExt := self externalArrayFrom: bound.
 	patternsExt := self externalArrayFrom: patterns.
 	retval := lib _mk_quantifier_const: c _: is_forall _: weight _: num_bound _: boundExt _: num_patterns _: patternsExt _: body.
@@ -11691,10 +11691,10 @@ Z3 class >> mk_quantifier_const_ex: c _: is_forall _: weight _: quantifier_id _:
 	c ensureValidZ3Object.
 	quantifier_id ensureValidZ3Object.
 	skolem_id ensureValidZ3Object.
-	bound ensureValidZ3ASTArray.
+	bound ensureValidZ3ASTArrayInContext: c.
 	patterns ensureValidZ3ObjectArray.
-	no_patterns ensureValidZ3ASTArray.
-	body ensureValidZ3AST.
+	no_patterns ensureValidZ3ASTArrayInContext: c.
+	body ensureValidZ3ASTInContext: c.
 	boundExt := self externalArrayFrom: bound.
 	patternsExt := self externalArrayFrom: patterns.
 	no_patternsExt := self externalArrayFrom: no_patterns.
@@ -11746,10 +11746,10 @@ Z3 class >> mk_quantifier_ex: c _: is_forall _: weight _: quantifier_id _: skole
 	quantifier_id ensureValidZ3Object.
 	skolem_id ensureValidZ3Object.
 	patterns ensureValidZ3ObjectArray.
-	no_patterns ensureValidZ3ASTArray.
-	sorts ensureValidZ3ASTArrayOfKind: SORT_AST.
+	no_patterns ensureValidZ3ASTArrayInContext: c.
+	sorts ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
 	decl_names ensureValidZ3ObjectArray.
-	body ensureValidZ3AST.
+	body ensureValidZ3ASTInContext: c.
 	patternsExt := self externalArrayFrom: patterns.
 	no_patternsExt := self externalArrayFrom: no_patterns.
 	sortsExt := self externalArrayFrom: sorts.
@@ -11781,7 +11781,7 @@ Z3 class >> mk_re_allchar: c _: regex_sort [
 	| retval |
 
 	c ensureValidZ3Object.
-	regex_sort ensureValidZ3ASTOfKind: SORT_AST.
+	regex_sort ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_re_allchar: c _: regex_sort.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11802,7 +11802,7 @@ Z3 class >> mk_re_complement: c _: re [
 	| retval |
 
 	c ensureValidZ3Object.
-	re ensureValidZ3AST.
+	re ensureValidZ3ASTInContext: c.
 	retval := lib _mk_re_complement: c _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11825,7 +11825,7 @@ Z3 class >> mk_re_concat: c _: n _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_re_concat: c _: n _: argsExt.
 	[
@@ -11851,8 +11851,8 @@ Z3 class >> mk_re_diff: c _: re1 _: re2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	re1 ensureValidZ3AST.
-	re2 ensureValidZ3AST.
+	re1 ensureValidZ3ASTInContext: c.
+	re2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_re_diff: c _: re1 _: re2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11875,7 +11875,7 @@ Z3 class >> mk_re_empty: c _: re [
 	| retval |
 
 	c ensureValidZ3Object.
-	re ensureValidZ3ASTOfKind: SORT_AST.
+	re ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_re_empty: c _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11898,7 +11898,7 @@ Z3 class >> mk_re_full: c _: re [
 	| retval |
 
 	c ensureValidZ3Object.
-	re ensureValidZ3ASTOfKind: SORT_AST.
+	re ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_re_full: c _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11921,7 +11921,7 @@ Z3 class >> mk_re_intersect: c _: n _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_re_intersect: c _: n _: argsExt.
 	[
@@ -11950,7 +11950,7 @@ Z3 class >> mk_re_loop: c _: r _: lo _: hi [
 	| retval |
 
 	c ensureValidZ3Object.
-	r ensureValidZ3AST.
+	r ensureValidZ3ASTInContext: c.
 	retval := lib _mk_re_loop: c _: r _: lo _: hi.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11971,7 +11971,7 @@ Z3 class >> mk_re_option: c _: re [
 	| retval |
 
 	c ensureValidZ3Object.
-	re ensureValidZ3AST.
+	re ensureValidZ3ASTInContext: c.
 	retval := lib _mk_re_option: c _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -11992,7 +11992,7 @@ Z3 class >> mk_re_plus: c _: re [
 	| retval |
 
 	c ensureValidZ3Object.
-	re ensureValidZ3AST.
+	re ensureValidZ3ASTInContext: c.
 	retval := lib _mk_re_plus: c _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12013,7 +12013,7 @@ Z3 class >> mk_re_power: c _: re _: n [
 	| retval |
 
 	c ensureValidZ3Object.
-	re ensureValidZ3AST.
+	re ensureValidZ3ASTInContext: c.
 	retval := lib _mk_re_power: c _: re _: n.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12034,8 +12034,8 @@ Z3 class >> mk_re_range: c _: lo _: hi [
 	| retval |
 
 	c ensureValidZ3Object.
-	lo ensureValidZ3AST.
-	hi ensureValidZ3AST.
+	lo ensureValidZ3ASTInContext: c.
+	hi ensureValidZ3ASTInContext: c.
 	retval := lib _mk_re_range: c _: lo _: hi.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12056,7 +12056,7 @@ Z3 class >> mk_re_sort: c _: seq [
 	| retval |
 
 	c ensureValidZ3Object.
-	seq ensureValidZ3ASTOfKind: SORT_AST.
+	seq ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_re_sort: c _: seq.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -12077,7 +12077,7 @@ Z3 class >> mk_re_star: c _: re [
 	| retval |
 
 	c ensureValidZ3Object.
-	re ensureValidZ3AST.
+	re ensureValidZ3ASTInContext: c.
 	retval := lib _mk_re_star: c _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12100,7 +12100,7 @@ Z3 class >> mk_re_union: c _: n _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_re_union: c _: n _: argsExt.
 	[
@@ -12132,7 +12132,7 @@ Z3 class >> mk_real2int: c _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_real2int: c _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12178,7 +12178,7 @@ Z3 class >> mk_real_int64: c _: num _: den [
 
 	   \sa Z3_mk_real
 	   def_API('Z3_mk_real_int64', AST, (_in(CONTEXT), _in(INT64), _in(INT64)))
-
+	 
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -12242,8 +12242,8 @@ Z3 class >> mk_rec_func_decl: c _: s _: domain_size _: domain _: range [
 
 	c ensureValidZ3Object.
 	s ensureValidZ3Object.
-	domain ensureValidZ3ASTArrayOfKind: SORT_AST.
-	range ensureValidZ3ASTOfKind: SORT_AST.
+	domain ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
+	range ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	domainExt := self externalArrayFrom: domain.
 	retval := lib _mk_rec_func_decl: c _: s _: domain_size _: domainExt _: range.
 	[
@@ -12271,8 +12271,8 @@ Z3 class >> mk_rem: c _: arg1 _: arg2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	arg1 ensureValidZ3AST.
-	arg2 ensureValidZ3AST.
+	arg1 ensureValidZ3ASTInContext: c.
+	arg2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_rem: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12295,7 +12295,7 @@ Z3 class >> mk_repeat: c _: i _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_repeat: c _: i _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12318,7 +12318,7 @@ Z3 class >> mk_rotate_left: c _: i _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_rotate_left: c _: i _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12341,7 +12341,7 @@ Z3 class >> mk_rotate_right: c _: i _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_rotate_right: c _: i _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12362,7 +12362,7 @@ Z3 class >> mk_sbv_to_str: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
 	retval := lib _mk_sbv_to_str: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12391,8 +12391,8 @@ Z3 class >> mk_select: c _: a _: i [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	i ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	i ensureValidZ3ASTInContext: c.
 	retval := lib _mk_select: c _: a _: i.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12415,8 +12415,8 @@ Z3 class >> mk_select_n: c _: a _: n _: idxs [
 	| retval idxsExt |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	idxs ensureValidZ3ASTArray.
+	a ensureValidZ3ASTInContext: c.
+	idxs ensureValidZ3ASTArrayInContext: c.
 	idxsExt := self externalArrayFrom: idxs.
 	retval := lib _mk_select_n: c _: a _: n _: idxsExt.
 	[
@@ -12443,8 +12443,8 @@ Z3 class >> mk_seq_at: c _: s _: index [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
-	index ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
+	index ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_at: c _: s _: index.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12467,7 +12467,7 @@ Z3 class >> mk_seq_concat: c _: n _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_seq_concat: c _: n _: argsExt.
 	[
@@ -12495,8 +12495,8 @@ Z3 class >> mk_seq_contains: c _: container _: containee [
 	| retval |
 
 	c ensureValidZ3Object.
-	container ensureValidZ3AST.
-	containee ensureValidZ3AST.
+	container ensureValidZ3ASTInContext: c.
+	containee ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_contains: c _: container _: containee.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12519,7 +12519,7 @@ Z3 class >> mk_seq_empty: c _: seq [
 	| retval |
 
 	c ensureValidZ3Object.
-	seq ensureValidZ3ASTOfKind: SORT_AST.
+	seq ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_seq_empty: c _: seq.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12540,9 +12540,9 @@ Z3 class >> mk_seq_extract: c _: s _: offset _: length [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
-	offset ensureValidZ3AST.
-	length ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
+	offset ensureValidZ3ASTInContext: c.
+	length ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_extract: c _: s _: offset _: length.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12563,8 +12563,8 @@ Z3 class >> mk_seq_in_re: c _: seq _: re [
 	| retval |
 
 	c ensureValidZ3Object.
-	seq ensureValidZ3AST.
-	re ensureValidZ3AST.
+	seq ensureValidZ3ASTInContext: c.
+	re ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_in_re: c _: seq _: re.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12587,9 +12587,9 @@ Z3 class >> mk_seq_index: c _: s _: substr _: offset [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
-	substr ensureValidZ3AST.
-	offset ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
+	substr ensureValidZ3ASTInContext: c.
+	offset ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_index: c _: s _: substr _: offset.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12610,8 +12610,8 @@ Z3 class >> mk_seq_last_index: c _: s _: substr [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
-	substr ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
+	substr ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_last_index: c _: s _: substr.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12632,7 +12632,7 @@ Z3 class >> mk_seq_length: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_length: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12654,8 +12654,8 @@ Z3 class >> mk_seq_nth: c _: s _: index [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
-	index ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
+	index ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_nth: c _: s _: index.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12678,8 +12678,8 @@ Z3 class >> mk_seq_prefix: c _: prefix _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	prefix ensureValidZ3AST.
-	s ensureValidZ3AST.
+	prefix ensureValidZ3ASTInContext: c.
+	s ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_prefix: c _: prefix _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12700,9 +12700,9 @@ Z3 class >> mk_seq_replace: c _: s _: src _: dst [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
-	src ensureValidZ3AST.
-	dst ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
+	src ensureValidZ3ASTInContext: c.
+	dst ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_replace: c _: s _: src _: dst.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12723,7 +12723,7 @@ Z3 class >> mk_seq_sort: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_seq_sort: c _: s.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -12746,8 +12746,8 @@ Z3 class >> mk_seq_suffix: c _: suffix _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	suffix ensureValidZ3AST.
-	s ensureValidZ3AST.
+	suffix ensureValidZ3ASTInContext: c.
+	s ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_suffix: c _: suffix _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12768,7 +12768,7 @@ Z3 class >> mk_seq_to_re: c _: seq [
 	| retval |
 
 	c ensureValidZ3Object.
-	seq ensureValidZ3AST.
+	seq ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_to_re: c _: seq.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12789,7 +12789,7 @@ Z3 class >> mk_seq_unit: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _mk_seq_unit: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12812,8 +12812,8 @@ Z3 class >> mk_set_add: c _: set _: elem [
 	| retval |
 
 	c ensureValidZ3Object.
-	set ensureValidZ3AST.
-	elem ensureValidZ3AST.
+	set ensureValidZ3ASTInContext: c.
+	elem ensureValidZ3ASTInContext: c.
 	retval := lib _mk_set_add: c _: set _: elem.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12834,7 +12834,7 @@ Z3 class >> mk_set_complement: c _: arg [
 	| retval |
 
 	c ensureValidZ3Object.
-	arg ensureValidZ3AST.
+	arg ensureValidZ3ASTInContext: c.
 	retval := lib _mk_set_complement: c _: arg.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12857,8 +12857,8 @@ Z3 class >> mk_set_del: c _: set _: elem [
 	| retval |
 
 	c ensureValidZ3Object.
-	set ensureValidZ3AST.
-	elem ensureValidZ3AST.
+	set ensureValidZ3ASTInContext: c.
+	elem ensureValidZ3ASTInContext: c.
 	retval := lib _mk_set_del: c _: set _: elem.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12879,8 +12879,8 @@ Z3 class >> mk_set_difference: c _: arg1 _: arg2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	arg1 ensureValidZ3AST.
-	arg2 ensureValidZ3AST.
+	arg1 ensureValidZ3ASTInContext: c.
+	arg2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_set_difference: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12901,8 +12901,8 @@ Z3 class >> mk_set_has_size: c _: set _: k [
 	| retval |
 
 	c ensureValidZ3Object.
-	set ensureValidZ3AST.
-	k ensureValidZ3AST.
+	set ensureValidZ3ASTInContext: c.
+	k ensureValidZ3ASTInContext: c.
 	retval := lib _mk_set_has_size: c _: set _: k.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12923,7 +12923,7 @@ Z3 class >> mk_set_intersect: c _: num_args _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_set_intersect: c _: num_args _: argsExt.
 	[
@@ -12951,8 +12951,8 @@ Z3 class >> mk_set_member: c _: elem _: set [
 	| retval |
 
 	c ensureValidZ3Object.
-	elem ensureValidZ3AST.
-	set ensureValidZ3AST.
+	elem ensureValidZ3ASTInContext: c.
+	set ensureValidZ3ASTInContext: c.
 	retval := lib _mk_set_member: c _: elem _: set.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -12973,7 +12973,7 @@ Z3 class >> mk_set_sort: c _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_set_sort: c _: ty.
 	c errorCheck.
 	^ Z3Sort fromExternalAddress: retval inContext: c.
@@ -12994,8 +12994,8 @@ Z3 class >> mk_set_subset: c _: arg1 _: arg2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	arg1 ensureValidZ3AST.
-	arg2 ensureValidZ3AST.
+	arg1 ensureValidZ3ASTInContext: c.
+	arg2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_set_subset: c _: arg1 _: arg2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13016,7 +13016,7 @@ Z3 class >> mk_set_union: c _: num_args _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_set_union: c _: num_args _: argsExt.
 	[
@@ -13046,7 +13046,7 @@ Z3 class >> mk_sign_ext: c _: i _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_sign_ext: c _: i _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13108,7 +13108,7 @@ Z3 class >> mk_simplifier: c _: name [
 	   Simplifiers are the basic building block for creating custom solvers for specific problem domains.
 
 	   def_API('Z3_mk_simplifier', SIMPLIFIER, (_in(CONTEXT), _in(STRING)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -13249,9 +13249,9 @@ Z3 class >> mk_store: c _: a _: i _: v [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	i ensureValidZ3AST.
-	v ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	i ensureValidZ3ASTInContext: c.
+	v ensureValidZ3ASTInContext: c.
 	retval := lib _mk_store: c _: a _: i _: v.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13273,9 +13273,9 @@ Z3 class >> mk_store_n: c _: a _: n _: idxs _: v [
 	| retval idxsExt |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	idxs ensureValidZ3ASTArray.
-	v ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	idxs ensureValidZ3ASTArrayInContext: c.
+	v ensureValidZ3ASTInContext: c.
 	idxsExt := self externalArrayFrom: idxs.
 	retval := lib _mk_store_n: c _: a _: n _: idxsExt _: v.
 	[
@@ -13303,8 +13303,8 @@ Z3 class >> mk_str_le: c _: prefix _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	prefix ensureValidZ3AST.
-	s ensureValidZ3AST.
+	prefix ensureValidZ3ASTInContext: c.
+	s ensureValidZ3ASTInContext: c.
 	retval := lib _mk_str_le: c _: prefix _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13327,8 +13327,8 @@ Z3 class >> mk_str_lt: c _: prefix _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	prefix ensureValidZ3AST.
-	s ensureValidZ3AST.
+	prefix ensureValidZ3ASTInContext: c.
+	s ensureValidZ3ASTInContext: c.
 	retval := lib _mk_str_lt: c _: prefix _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13349,7 +13349,7 @@ Z3 class >> mk_str_to_int: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
 	retval := lib _mk_str_to_int: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13394,7 +13394,7 @@ Z3 class >> mk_string_from_code: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _mk_string_from_code: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13464,7 +13464,7 @@ Z3 class >> mk_string_to_code: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _mk_string_to_code: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13490,7 +13490,7 @@ Z3 class >> mk_sub: c _: num_args _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	args ensureValidZ3ASTArray.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _mk_sub: c _: num_args _: argsExt.
 	[
@@ -13539,7 +13539,7 @@ Z3 class >> mk_transitive_closure: c _: f [
 	| retval |
 
 	c ensureValidZ3Object.
-	f ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	f ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _mk_transitive_closure: c _: f.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -13560,7 +13560,7 @@ Z3 class >> mk_tree_order: c _: a _: id [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3ASTOfKind: SORT_AST.
+	a ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_tree_order: c _: a _: id.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -13614,7 +13614,7 @@ Z3 class >> mk_tuple_sort: c _: mk_tuple_name _: num_fields _: field_names _: fi
 	c ensureValidZ3Object.
 	mk_tuple_name ensureValidZ3Object.
 	field_names ensureValidZ3ObjectArray.
-	field_sorts ensureValidZ3ASTArrayOfKind: SORT_AST.
+	field_sorts ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
 	field_namesExt := self externalArrayFrom: field_names.
 	field_sortsExt := self externalArrayFrom: field_sorts.
 	mk_tuple_declExt := self externalArrayFrom: mk_tuple_decl.
@@ -13650,12 +13650,12 @@ Z3 class >> mk_type_variable: c _: s [
 	"
 	   \brief Create a type variable.
 
-	   Functions using type variables can be applied to instantiations that match the signature
+	   Functions using type variables can be applied to instantiations that match the signature 
 	   of the function. Assertions using type variables correspond to assertions over all possible
 	   instantiations.
 
 	   def_API('Z3_mk_type_variable', SORT, (_in(CONTEXT), _in(SYMBOL)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -13678,7 +13678,7 @@ Z3 class >> mk_u32string: c _: len _: chars [
 	   0 characters. The string is unescaped.
 
 	   def_API('Z3_mk_u32string', AST, (_in(CONTEXT), _in(UINT), _in_array(1, UINT)))
-
+	 
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -13710,7 +13710,7 @@ Z3 class >> mk_ubv_to_str: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3AST.
+	s ensureValidZ3ASTInContext: c.
 	retval := lib _mk_ubv_to_str: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13733,7 +13733,7 @@ Z3 class >> mk_unary_minus: c _: arg [
 	| retval |
 
 	c ensureValidZ3Object.
-	arg ensureValidZ3AST.
+	arg ensureValidZ3ASTInContext: c.
 	retval := lib _mk_unary_minus: c _: arg.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13782,7 +13782,7 @@ Z3 class >> mk_unsigned_int64: c _: v _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_unsigned_int64: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13808,7 +13808,7 @@ Z3 class >> mk_unsigned_int: c _: v _: ty [
 	| retval |
 
 	c ensureValidZ3Object.
-	ty ensureValidZ3ASTOfKind: SORT_AST.
+	ty ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _mk_unsigned_int: c _: v _: ty.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13831,8 +13831,8 @@ Z3 class >> mk_xor: c _: t1 _: t2 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
-	t2 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
+	t2 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_xor: c _: t1 _: t2.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13857,7 +13857,7 @@ Z3 class >> mk_zero_ext: c _: i _: t1 [
 	| retval |
 
 	c ensureValidZ3Object.
-	t1 ensureValidZ3AST.
+	t1 ensureValidZ3ASTInContext: c.
 	retval := lib _mk_zero_ext: c _: i _: t1.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -13918,7 +13918,7 @@ Z3 class >> model_eval: c _: m _: t _: model_completion _: v [
 
 	c ensureValidZ3Object.
 	m ensureValidZ3Object.
-	t ensureValidZ3AST.
+	t ensureValidZ3ASTInContext: c.
 	vExt := self externalArrayFrom: v.
 	retval := lib _model_eval: c _: m _: t _: model_completion _: vExt.
 	[
@@ -13951,7 +13951,7 @@ Z3 class >> model_extrapolate: c _: m _: fml [
 
 	c ensureValidZ3Object.
 	m ensureValidZ3Object.
-	fml ensureValidZ3AST.
+	fml ensureValidZ3ASTInContext: c.
 	retval := lib _model_extrapolate: c _: m _: fml.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -14003,7 +14003,7 @@ Z3 class >> model_get_const_interp: c _: m _: a [
 
 	c ensureValidZ3Object.
 	m ensureValidZ3Object.
-	a ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	a ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _model_get_const_interp: c _: m _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -14178,7 +14178,7 @@ Z3 class >> model_get_sort_universe: c _: m _: s [
 
 	c ensureValidZ3Object.
 	m ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _model_get_sort_universe: c _: m _: s.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -14200,7 +14200,7 @@ Z3 class >> model_has_interp: c _: m _: a [
 
 	c ensureValidZ3Object.
 	m ensureValidZ3Object.
-	a ensureValidZ3ASTOfKind: FUNC_DECL_AST.
+	a ensureValidZ3ASTInContext: c ofKind: FUNC_DECL_AST.
 	retval := lib _model_has_interp: c _: m _: a.
 	c errorCheck.
 	^ retval
@@ -15125,9 +15125,9 @@ Z3 class >> parse_smtlib2_file: c _: file_name _: num_sorts _: sort_names _: sor
 
 	c ensureValidZ3Object.
 	sort_names ensureValidZ3ObjectArray.
-	sorts ensureValidZ3ASTArrayOfKind: SORT_AST.
+	sorts ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
 	decl_names ensureValidZ3ObjectArray.
-	decls ensureValidZ3ASTArrayOfKind: FUNC_DECL_AST.
+	decls ensureValidZ3ASTArrayInContext: c ofKind: FUNC_DECL_AST.
 	sort_namesExt := self externalArrayFrom: sort_names.
 	sortsExt := self externalArrayFrom: sorts.
 	decl_namesExt := self externalArrayFrom: decl_names.
@@ -15163,9 +15163,9 @@ Z3 class >> parse_smtlib2_string: c _: str _: num_sorts _: sort_names _: sorts _
 
 	c ensureValidZ3Object.
 	sort_names ensureValidZ3ObjectArray.
-	sorts ensureValidZ3ASTArrayOfKind: SORT_AST.
+	sorts ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
 	decl_names ensureValidZ3ObjectArray.
-	decls ensureValidZ3ASTArrayOfKind: FUNC_DECL_AST.
+	decls ensureValidZ3ASTArrayInContext: c ofKind: FUNC_DECL_AST.
 	sort_namesExt := self externalArrayFrom: sort_names.
 	sortsExt := self externalArrayFrom: sorts.
 	decl_namesExt := self externalArrayFrom: decl_names.
@@ -15190,7 +15190,7 @@ Z3 class >> parser_context_add_decl: c _: pc _: f [
 	   \brief Add a function declaration.
 
 	   def_API('Z3_parser_context_add_decl', VOID, (_in(CONTEXT), _in(PARSER_CONTEXT), _in(FUNC_DECL)))
-
+	 
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15205,7 +15205,7 @@ Z3 class >> parser_context_add_sort: c _: pc _: s [
 	   \brief Add a sort declaration.
 
 	   def_API('Z3_parser_context_add_sort', VOID, (_in(CONTEXT), _in(PARSER_CONTEXT), _in(SORT)))
-
+	 
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15220,7 +15220,7 @@ Z3 class >> parser_context_dec_ref: c _: pc [
 	   \brief Decrement the reference counter of the given \c Z3_parser_context object.
 
 	   def_API('Z3_parser_context_dec_ref', VOID, (_in(CONTEXT), _in(PARSER_CONTEXT)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15233,9 +15233,9 @@ Z3 class >> parser_context_dec_ref: c _: pc [
 Z3 class >> parser_context_from_string: c _: pc _: s [
 	"
 	   \brief Parse a string of SMTLIB2 commands. Return assertions.
-
+	  
 	   def_API('Z3_parser_context_from_string', AST_VECTOR, (_in(CONTEXT), _in(PARSER_CONTEXT), _in(STRING)))
-
+	 
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15250,7 +15250,7 @@ Z3 class >> parser_context_inc_ref: c _: pc [
 	   \brief Increment the reference counter of the given \c Z3_parser_context object.
 
 	   def_API('Z3_parser_context_inc_ref', VOID, (_in(CONTEXT), _in(PARSER_CONTEXT)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15317,9 +15317,9 @@ Z3 class >> polynomial_subresultants: c _: p _: q _: x [
 	| retval |
 
 	c ensureValidZ3Object.
-	p ensureValidZ3AST.
-	q ensureValidZ3AST.
-	x ensureValidZ3AST.
+	p ensureValidZ3ASTInContext: c.
+	q ensureValidZ3ASTInContext: c.
+	x ensureValidZ3ASTInContext: c.
 	retval := lib _polynomial_subresultants: c _: p _: q _: x.
 	c errorCheck.
 	^ Z3ASTVector fromExternalAddress: retval inContext: c.
@@ -15558,8 +15558,8 @@ Z3 class >> qe_model_project: c _: m _: num_bounds _: bound _: body [
 
 	c ensureValidZ3Object.
 	m ensureValidZ3Object.
-	bound ensureValidZ3ASTArray.
-	body ensureValidZ3AST.
+	bound ensureValidZ3ASTArrayInContext: c.
+	body ensureValidZ3ASTInContext: c.
 	boundExt := self externalArrayFrom: bound.
 	retval := lib _qe_model_project: c _: m _: num_bounds _: boundExt _: body.
 	[
@@ -15667,7 +15667,7 @@ Z3 class >> rcf_coefficient: c _: a _: i [
 	   \pre Z3_rcf_is_algebraic(ctx, a);
 
 	   def_API('Z3_rcf_coefficient', RCF_NUM, (_in(CONTEXT), _in(RCF_NUM), _in(UINT)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15727,7 +15727,7 @@ Z3 class >> rcf_extension_index: c _: a [
 	   \brief Return the index of a field extension.
 
 	  def_API('Z3_rcf_extension_index', UINT, (_in(CONTEXT), _in(RCF_NUM)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15758,7 +15758,7 @@ Z3 class >> rcf_get_numerator_denominator: c _: a _: n _: d [
 	   We have that \ccode{a = n/d}, moreover \c n and \c d are not represented using rational functions.
 
 	   def_API('Z3_rcf_get_numerator_denominator', VOID, (_in(CONTEXT), _in(RCF_NUM), _out(RCF_NUM), _out(RCF_NUM)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15790,7 +15790,7 @@ Z3 class >> rcf_infinitesimal_name: c _: a [
 	   \pre Z3_rcf_is_infinitesimal(ctx, a);
 
 	   def_API('Z3_rcf_infinitesimal_name', SYMBOL, (_in(CONTEXT), _in(RCF_NUM)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15807,7 +15807,7 @@ Z3 class >> rcf_interval: c _: a _: lower_is_inf _: lower_is_open _: lower _: up
 	   \pre Z3_rcf_is_algebraic(ctx, a);
 
 	   def_API('Z3_rcf_interval', INT, (_in(CONTEXT), _in(RCF_NUM), _out(INT), _out(INT), _out(RCF_NUM), _out(INT), _out(INT), _out(RCF_NUM)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15837,7 +15837,7 @@ Z3 class >> rcf_is_algebraic: c _: a [
 	   \brief Return \c true if \c a represents an algebraic number.
 
 	   def_API('Z3_rcf_is_algebraic', BOOL, (_in(CONTEXT), _in(RCF_NUM)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15852,7 +15852,7 @@ Z3 class >> rcf_is_infinitesimal: c _: a [
 	   \brief Return \c true if \c a represents an infinitesimal.
 
 	   def_API('Z3_rcf_is_infinitesimal', BOOL, (_in(CONTEXT), _in(RCF_NUM)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15867,7 +15867,7 @@ Z3 class >> rcf_is_rational: c _: a [
 	   \brief Return \c true if \c a represents a rational number.
 
 	   def_API('Z3_rcf_is_rational', BOOL, (_in(CONTEXT), _in(RCF_NUM)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -15882,7 +15882,7 @@ Z3 class >> rcf_is_transcendental: c _: a [
 	   \brief Return \c true if \c a represents a transcendental number.
 
 	   def_API('Z3_rcf_is_transcendental', BOOL, (_in(CONTEXT), _in(RCF_NUM)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16068,7 +16068,7 @@ Z3 class >> rcf_num_coefficients: c _: a [
 	   \pre Z3_rcf_is_algebraic(ctx, a);
 
 	   def_API('Z3_rcf_num_coefficients', UINT, (_in(CONTEXT), _in(RCF_NUM)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16085,7 +16085,7 @@ Z3 class >> rcf_num_sign_condition_coefficients: c _: a _: i [
 	   \pre Z3_rcf_is_algebraic(ctx, a);
 
 	   def_API('Z3_rcf_num_sign_condition_coefficients', UINT, (_in(CONTEXT), _in(RCF_NUM), _in(UINT)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16102,7 +16102,7 @@ Z3 class >> rcf_num_sign_conditions: c _: a [
 	   \pre Z3_rcf_is_algebraic(ctx, a);
 
 	   def_API('Z3_rcf_num_sign_conditions', UINT, (_in(CONTEXT), _in(RCF_NUM)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16164,7 +16164,7 @@ Z3 class >> rcf_sign_condition_coefficient: c _: a _: i _: j [
 	   \pre Z3_rcf_is_algebraic(ctx, a);
 
 	   def_API('Z3_rcf_sign_condition_coefficient', RCF_NUM, (_in(CONTEXT), _in(RCF_NUM), _in(UINT), _in(UINT)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16181,7 +16181,7 @@ Z3 class >> rcf_sign_condition_sign: c _: a _: i [
 	   \pre Z3_rcf_is_algebraic(ctx, a);
 
 	   def_API('Z3_rcf_sign_condition_sign', INT, (_in(CONTEXT), _in(RCF_NUM), _in(UINT)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16213,7 +16213,7 @@ Z3 class >> rcf_transcendental_name: c _: a [
 	   \pre Z3_rcf_is_transcendtal(ctx, a);
 
 	   def_API('Z3_rcf_transcendental_name', SYMBOL, (_in(CONTEXT), _in(RCF_NUM)))
-
+   
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16342,7 +16342,7 @@ Z3 class >> simplifier_and_then: c _: t1 _: t2 [
 	   to every subgoal produced by \c t1.
 
 	   def_API('Z3_simplifier_and_then', SIMPLIFIER, (_in(CONTEXT), _in(SIMPLIFIER), _in(SIMPLIFIER)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16357,7 +16357,7 @@ Z3 class >> simplifier_dec_ref: c _: g [
 	   \brief Decrement the reference counter of the given simplifier.
 
 	   def_API('Z3_simplifier_dec_ref', VOID, (_in(CONTEXT), _in(SIMPLIFIER)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16372,7 +16372,7 @@ Z3 class >> simplifier_get_descr: c _: name [
 	   \brief Return a string containing a description of the simplifier with the given name.
 
 	   def_API('Z3_simplifier_get_descr', STRING, (_in(CONTEXT), _in(STRING)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16392,7 +16392,7 @@ Z3 class >> simplifier_get_help: c _: t [
 	   \brief Return a string containing a description of parameters accepted by the given simplifier.
 
 	   def_API('Z3_simplifier_get_help', STRING, (_in(CONTEXT), _in(SIMPLIFIER)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16407,7 +16407,7 @@ Z3 class >> simplifier_get_param_descrs: c _: t [
 	   \brief Return the parameter description set for the given simplifier object.
 
 	   def_API('Z3_simplifier_get_param_descrs', PARAM_DESCRS, (_in(CONTEXT), _in(SIMPLIFIER)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16422,7 +16422,7 @@ Z3 class >> simplifier_inc_ref: c _: t [
 	   \brief Increment the reference counter of the given simplifier.
 
 	   def_API('Z3_simplifier_inc_ref', VOID, (_in(CONTEXT), _in(SIMPLIFIER)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16437,7 +16437,7 @@ Z3 class >> simplifier_using_params: c _: t _: p [
 	   \brief Return a simplifier that applies \c t using the given set of parameters.
 
 	   def_API('Z3_simplifier_using_params', SIMPLIFIER, (_in(CONTEXT), _in(SIMPLIFIER), _in(PARAMS)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16466,7 +16466,7 @@ Z3 class >> simplify: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _simplify: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -16495,7 +16495,7 @@ Z3 class >> simplify_ex: c _: a _: p [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	p ensureValidZ3Object.
 	retval := lib _simplify_ex: c _: a _: p.
 	c errorCheck.
@@ -16554,9 +16554,9 @@ Z3 class >> simplify_get_param_descrs: c [
 Z3 class >> solver_add_simplifier: c _: solver _: simplifier [
 	"
 	 \brief Attach simplifier to a solver. The solver will use the simplifier for incremental pre-processing.
-
+	
 		def_API('Z3_solver_add_simplifier', SOLVER, (_in(CONTEXT), _in(SOLVER), _in(SIMPLIFIER)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16585,7 +16585,7 @@ Z3 class >> solver_assert: c _: s _: a [
 
 	c ensureValidZ3Object.
 	s ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _solver_assert: c _: s _: a.
 	c errorCheck.
 	^ retval
@@ -16619,8 +16619,8 @@ Z3 class >> solver_assert_and_track: c _: s _: a _: p [
 
 	c ensureValidZ3Object.
 	s ensureValidZ3Object.
-	a ensureValidZ3AST.
-	p ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
+	p ensureValidZ3ASTInContext: c.
 	retval := lib _solver_assert_and_track: c _: s _: a _: p.
 	c errorCheck.
 	^ retval
@@ -16682,7 +16682,7 @@ Z3 class >> solver_check_assumptions: c _: s _: num_assumptions _: assumptions [
 
 	c ensureValidZ3Object.
 	s ensureValidZ3Object.
-	assumptions ensureValidZ3ASTArray.
+	assumptions ensureValidZ3ASTArrayInContext: c.
 	assumptionsExt := self externalArrayFrom: assumptions.
 	retval := lib _solver_check_assumptions: c _: s _: num_assumptions _: assumptionsExt.
 	[
@@ -16702,7 +16702,7 @@ Z3 class >> solver_congruence_next: c _: s _: a [
 	   Repeated calls on the siblings will result in returning to the original expression.
 
 	   def_API('Z3_solver_congruence_next', AST, (_in(CONTEXT), _in(SOLVER), _in(AST)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16710,7 +16710,7 @@ Z3 class >> solver_congruence_next: c _: s _: a [
 
 	c ensureValidZ3Object.
 	s ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _solver_congruence_next: c _: s _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -16727,7 +16727,7 @@ Z3 class >> solver_congruence_root: c _: s _: a [
 	   That is, the congruences are not consequences but they are true under the current state.
 
 	   def_API('Z3_solver_congruence_root', AST, (_in(CONTEXT), _in(SOLVER), _in(AST)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -16735,7 +16735,7 @@ Z3 class >> solver_congruence_root: c _: s _: a [
 
 	c ensureValidZ3Object.
 	s ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _solver_congruence_root: c _: s _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -17254,9 +17254,9 @@ Z3 class >> solver_next_split: c _: cb _: t _: idx _: phase [
 		The function returns false and ignores the given expression in case the expression is already assigned internally
 		(due to relevancy propagation, this assignments might not have been reported yet by the fixed callback).
 		In case the function is called in the decide callback, it overrides the currently selected variable and phase.
-
+	 
 	  def_API('Z3_solver_next_split', BOOL, (_in(CONTEXT), _in(SOLVER_CALLBACK), _in(AST), _in(UINT), _in(LBOOL)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -17294,7 +17294,7 @@ Z3 class >> solver_pop: c _: s _: n [
 { #category : #API }
 Z3 class >> solver_propagate_consequence: c _: cb _: num_fixed _: fixed _: num_eqs _: eq_lhs _: eq_rhs _: conseq [
 	"
-	   \brief propagate a consequence based on fixed values and equalities.
+	   \brief propagate a consequence based on fixed values and equalities.       
 	   A client may invoke it during the \c propagate_fixed, \c propagate_eq, \c propagate_diseq, and \c propagate_final callbacks.
 	   The callback adds a propagation consequence based on the fixed values passed \c ids and equalities \c eqs based on parameters \c lhs, \c rhs.
 	   
@@ -17311,7 +17311,7 @@ Z3 class >> solver_propagate_consequence: c _: cb _: num_fixed _: fixed _: num_e
 	   \param num_eqs - number of equalities used as premise to propagation
 	   \param lhs - left side of equalities
 	   \param rhs - right side of equalities
-	   \param consequence - consequence to propagate. It is typically an atomic formula, but it can be an arbitrary formula.
+	   \param consequence - consequence to propagate. It is typically an atomic formula, but it can be an arbitrary formula. 
 
 	   def_API('Z3_solver_propagate_consequence', BOOL, (_in(CONTEXT), _in(SOLVER_CALLBACK), _in(UINT), _in_array(2, AST), _in(UINT), _in_array(4, AST), _in_array(4, AST), _in(AST)))
 	
@@ -17326,11 +17326,11 @@ Z3 class >> solver_propagate_consequence: c _: cb _: num_fixed _: fixed _: num_e
 { #category : #API }
 Z3 class >> solver_propagate_created: c _: s _: created_eh [
 	"
-	   \brief register a callback when a new expression with a registered function is used by the solver
+	   \brief register a callback when a new expression with a registered function is used by the solver 
 	   The registered function appears at the top level and is created using \ref Z3_solver_propagate_declare.
 
 	   def_API('Z3_solver_propagate_created', VOID, (_in(CONTEXT), _in(SOLVER), _fnptr(Z3_created_eh)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -17346,7 +17346,7 @@ Z3 class >> solver_propagate_decide: c _: s _: decide_eh [
 	   The callback may change the arguments by providing other values by calling \ref Z3_solver_next_split
 
 	   def_API('Z3_solver_propagate_decide', VOID, (_in(CONTEXT), _in(SOLVER), _fnptr(Z3_decide_eh)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -17374,8 +17374,8 @@ Z3 class >> solver_propagate_declare: c _: name _: n _: domain _: range [
 
 	c ensureValidZ3Object.
 	name ensureValidZ3Object.
-	domain ensureValidZ3ASTArrayOfKind: SORT_AST.
-	range ensureValidZ3ASTOfKind: SORT_AST.
+	domain ensureValidZ3ASTArrayInContext: c ofKind: SORT_AST.
+	range ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	domainExt := self externalArrayFrom: domain.
 	retval := lib _solver_propagate_declare: c _: name _: n _: domainExt _: range.
 	[
@@ -17394,7 +17394,7 @@ Z3 class >> solver_propagate_diseq: c _: s _: eq_eh [
 	   \brief register a callback on expression dis-equalities.
 
 	   def_API('Z3_solver_propagate_diseq', VOID, (_in(CONTEXT), _in(SOLVER), _fnptr(Z3_eq_eh)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -17409,7 +17409,7 @@ Z3 class >> solver_propagate_eq: c _: s _: eq_eh [
 	   \brief register a callback on expression equalities.
 
 	   def_API('Z3_solver_propagate_eq', VOID, (_in(CONTEXT), _in(SOLVER), _fnptr(Z3_eq_eh)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -17427,14 +17427,14 @@ Z3 class >> solver_propagate_final: c _: s _: final_eh [
 
 	   The \c final_eh callback takes as argument the original user_context that was used
 	   when calling \c Z3_solver_propagate_init, and it takes a callback context with the
-	   opaque type \c Z3_solver_callback.
+	   opaque type \c Z3_solver_callback. 
 	   The callback context is passed as argument to invoke the \c Z3_solver_propagate_consequence function.
-	   The callback context can only be accessed (for propagation and for dynamically registering expressions) within a callback.
+	   The callback context can only be accessed (for propagation and for dynamically registering expressions) within a callback. 
 	   If the callback context gets used for propagation or conflicts, those propagations take effect and
 	   may trigger new decision variables to be set.
 
 	   def_API('Z3_solver_propagate_final', VOID, (_in(CONTEXT), _in(SOLVER), _fnptr(Z3_final_eh)))
-
+	 
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -17452,7 +17452,7 @@ Z3 class >> solver_propagate_fixed: c _: s _: fixed_eh [
 	   - Bit-vectors
 
 	   def_API('Z3_solver_propagate_fixed', VOID, (_in(CONTEXT), _in(SOLVER), _fnptr(Z3_fixed_eh)))
-
+	 
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -17471,10 +17471,10 @@ Z3 class >> solver_propagate_init: c _: s _: user_context _: push_eh _: pop_eh _
 	   \param user_context - a context used to maintain state for callbacks.
 	   \param push_eh - a callback invoked when scopes are pushed
 	   \param pop_eh - a callback invoked when scopes are popped
-	   \param fresh_eh - a solver may spawn new solvers internally. This callback is used to produce a fresh user_context to be associated with fresh solvers.
+	   \param fresh_eh - a solver may spawn new solvers internally. This callback is used to produce a fresh user_context to be associated with fresh solvers. 
 
 	   def_API('Z3_solver_propagate_init', VOID, (_in(CONTEXT), _in(SOLVER), _in(VOID_PTR), _fnptr(Z3_push_eh), _fnptr(Z3_pop_eh), _fnptr(Z3_fresh_eh)))
-
+	 
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -17498,7 +17498,7 @@ Z3 class >> solver_propagate_register: c _: s _: e [
 
 	c ensureValidZ3Object.
 	s ensureValidZ3Object.
-	e ensureValidZ3AST.
+	e ensureValidZ3ASTInContext: c.
 	retval := lib _solver_propagate_register: c _: s _: e.
 	c errorCheck.
 	^ retval
@@ -17554,17 +17554,17 @@ Z3 class >> solver_push: c _: s [
 Z3 class >> solver_register_on_clause: c _: s _: user_context _: on_clause_eh [
 	"
 	   \brief register a callback to that retrieves assumed, inferred and deleted clauses during search.
-
+	   
 	   \param c - context.
 	   \param s - solver object.
 	   \param user_context - a context used to maintain state for callbacks.
-	   \param on_clause_eh - a callback that is invoked by when a clause is
+	   \param on_clause_eh - a callback that is invoked by when a clause is 
 							   - asserted to the CDCL engine (corresponding to an input clause after pre-processing)
 							   - inferred by CDCL(T) using either a SAT or theory conflict/propagation
 							   - deleted by the CDCL(T) engine
 
 	   def_API('Z3_solver_register_on_clause', VOID, (_in(CONTEXT), _in(SOLVER), _in(VOID_PTR), _fnptr(Z3_on_clause_eh)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
@@ -17703,7 +17703,7 @@ Z3 class >> sort_to_ast: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _sort_to_ast: c _: s.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -17722,7 +17722,7 @@ Z3 class >> sort_to_string: c _: s [
 	| retval |
 
 	c ensureValidZ3Object.
-	s ensureValidZ3ASTOfKind: SORT_AST.
+	s ensureValidZ3ASTInContext: c ofKind: SORT_AST.
 	retval := lib _sort_to_string: c _: s.
 	c errorCheck.
 	^ retval
@@ -17890,9 +17890,9 @@ Z3 class >> substitute: c _: a _: num_exprs _: from _: to [
 	| retval fromExt toExt |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	from ensureValidZ3ASTArray.
-	to ensureValidZ3ASTArray.
+	a ensureValidZ3ASTInContext: c.
+	from ensureValidZ3ASTArrayInContext: c.
+	to ensureValidZ3ASTArrayInContext: c.
 	fromExt := self externalArrayFrom: from.
 	toExt := self externalArrayFrom: to.
 	retval := lib _substitute: c _: a _: num_exprs _: fromExt _: toExt.
@@ -17916,16 +17916,16 @@ Z3 class >> substitute_funs: c _: a _: num_funs _: from _: to [
 	   refers to the first argument of \c from, the free variable at index 1 corresponds to the second argument.
 
 	   def_API('Z3_substitute_funs', AST, (_in(CONTEXT), _in(AST), _in(UINT), _in_array(2, FUNC_DECL), _in_array(2, AST)))
-
+	
 
 		AUTOMATICALLY GENERATED BY apigen.py. DO NOT EDIT!
 	"
 	| retval fromExt toExt |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	from ensureValidZ3ASTArrayOfKind: FUNC_DECL_AST.
-	to ensureValidZ3ASTArray.
+	a ensureValidZ3ASTInContext: c.
+	from ensureValidZ3ASTArrayInContext: c ofKind: FUNC_DECL_AST.
+	to ensureValidZ3ASTArrayInContext: c.
 	fromExt := self externalArrayFrom: from.
 	toExt := self externalArrayFrom: to.
 	retval := lib _substitute_funs: c _: a _: num_funs _: fromExt _: toExt.
@@ -17945,7 +17945,7 @@ Z3 class >> substitute_vars: c _: a _: num_exprs _: to [
 	"
 	   \brief Substitute the variables in \c a with the expressions in \c to.
 	   For every \c i smaller than \c num_exprs, the variable with de-Bruijn index \c i is replaced with term \ccode{to[i]}.
-	   Note that a variable is created using the function \ref Z3_mk_bound.
+	   Note that a variable is created using the function \ref Z3_mk_bound. 
 
 	   def_API('Z3_substitute_vars', AST, (_in(CONTEXT), _in(AST), _in(UINT), _in_array(2, AST)))
 	
@@ -17955,8 +17955,8 @@ Z3 class >> substitute_vars: c _: a _: num_exprs _: to [
 	| retval toExt |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	to ensureValidZ3ASTArray.
+	a ensureValidZ3ASTInContext: c.
+	to ensureValidZ3ASTArrayInContext: c.
 	toExt := self externalArrayFrom: to.
 	retval := lib _substitute_vars: c _: a _: num_exprs _: toExt.
 	[
@@ -18301,7 +18301,7 @@ Z3 class >> to_app: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _to_app: c _: a.
 	c errorCheck.
 	^ Z3AST fromExternalAddress: retval inContext: c.
@@ -18324,7 +18324,7 @@ Z3 class >> to_func_decl: c _: a [
 	| retval |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: c.
 	retval := lib _to_func_decl: c _: a.
 	c errorCheck.
 	^ Z3FuncDecl fromExternalAddress: retval inContext: c.
@@ -18368,7 +18368,7 @@ Z3 class >> translate: source _: a _: target [
 	| retval |
 
 	source ensureValidZ3Object.
-	a ensureValidZ3AST.
+	a ensureValidZ3ASTInContext: source.
 	target ensureValidZ3Object.
 	retval := lib _translate: source _: a _: target.
 	source errorCheck.
@@ -18415,8 +18415,8 @@ Z3 class >> update_term: c _: a _: num_args _: args [
 	| retval argsExt |
 
 	c ensureValidZ3Object.
-	a ensureValidZ3AST.
-	args ensureValidZ3ASTArray.
+	a ensureValidZ3ASTInContext: c.
+	args ensureValidZ3ASTArrayInContext: c.
 	argsExt := self externalArrayFrom: args.
 	retval := lib _update_term: c _: a _: num_args _: argsExt.
 	[

--- a/src/Z3/Z3AST.class.st
+++ b/src/Z3/Z3AST.class.st
@@ -92,14 +92,15 @@ Z3AST >> ensureSet [
 ]
 
 { #category : #utilities }
-Z3AST >> ensureValidZ3AST [
-	self ensureValidZ3Object
+Z3AST >> ensureValidZ3ASTInContext: context [ 
+	self ensureValidZ3Object.
+	ctx == context ifFalse:[ self error:'Invalid Z3 AST (wrong context)' ].
 ]
 
 { #category : #utilities }
-Z3AST >> ensureValidZ3ASTOfKind: kind [
-	self ensureValidZ3Object.
-	self kind ~~ kind ifTrue:[ self error: 'Invalid Z3 AST (wrong kind)' ].
+Z3AST >> ensureValidZ3ASTInContext: context ofKind: kind [ 
+	self ensureValidZ3ASTInContext: context.
+	self kind ~~ kind ifTrue:[ self error:'Invalid Z3 AST (wrong kind)' ].
 ]
 
 { #category : #GT }


### PR DESCRIPTION
While working on ISA I had numerous crashes due to mixing ASTs from
different contexts.
    
This PR extends checks done in Z3 API calls to also check that AST
(and arrays of ASTs) belong to the same context as passed to the API
itself. At least, this way one gets smalltalk error early on rather
than annoying segfault in the middle of Z3 callout.
