### PR TITLE
Sync annotation parsing with declaration parsing

### DIFF
--- a/src/SpriteLang/RefinementParser.class.st
+++ b/src/SpriteLang/RefinementParser.class.st
@@ -203,7 +203,7 @@ sigP :: String -> FP.Parser Sig
 here Sig is just type-alias for (F.Symbol, RType, Maybe Metric)
 "
 	^keyword asParser, #space asParser plus,
-	NNFParser lowerId trim,
+	self identifier trim,
 	$: asParser trim,
 	rtype trim,
 	self metricP optional


### PR DESCRIPTION
Identifier in annotations and in declaration must match. However they were parsed differently, while `#sigP:` used `NNFParser lowerId` (for annotation), `#plainDecl` used `self identifier` (for declaration).

This commit changes `#sigP:` to also use `self identifier` so both are in sync.