### PR TITLE
Fix inverted logic in `HPredAnd>>pTrivial`

### DIFF
--- a/src/SpriteLang/HPredAnd.extension.st
+++ b/src/SpriteLang/HPredAnd.extension.st
@@ -2,7 +2,7 @@ Extension { #name : #HPredAnd }
 
 { #category : #'*SpriteLang' }
 HPredAnd >> pTrivial [
-	ps isEmpty ifTrue: [ ^false ].
+	ps isEmpty ifTrue: [ ^true ].
 	^super pTrivial
 ]
 


### PR DESCRIPTION
An empty conjunction should be deemed trivial, not the other way around.

Also cf. `Constraints.hs`