### PR TITLE
Fix nasty bug in `SpriteDecl >> toANF`

### DIFF
--- a/src/Metalanguage/SpriteDecl.extension.st
+++ b/src/Metalanguage/SpriteDecl.extension.st
@@ -18,7 +18,7 @@ SpriteDecl >> macroExpandEVar: x to: aΛExpr [
 
 { #category : #'*Metalanguage' }
 SpriteDecl >> toANF [
-	^SpriteDecl
+	^self class
 		bind: bind
 		expr: expr toANF
 ]


### PR DESCRIPTION
Due to a bug, `SpriteDecl >> toANF` created another `SpriteDecl`. even if receiver was (recursive) `SpriteRDecl`, silently turning `let rec`s into just `let`s on the way.

It should create new decl of the same class! This commit does so.