### PR TITLE
Fix bogus `Z3ArithmeticNode>>\\`

### DIFF
--- a/src/PreSmalltalks-Tests/ArithmeticTest.class.st
+++ b/src/PreSmalltalks-Tests/ArithmeticTest.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #ArithmeticTest,
+	#superclass : #TestCase,
+	#category : #'PreSmalltalks-Tests'
+}
+
+{ #category : #tests }
+ArithmeticTest >> testEuclideanMod [
+	self assert: (7  mod:  3) equals: 1.
+	self assert: (7  mod: -3) equals: 1.
+	self assert: (-7 mod:  3) equals: 2.
+	self assert: (-7 mod: -3) equals: 2.
+]

--- a/src/PreSmalltalks/Number.extension.st
+++ b/src/PreSmalltalks/Number.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #Number }
+
+{ #category : #'*PreSmalltalks' }
+Number >> mod: aNumber [
+	"Boute's Euclidean modulo (always nonnegative)"
+	| r |
+	r := self \\ aNumber.
+	^r >= 0
+		ifTrue: [ r ]
+		ifFalse: [ r + aNumber abs ]
+]

--- a/src/Refinements-Tests/LFxClassificationTest.class.st
+++ b/src/Refinements-Tests/LFxClassificationTest.class.st
@@ -14,7 +14,7 @@ LFxClassificationTest >> testIsEBin [
 	self assert: (x-y)  isEBin.
 	self assert: (x*y)  isEBin.
 	self assert: (x/y)  isEBin.
-	self assert: (x\\y) isEBin.
+	self assert: (x mod: y) isEBin. "Not \\!!!"
 	
 	self deny:   'x' toInt  isEBin.
 	self deny:   'A' toBool isEBin.

--- a/src/Z3-Tests/SimpleZ3Test.class.st
+++ b/src/Z3-Tests/SimpleZ3Test.class.st
@@ -398,6 +398,24 @@ SimpleZ3Test >> testLambda [
 ]
 
 { #category : #tests }
+SimpleZ3Test >> testMathMod [
+	"In Smalltalk, \\ is 'True Mathematical' signed modulo"
+	
+	self assert: 9 \\ 4                         equals:  1.
+	self assert: (9 toInt \\ 4 toInt) simplify  equals:  1.
+	
+	self assert: -9 \\ 4                        equals:  3.
+	self assert: (-9 toInt \\ 4 toInt) simplify equals:  3.
+	
+	self assert: 9 \\ -4                        equals: -3.
+	self assert: (9 toInt \\ -4 toInt) simplify equals: -3.
+	
+	self assert: -9 \\ -4                        equals: -1.
+	self assert: (-9 toInt \\ -4 toInt) simplify equals: -1.
+
+]
+
+{ #category : #tests }
 SimpleZ3Test >> testMixedTheories [
 	"A not-totally-trivial mix of Z, uninterpreted functions, and McCarty arrays,
 	 given in Bjorner's 'Programming Z3'.
@@ -416,6 +434,22 @@ SimpleZ3Test >> testMixedTheories [
 	solver := Z3Solver new.
 	solver proveValid: fml.
 	solver release
+]
+
+{ #category : #tests }
+SimpleZ3Test >> testMod [
+	"In Smalltalk, \\ is 'True Mathematical' signed modulo:"
+	self assert: 9 \\ -4 equals: -3.
+	"However, Z3_mk_mod() uses Boute's Euclidean definition:"
+	self deny: (9 toInt \\ -4 toInt) simplify equals: 1.
+	self assert: (9 toInt mod: -4 toInt) simplify equals: 1.
+
+	"So we wrap Z3_mk_mod in mod:."
+	self assert: (7 toInt mod: 3 toInt) simplify equals: 1.
+	self assert: (7 toInt mod: -3 toInt) simplify equals: 1.
+	self assert: (-7 toInt mod: 3 toInt) simplify equals: 2.
+	self assert: (-7 toInt mod: -3 toInt) simplify equals: 2.
+
 ]
 
 { #category : #tests }

--- a/src/Z3/Z3ArithmeticNode.class.st
+++ b/src/Z3/Z3ArithmeticNode.class.st
@@ -129,13 +129,16 @@ Z3ArithmeticNode >> >= rhs [
 ]
 
 { #category : #arithmetic }
-Z3ArithmeticNode >> \\ rhs [
-	(self isLikeMe: rhs) ifTrue:[
-		^ Z3 mk_mod: ctx _: self _: rhs.
-	].
-	^self retry: #'\\' coercing: rhs
-	
-
+Z3ArithmeticNode >> \\ divisor [
+	"True-Mathematical modulo (sign follows divisor)"
+	| mod |
+	(self isLikeMe: divisor) ifFalse: [ ^self retry: #\\ coercing: divisor ].
+	mod := self mod: divisor.
+	^divisor >= 0
+		ifThen: mod
+		else: (mod === 0
+					ifThen: mod
+					else: mod + divisor )
 ]
 
 { #category : #arithmetic }
@@ -158,6 +161,17 @@ Z3ArithmeticNode >> max: rhs [
 { #category : #arithmetic }
 Z3ArithmeticNode >> min: rhs [ 
 	^self <= rhs ifThen: self else: rhs
+]
+
+{ #category : #arithmetic }
+Z3ArithmeticNode >> mod: rhs [
+	"Boute's Euclidean modulo (always nonnegative)"
+	(self isLikeMe: rhs) ifTrue:[
+		^ Z3 mk_mod: ctx _: self _: rhs.
+	].
+	^self retry: #'mod:' coercing: rhs
+	
+
 ]
 
 { #category : #arithmetic }


### PR DESCRIPTION
In Smalltalk, `\\` means "true mathematical" (sign follows divisor) modulo, but `Z3_mk_mod()` is Boute's Euclidean (always nonnegative) modulo.