### PR TITLE
Fixes to `#spriteOn:indent:`

### DIFF
--- a/src/SpriteLang-Tests/ΛParserTest.class.st
+++ b/src/SpriteLang-Tests/ΛParserTest.class.st
@@ -57,6 +57,25 @@ let incf = (z) => {
 ]
 
 { #category : #tests }
+ΛParserTest >> testLetInLet [
+	| program |
+	program := ΛκParser new end parse: '
+let a = {
+  let b = 1;
+  b + 1
+};
+'.
+	self deny: program isPetitFailure.
+
+	self assert:  program quals isEmpty.
+	self assert:  program meas  isEmpty.
+	self assert:  program data  isEmpty.
+	self assert: (program expr  isLet).
+	self assert: (program expr decl expr isLet).
+
+]
+
+{ #category : #tests }
 ΛParserTest >> testMeasures [
 	| program |
 	program := ΛκParser new end parse: '

--- a/src/SpriteLang/ECon.class.st
+++ b/src/SpriteLang/ECon.class.st
@@ -82,6 +82,14 @@ ECon >> spriteOn: aStream indent: level [
 
 ]
 
+{ #category : #'as yet unclassified' }
+ECon >> spriteOn: stream indent: level asΛEAppWithArgs: args [
+	self assert: args size == 2.
+	args first spriteOn: stream indent: level.
+	stream space; nextPutAll: prim primOp class operator; space.
+	args second spriteOn: stream indent: level.		
+]
+
 { #category : #substitution }
 ECon >> subst: θ [
 	^self

--- a/src/SpriteLang/EVar.extension.st
+++ b/src/SpriteLang/EVar.extension.st
@@ -63,6 +63,15 @@ EVar >> spriteOn: stream indent: level [
 ]
 
 { #category : #'*SpriteLang' }
+EVar >> spriteOn: stream indent: level asΛEAppWithArgs: args [
+	stream nextPutAll: sym.
+	stream nextPut: $(.
+	args do: [ :arg | arg spriteOn: stream indent: level ]
+		separatedBy:[ stream nextPutAll: ', ' ].
+	stream nextPut: $).
+]
+
+{ #category : #'*SpriteLang' }
 EVar >> synthImm: Γ [
 "
 synthImm :: Env -> SrcImm -> CG RType

--- a/src/SpriteLang/SpriteDecl.class.st
+++ b/src/SpriteLang/SpriteDecl.class.st
@@ -118,7 +118,16 @@ SpriteDecl >> spriteOn: aStream indent: level [
 	self isRecursive ifTrue:[	aStream nextPutAll:'rec ' ].
 	aStream nextPutAll:bind id.
 	aStream nextPutAll:' = '.
-	body spriteOn: aStream indent: level.
+	body isLet ifTrue:[
+		aStream nextPut: ${; cr.
+		aStream next: level + 1 * 4 put: Character space.
+		body spriteOn: aStream indent: level + 1.
+		aStream cr.
+		aStream next: level * 4 put: Character space.
+		aStream nextPut: $}.
+	] ifFalse:[
+		body spriteOn: aStream indent: level.
+	].
 
 ]
 

--- a/src/SpriteLang/SpriteRDecl.class.st
+++ b/src/SpriteLang/SpriteRDecl.class.st
@@ -54,3 +54,8 @@ SpriteRDecl >> check: Γ rtype: t′ e′: e′ [
 SpriteRDecl >> inlineInto: e [
 	^ELet decl: self expr: e
 ]
+
+{ #category : #testing }
+SpriteRDecl >> isRecursive [
+	^ true
+]

--- a/src/SpriteLang/ΛEApp.class.st
+++ b/src/SpriteLang/ΛEApp.class.st
@@ -124,11 +124,8 @@ embedApp :: SrcExpr -> F.Expr
 		eapp := eapp expr.
 	].
 	func := eapp.
-
-	func spriteOn: stream indent: level.
-	stream nextPut: $(.
-	args do:[:arg | arg spriteOn: stream indent: level ] separatedBy:[stream nextPutAll:', '].
-	stream nextPut: $).
+	
+	func imm spriteOn: stream indent: level asΛEAppWithArgs: args.
 
 ]
 


### PR DESCRIPTION
This PR contains some fixes to Sprite printing introduces in PR #582