### PR TITLE
Improve support for bitvectors in Refinements

### DIFF
--- a/src/Refinements/Expr.class.st
+++ b/src/Refinements/Expr.class.st
@@ -73,9 +73,10 @@ Expr >> , rhs [
 
 { #category : #'theory symbols' }
 Expr >> - rhs [
-	^ECst
-		e: (EMessageSend of: (MessageSend receiver: self selector: #- argument: rhs))
-		sort: Int sort
+	^EBin
+		bop: #-
+		left: self
+		right: rhs
 ]
 
 { #category : #'theory symbols' }

--- a/src/Refinements/Expr.class.st
+++ b/src/Refinements/Expr.class.st
@@ -59,6 +59,14 @@ Expr >> & anotherPred [
 ]
 
 { #category : #'theory symbols' }
+Expr >> * rhs [
+	^EBin
+		bop: #*
+		left: self
+		right: rhs
+]
+
+{ #category : #'theory symbols' }
 Expr >> + rhs [
 	^EBin
 		bop: #+
@@ -75,6 +83,14 @@ Expr >> , rhs [
 Expr >> - rhs [
 	^EBin
 		bop: #-
+		left: self
+		right: rhs
+]
+
+{ #category : #'theory symbols' }
+Expr >> / rhs [
+	^EBin
+		bop: #/
 		left: self
 		right: rhs
 ]
@@ -237,6 +253,14 @@ Expr >> bitRotateRight: shamt [
 		uop: #bitRotateRight:
 		arg: self
 		index: shamt
+]
+
+{ #category : #'theory symbols' }
+Expr >> bitShiftLeft: shamt [ 
+	^EBin
+		bop: #bitShiftLeft:
+		left: self
+		right: shamt
 ]
 
 { #category : #'theory symbols' }

--- a/src/Refinements/TheorySymbol.class.st
+++ b/src/Refinements/TheorySymbol.class.st
@@ -122,7 +122,9 @@ TheorySymbol class >> bvInterpSymbols [
 		"-- Arithmetic"
 		'bvadd'  interpBvBop: #+.
 		'bvsub'  interpBvBop: #-.
-		"TODO: bvsub, bvmul, bvudiv, bvurem, bvsdiv, bvsrem, bvsmod"
+		'bvmul'  interpBvBop: #*.
+		'bvsdiv' interpBvBop: #/.
+		"TODO: bvudiv, bvurem, bvsrem, bvsmod"
 
 		"-- Comparisons"
 		"TODO: bvcomp, bvult, bvule, bvugt, bvuge"

--- a/src/Refinements/TheorySymbol.class.st
+++ b/src/Refinements/TheorySymbol.class.st
@@ -125,9 +125,15 @@ TheorySymbol class >> bvInterpSymbols [
 		"TODO: bvsub, bvmul, bvudiv, bvurem, bvsdiv, bvsrem, bvsmod"
 
 		"-- Comparisons"
-		"TODO: bvcomp, bvult, bvule, bvugt, bvuge, bvslt, bvsle, bvsgt, bvsge"
+		"TODO: bvcomp, bvult, bvule, bvugt, bvuge"
+		'bvslt' interpBvCmp: #<.
+		'bvsle' interpBvCmp: #<=.
 		'bvsgt' interpBvCmp: #>.
 		'bvsge' interpBvCmp: #>=.
+		
+		'bveq' interpBvCmp: #=.
+		'bvne' interpBvCmp: #~=.
+		
 
 		'toBitVector' interpSym: [ :args :returnSort | args first toBitVector: returnSort length ] sort: self toBitVectorSort.
 		

--- a/src/Refinements/TheorySymbol.class.st
+++ b/src/Refinements/TheorySymbol.class.st
@@ -117,7 +117,8 @@ TheorySymbol class >> bvInterpSymbols [
 		'bvxnor' interpBvBop: #bitXnor:  .
 
 		"-- Shifts"
-		"TODO: bvshl, bvlshr, bvashr, rotate_left, rotate_right"
+		"TODO: bvlshr, bvashr, rotate_left, rotate_right"
+		'bvshl' interpBvBop: #bitShiftLeft:  .
 		
 		"-- Arithmetic"
 		'bvadd'  interpBvBop: #+.


### PR DESCRIPTION
This PR improves the support of bitvectors in Refinements by adding more theory symbols and updating `Expr`. More specifically, it adds stuff needed by Tinyrossa-Formal (in its currest state). 

I do not pretend I really understand what I'm doing here, especially re. my changes in `Expr` . Careful review is needed.