### PR TITLE
Add floating point support

### DIFF
--- a/src/Z3-FFI-Pharo/Z3ObjectType.class.st
+++ b/src/Z3-FFI-Pharo/Z3ObjectType.class.st
@@ -16,7 +16,7 @@ Z3ObjectType >> emitReturn: aBuilder resultTempVar: resultVar context: aContext 
 		returnTop	
 ]
 
-{ #category : 'emitting code' }
+{ #category : #'emitting code' }
 Z3ObjectType >> emitReturn: aBuilder resultTempVar: resultVar context: aContext inCallout: callout [
 	^ self emitReturn: aBuilder resultTempVar: resultVar context: aContext
 ]

--- a/src/Z3-Tests/FloatingPointTest.class.st
+++ b/src/Z3-Tests/FloatingPointTest.class.st
@@ -1,0 +1,64 @@
+Class {
+	#name : #FloatingPointTest,
+	#superclass : #TestCaseWithZ3Context,
+	#category : #'Z3-Tests'
+}
+
+{ #category : #tests }
+FloatingPointTest >> testArithmetic [
+
+	| a b aVal bVal |
+	aVal := 3.5.
+	bVal := -7.8.
+	a := aVal toFloatingPoint: 64.
+	b := bVal toFloatingPoint: 64.
+
+	self assert: a + bVal equals: aVal + bVal.
+	self assert: a - bVal equals: aVal - bVal.
+	self assert: a * b equals: aVal * bVal.
+	self assert: a / b equals: aVal / bVal.
+	self assert: (a rem: b) equals: (aVal rem: bVal).
+	self assert: a sqrt equals: aVal sqrt.
+	self assert: b abs equals: bVal abs.
+	self assert: b neg equals: bVal negated
+]
+
+{ #category : #tests }
+FloatingPointTest >> testInf [
+
+	| ctxt solver model a b |
+	
+	ctxt := Z3Context current.
+
+	solver := ctxt mkSolver.
+	a := 'a' toFloatingPoint: 64.
+	b := 'b' toFloatingPoint: 64.
+
+	solver assert: a isInfinite.
+	solver assert: a === b.
+
+	self assert: solver check.
+	
+	model := solver getModel constants.
+
+	self assert: (model at: 'b') isInfinite
+	
+]
+
+{ #category : #tests }
+FloatingPointTest >> testNan [
+
+	| ctxt solver a b |
+	
+	ctxt := Z3Context current.
+
+	solver := ctxt mkSolver.
+	a := 'a' toFloatingPoint: 64.
+	b := 'b' toFloatingPoint: 64.
+
+	solver assert: a isNaN.
+	solver assert: a === b.
+
+	self deny: solver check.
+	
+]

--- a/src/Z3/Float.extension.st
+++ b/src/Z3/Float.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #Float }
+
+{ #category : #'*Z3' }
+Float >> toFloatingPoint: length [
+
+	| bits ctxt sort |
+	length = 64 ifFalse: [ self error: 'bit length mismatch' ].
+
+	bits := ((self basicAt: 1) bitShift: 32) + (self basicAt: 2)
+		        toBitVector: length.
+
+	ctxt := Z3Context current.
+	sort := ctxt mkFloatingPointSort64.
+
+	^ (Z3 mk_fpa_to_fp_bv: ctxt _: bits _: sort) simplify
+]

--- a/src/Z3/FloatingPoint.class.st
+++ b/src/Z3/FloatingPoint.class.st
@@ -1,0 +1,261 @@
+Class {
+	#name : #FloatingPoint,
+	#superclass : #Z3Node,
+	#category : #'Z3-Core'
+}
+
+{ #category : #'instance creation' }
+FloatingPoint class >> sym: variableNameString length: xlen [
+
+	^ self var: variableNameString ofSort: Z3Sort float
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> * rhs [
+
+	^ self mul: rhs roundingMode: self defaultRoundingMode
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> + rhs [
+
+	^ self add: rhs roundingMode: self defaultRoundingMode
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> - rhs [
+
+	^ self sub: rhs roundingMode: self defaultRoundingMode
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> / rhs [
+
+	^ self div: rhs roundingMode: self defaultRoundingMode
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> < rhs [
+
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_fpa_lt: ctx _: self _: rhs.
+	].
+	^self retry: #< coercing: rhs
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> <= rhs [
+
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_fpa_leq: ctx _: self _: rhs.
+	].
+	^self retry: #<= coercing: rhs
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> > rhs [
+
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_fpa_gt: ctx _: self _: rhs.
+	].
+	^self retry: #> coercing: rhs
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> >= rhs [
+
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_fpa_geq: ctx _: self _: rhs.
+	].
+	^self retry: #>= coercing: rhs
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> abs [
+
+	^ Z3 mk_fpa_abs: ctx _: self
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> add: rhs roundingMode: roundingMode [
+
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_fpa_add: ctx _: roundingMode _: self _: rhs
+	].
+	^self retry: #add:roundingMode: with: roundingMode coercing: rhs
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> defaultRoundingMode [
+
+	^ Z3 mk_fpa_round_nearest_ties_to_away: ctx
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> div: rhs roundingMode: roundingMode [
+
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_fpa_div: ctx _: roundingMode _: self _: rhs
+	].
+	^self retry: #div:roundingMode: with: roundingMode coercing: rhs
+]
+
+{ #category : #operations }
+FloatingPoint >> eq: rhs [
+
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_fpa_eq: ctx _: self _: rhs.
+	].
+	^self retry: #eq: coercing: rhs
+]
+
+{ #category : #testing }
+FloatingPoint >> isInfinite [
+	
+	^ Z3 mk_fpa_is_infinite: ctx _: self
+]
+
+{ #category : #testing }
+FloatingPoint >> isNaN [
+	
+	^ Z3 mk_fpa_is_nan: ctx _: self
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> isNegative [
+
+	^ Z3 mk_fpa_is_negative: ctx _: self
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> isNormal [
+
+	^ Z3 mk_fpa_is_normal: ctx _: self
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> isPositive [
+
+	^ Z3 mk_fpa_is_positive: ctx _: self
+]
+
+{ #category : #testing }
+FloatingPoint >> isSubnormal [
+	
+	^ Z3 mk_fpa_is_subnormal: ctx _: self
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> isZero [
+
+	^ Z3 mk_fpa_is_zero: ctx _: self
+]
+
+{ #category : #accessing }
+FloatingPoint >> length [
+
+	^ self sort length
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> max: rhs [
+
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_fpa_max: ctx _: self _: rhs.
+	].
+	^self retry: #max: coercing: rhs
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> min: rhs [
+
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_fpa_min: ctx _: self _: rhs.
+	].
+	^self retry: #min: coercing: rhs
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> mul: rhs roundingMode: roundingMode [
+
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_fpa_mul: ctx _: roundingMode _: self _: rhs
+	].
+	^self retry: #mul:roundingMode: with: roundingMode coercing: rhs
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> neg [
+
+	^ Z3 mk_fpa_neg: ctx _: self
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> rem: rhs [
+
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_fpa_rem: ctx _: self _: rhs.
+	].
+	^self retry: #rem: coercing: rhs
+]
+
+{ #category : #adapting }
+FloatingPoint >> retry: selector coercing: rhs [
+	
+	^ self perform: selector with: (rhs toFloatingPoint: self length)
+]
+
+{ #category : #adapting }
+FloatingPoint >> retry: selector with: anotherVal coercing: rhs [
+	
+	^ self perform: selector with: (rhs toFloatingPoint: self length) with: anotherVal
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> sqrt [
+
+	^ self sqrt: self defaultRoundingMode
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> sqrt: roundingMode [
+
+	^ Z3 mk_fpa_sqrt: ctx _: roundingMode _: self
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> sub: rhs roundingMode: roundingMode [
+
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_fpa_sub: ctx _: roundingMode _: self _: rhs
+	].
+	^self retry: #sub:roundingMode: with: roundingMode coercing: rhs
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> toBitVector [
+
+	^ (Z3 mk_fpa_to_ieee_bv: ctx _: self) simplify
+]
+
+{ #category : #arithmetic }
+FloatingPoint >> toBitVector: length [
+
+	length = self length ifFalse: [ self error: 'bit length mismatch' ].
+
+	^ self toBitVector
+]
+
+{ #category : #accessing }
+FloatingPoint >> toFloatingPoint: length [
+
+	length = self length ifFalse: [ self error: 'bit length mismatch' ].
+
+	^ self
+]
+
+{ #category : #evaluating }
+FloatingPoint >> value [
+
+	^ [ Z3 get_numeral_double: ctx _: self ] onErrorDo: [ ^ self ]
+]

--- a/src/Z3/RoundingMode.class.st
+++ b/src/Z3/RoundingMode.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #RoundingMode,
+	#superclass : #Z3Node,
+	#category : #'Z3-Core'
+}

--- a/src/Z3/String.extension.st
+++ b/src/Z3/String.extension.st
@@ -37,6 +37,12 @@ String >> toDatatype: t [
 ]
 
 { #category : #'*Z3' }
+String >> toFloatingPoint: length [
+
+	^ FloatingPoint sym: self length: length
+]
+
+{ #category : #'*Z3' }
 String >> toInt [
 	^Int const: self
 ]

--- a/src/Z3/Z3Context.class.st
+++ b/src/Z3/Z3Context.class.st
@@ -242,6 +242,36 @@ Z3Context >> mkFalse [
 ]
 
 { #category : #'API wrappers' }
+Z3Context >> mkFloatingPointSort128 [
+
+	^Z3 mk_fpa_sort_128: self
+]
+
+{ #category : #'API wrappers' }
+Z3Context >> mkFloatingPointSort16 [
+
+	^Z3 mk_fpa_sort_16: self
+]
+
+{ #category : #'API wrappers' }
+Z3Context >> mkFloatingPointSort32 [
+
+	^Z3 mk_fpa_sort_32: self
+]
+
+{ #category : #'API wrappers' }
+Z3Context >> mkFloatingPointSort64 [
+
+	^Z3 mk_fpa_sort_64: self
+]
+
+{ #category : #'API wrappers' }
+Z3Context >> mkFloatingPointSortEbits: ebits sbits: sbits [
+
+	^Z3 mk_fpa_sort: self _: ebits _: sbits
+]
+
+{ #category : #'API wrappers' }
 Z3Context >> mkForAll: terms [
 	^Z3 mk_pattern: self _: terms size _: terms
 ]
@@ -314,6 +344,12 @@ Z3Context >> mkPattern: terms [
 { #category : #'API wrappers' }
 Z3Context >> mkRealSort [
 	^Z3 mk_real_sort: self
+]
+
+{ #category : #'API wrappers' }
+Z3Context >> mkRoundingModeSort [
+
+	^Z3 mk_fpa_rounding_mode_sort: self
 ]
 
 { #category : #'API wrappers' }

--- a/src/Z3/Z3FloatingPointSort.class.st
+++ b/src/Z3/Z3FloatingPointSort.class.st
@@ -1,0 +1,32 @@
+Class {
+	#name : #Z3FloatingPointSort,
+	#superclass : #Z3Sort,
+	#category : #'Z3-Core'
+}
+
+{ #category : #inhabitation }
+Z3FloatingPointSort >> anyOne [
+	
+	^ 0.0 toFloatingPoint: self length
+]
+
+{ #category : #'type theory' }
+Z3FloatingPointSort >> cast: value [
+	
+	^ value toFloatingPoint: self length
+]
+
+{ #category : #'type theory' }
+Z3FloatingPointSort >> length [
+	"Return length in bits"
+
+	^ (Z3 fpa_get_ebits: ctx _: self)
+	  + (Z3 fpa_get_sbits: ctx _: self)
+]
+
+{ #category : #'type theory' }
+Z3FloatingPointSort >> nodeClass [
+
+	^ FloatingPoint
+
+]

--- a/src/Z3/Z3Node.class.st
+++ b/src/Z3/Z3Node.class.st
@@ -357,7 +357,7 @@ Z3Node >> renameVariables: su [
 
 { #category : #adapting }
 Z3Node >> retry: selector coercing: rhs [
-	^self subclassResponsibility
+	^ self subclassResponsibility 
 ]
 
 { #category : #operations }

--- a/src/Z3/Z3RoundingModeSort.class.st
+++ b/src/Z3/Z3RoundingModeSort.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #Z3RoundingModeSort,
+	#superclass : #Z3Sort,
+	#category : #'Z3-Core'
+}

--- a/src/Z3/Z3Sort.class.st
+++ b/src/Z3/Z3Sort.class.st
@@ -28,9 +28,16 @@ Z3Sort class >> classForSortKind: sortKind [
 	sortKind = BV_SORT ifTrue: [ ^ Z3BitVectorSort ].
 	sortKind = ARRAY_SORT ifTrue: [ ^ Z3ArraySort ].
 	sortKind = DATATYPE_SORT ifTrue: [ ^ Z3DatatypeSort ].
+	sortKind = FLOATING_POINT_SORT ifTrue: [ ^ Z3FloatingPointSort ].
+	sortKind = ROUNDING_MODE_SORT ifTrue: [ ^ Z3RoundingModeSort ].
 
 	self error: '(Yet) unsupported sort kind: ' , sortKind printString             
 
+]
+
+{ #category : #'instance creation' }
+Z3Sort class >> float [
+	^ Z3Context current mkFloatingPointSort64
 ]
 
 { #category : #'instance creation' }
@@ -165,7 +172,7 @@ Z3Sort >> name [
 
 { #category : #'type theory' }
 Z3Sort >> nodeClass [
-	^ self subclassResponsibility
+	^ RoundingMode
 
 ]
 


### PR DESCRIPTION
Hi! As we talked, I added FP support
I think the one big issue with this PR is the handling of the "rounding mode" in arithmetic operations (`+ - * /`). I'm not sure if there's a nice way to parameterize it while keeping a nice, declarative API (i.e. not converting them into `#add:withRounding:` and so on). Is there some better way I'm missing?