### PR TITLE
Show core program source after α-renaming when inspecting `Prog`

### DIFF
--- a/src/Metalanguage/Prog.class.st
+++ b/src/Metalanguage/Prog.class.st
@@ -26,5 +26,5 @@ Prog >> gtInspectorSpriteOfCoreIn: composite [
 
 	^composite text
 		title: 'Source (core program)';
-		display: [ self core spriteString ]
+		display: [ self uniq2 core spriteString ]
 ]


### PR DESCRIPTION
This commit changes GT inspector of core program to show program after α-renaming. This is more useful as this is the program MA is going to typecheck.