### PR TITLE
Improve support for BitVectors in Refinements

### DIFF
--- a/src/Refinements-Tests/FQBitVectorLengthTest.class.st
+++ b/src/Refinements-Tests/FQBitVectorLengthTest.class.st
@@ -5,6 +5,21 @@ Class {
 }
 
 { #category : #tests }
+FQBitVectorLengthTest >> test_32rotateIsNot33 [
+	self should: [self provePos: '
+bind 0 x : {v : (BitVec SizeXX) | v === (16r12345678 /// 32)}
+bind 1 y : {v : (BitVec Size33) | v === (x bitRotateLeft: 4)}
+bind 2 z : {v : (BitVec Size33) | v === (16r23456781 /// 33)}
+
+constraint:
+  env [0;1;2]
+  lhs {v : (BitVec Size33) | v === y }
+  rhs {v : (BitVec Size33) | v === z }
+  id 1 tag []
+'] raise: Incompatible
+]
+
+{ #category : #tests }
 FQBitVectorLengthTest >> test_4repeat2isNot9 [
 	self should: [self provePos: '
 bind 0 x : {v : (BitVec Size4) | v === (2r1000 /// 4)}
@@ -45,6 +60,36 @@ constraint:
   env [0;1;2]
   lhs {v : (BitVec Size8) | v === y }
   rhs {v : (BitVec Size8) | v === z }
+  id 1 tag []
+'
+]
+
+{ #category : #tests }
+FQBitVectorLengthTest >> test_inferRotateArgLength [
+	self provePos: '
+bind 0 x : {v : (BitVec SizeXX) | v === (16r12345678 /// 32)}
+bind 1 y : {v : (BitVec Size32) | v === (x bitRotateLeft: 4)}
+bind 2 z : {v : (BitVec Size32) | v === (16r23456781 /// 32)}
+
+constraint:
+  env [0;1;2]
+  lhs {v : (BitVec Size32) | v === y }
+  rhs {v : (BitVec Size32) | v === z }
+  id 1 tag []
+'
+]
+
+{ #category : #tests }
+FQBitVectorLengthTest >> test_inferRotateResultLength [
+	self provePos: '
+bind 0 x : {v : (BitVec Size32) | v === (16r12345678 /// 32)}
+bind 1 y : {v : (BitVec SizeXX) | v === (x bitRotateLeft: 4)}
+bind 2 z : {v : (BitVec Size32) | v === (16r23456781 /// 32)}
+
+constraint:
+  env [0;1;2]
+  lhs {v : (BitVec Size32) | v === y }
+  rhs {v : (BitVec Size32) | v === z }
   id 1 tag []
 '
 ]

--- a/src/Refinements/Expr.class.st
+++ b/src/Refinements/Expr.class.st
@@ -248,11 +248,19 @@ Expr >> bitOr: rhs [
 ]
 
 { #category : #'theory symbols' }
-Expr >> bitRotateRight: shamt [ 
+Expr >> bitRotateLeft: shamt [
+	^EIndexedUnary
+		uop: #bitRotateLeft:
+		arg: self
+		index: shamt asInteger "because Sprite turns the argument into a Z3 Int"
+]
+
+{ #category : #'theory symbols' }
+Expr >> bitRotateRight: shamt [
 	^EIndexedUnary
 		uop: #bitRotateRight:
 		arg: self
-		index: shamt
+		index: shamt asInteger "because Sprite turns the argument into a Z3 Int"
 ]
 
 { #category : #'theory symbols' }

--- a/src/Refinements/Expr.class.st
+++ b/src/Refinements/Expr.class.st
@@ -59,6 +59,14 @@ Expr >> & anotherPred [
 ]
 
 { #category : #'theory symbols' }
+Expr >> * rhs [
+	^EBin
+		bop: #*
+		left: self
+		right: rhs
+]
+
+{ #category : #'theory symbols' }
 Expr >> + rhs [
 	^EBin
 		bop: #+
@@ -73,9 +81,18 @@ Expr >> , rhs [
 
 { #category : #'theory symbols' }
 Expr >> - rhs [
-	^ECst
-		e: (EMessageSend of: (MessageSend receiver: self selector: #- argument: rhs))
-		sort: Int sort
+	^EBin
+		bop: #-
+		left: self
+		right: rhs
+]
+
+{ #category : #'theory symbols' }
+Expr >> / rhs [
+	^EBin
+		bop: #/
+		left: self
+		right: rhs
 ]
 
 { #category : #'theory symbols' }
@@ -236,6 +253,14 @@ Expr >> bitRotateRight: shamt [
 		uop: #bitRotateRight:
 		arg: self
 		index: shamt
+]
+
+{ #category : #'theory symbols' }
+Expr >> bitShiftLeft: shamt [ 
+	^EBin
+		bop: #bitShiftLeft:
+		left: self
+		right: shamt
 ]
 
 { #category : #'theory symbols' }

--- a/src/Refinements/String.extension.st
+++ b/src/Refinements/String.extension.st
@@ -56,6 +56,21 @@ String >> interpBvCmp: aSelector [
 ]
 
 { #category : #'*Refinements' }
+String >> interpBvRot: aSelector [
+	^self interpSymₜ: [ :shamt :x | x perform: aSelector with: shamt ] sort: TheorySymbol bvRotSort
+]
+
+{ #category : #'*Refinements' }
+String >> interpBvUop: aSelector [
+	^self
+		interpSym: [ :args :returnSort |
+			args size = 1 ifFalse: [ self error ].
+			args first sort = returnSort ifFalse: [ self error ].
+			args first perform: aSelector ]
+		sort: TheorySymbol bvUopSort
+]
+
+{ #category : #'*Refinements' }
 String >> interpSym: n sort: t [
 "
 interpSym :: Symbol -> Raw -> Sort -> (Symbol, TheorySymbol)

--- a/src/Refinements/TheorySymbol.class.st
+++ b/src/Refinements/TheorySymbol.class.st
@@ -106,7 +106,8 @@ TheorySymbol class >> bvInterpSymbols [
 		'sign_extend' interpSymₜ: [ :n :x | x signExtend:  n ] sort: self bvExtendSort.
 
 		"-- Unary Logic"
-		"TODO: bvnot, bvneg"
+		'bvnot'  interpBvUop: #bitInvert .
+		'bvneg'  interpBvUop: #negated   .
 		
 		"-- Binary Logic"
 		'bvand'  interpBvBop: #bitAnd:   .
@@ -117,22 +118,56 @@ TheorySymbol class >> bvInterpSymbols [
 		'bvxnor' interpBvBop: #bitXnor:  .
 
 		"-- Shifts"
-		"TODO: bvshl, bvlshr, bvashr, rotate_left, rotate_right"
+		'bvshl'  interpBvBop: #bitShiftLeft:            .
+		'bvlshr' interpBvBop: #bitShiftRight:           .
+		'bvashr' interpBvBop: #bitShiftRightArithmetic: .
+		"NB: shamt in rotate is a C int, not a BV, so these are indexed TLFs"
+		'rotate_left'  interpBvRot: #bitRotateLeft:  .
+		'rotate_right' interpBvRot: #bitRotateRight: .
 		
 		"-- Arithmetic"
-		'bvadd'  interpBvBop: #+.
-		'bvsub'  interpBvBop: #-.
-		"TODO: bvsub, bvmul, bvudiv, bvurem, bvsdiv, bvsrem, bvsmod"
+		'bvadd'  interpBvBop: #+       .
+		'bvsub'  interpBvBop: #-       .
+		'bvmul'  interpBvBop: #*       .
+		'bvsdiv' interpBvBop: #/       .
+		'bvsmod' interpBvBop: #\\      .
+		'bvudiv' interpBvBop: #bvudiv: .
+		'bvurem' interpBvBop: #bvurem: .
+		'bvsrem' interpBvBop: #bvsrem: .
 
 		"-- Comparisons"
-		"TODO: bvcomp, bvult, bvule, bvugt, bvuge, bvslt, bvsle, bvsgt, bvsge"
-		'bvsgt' interpBvCmp: #>.
-		'bvsge' interpBvCmp: #>=.
+		'bvslt' interpBvCmp: #<   .
+		'bvsle' interpBvCmp: #<=  .
+		'bvsgt' interpBvCmp: #>   .
+		'bvsge' interpBvCmp: #>=  .
+		'bvult' interpBvCmp: #<+  .
+		'bvule' interpBvCmp: #<=+ .
+		'bvugt' interpBvCmp: #>+  .
+		'bvuge' interpBvCmp: #>=+ .
+		'bveq'  interpBvCmp: #=   .
+		'bvne'  interpBvCmp: #~=  .
 
 		'toBitVector' interpSym: [ :args :returnSort | args first toBitVector: returnSort length ] sort: self toBitVectorSort.
 		
 		'bv' interpSymₜ: [ :sz :v  | v toBitVector: sz asInteger ] sort: self bvSort.
 	}
+]
+
+{ #category : #'known theories - function sorts' }
+TheorySymbol class >> bvRotSort [
+"
+-- Indexed identifier operation, purposely didn't place FAbs!
+--
+-- rot :: Int -> BitVec a -> BitVec a
+bvRotSort :: Sort
+bvRotSort  = FFunc FInt $ FFunc (bitVecSort 0) (bitVecSort 0)
+"
+	^TLFFunc
+		from: Int sort
+		to: (FFunc
+			from: (FApp s: (FTC new: FTyconBitVec new) t: (FTC new: FTyconUnknownBitVecSize new) )
+			to:   (FApp s: (FTC new: FTyconBitVec new) t: (FTC new: FTyconUnknownBitVecSize new) )
+		)
 ]
 
 { #category : #'known theories - function sorts' }
@@ -143,6 +178,20 @@ TheorySymbol class >> bvSort [
 			from: Int sort
 			to: (FApp s: (FTC new: FTyconBitVec new) t: (FTC new: FTyconUnknownBitVecSize new) )	
 		)
+]
+
+{ #category : #'known theories - function sorts' }
+TheorySymbol class >> bvUopSort [
+"
+-- uOp :: forall a. BitVec a -> BitVec a
+bvUopSort :: Sort
+bvUopSort = FAbs 0 $ FFunc (bitVecSort 0) (bitVecSort 0)
+"
+	^FAbs
+		int: 0
+		sort: (FFunc
+			from: 0 bitVecSort
+			to: 0 bitVecSort)
 ]
 
 { #category : #'known theories' }

--- a/src/SpriteLang-Tests/SpriteBitVectorTest.class.st
+++ b/src/SpriteLang-Tests/SpriteBitVectorTest.class.st
@@ -108,9 +108,161 @@ let main = (x) => {
 ]
 
 { #category : #tests }
+SpriteBitVectorTest >> test_Bvashr [
+	"
+		bvashr(10001000, 2) =
+		       11100010
+	"
+	self proveSafe: '
+⟦val main : BitVec(SizeXX)[v|v === (136///8)] => BitVec(SizeXX)[v|v === (226///8)]⟧
+let main = (x) => {
+  let shamt = toBitVector(2);
+  bvashr(x, shamt)
+};
+'
+]
+
+{ #category : #tests }
+SpriteBitVectorTest >> test_Bvlshr [
+	"
+		bvashr(10001000, 2) =
+		       00100010
+	"
+	self proveSafe: '
+⟦val main : BitVec(SizeXX)[v|v === (136///8)] => BitVec(SizeXX)[v|v === (34///8)]⟧
+let main = (x) => {
+  let shamt = toBitVector(2);
+  bvlshr(x, shamt)
+};
+'
+]
+
+{ #category : #tests }
+SpriteBitVectorTest >> test_Bvneg [
+	self proveSafe: '
+⟦val main : BitVec(SizeXX)[v|v === (1///8)] => BitVec(SizeXX)[v|v === (16rFF///8)]⟧
+let main = (x) => {
+  bvneg(x)
+};
+'
+]
+
+{ #category : #tests }
+SpriteBitVectorTest >> test_Bvnot [
+	self proveSafe: '
+⟦val main : BitVec(SizeXX)[v|v === (16r0F///8)] => BitVec(SizeXX)[v|v === (16rF0///8)]⟧
+let main = (x) => {
+  bvnot(x)
+};
+'
+]
+
+{ #category : #tests }
+SpriteBitVectorTest >> test_Bvsmod_1 [
+	"
+	 Cf. example 1 in Number>>\\
+	 bvsmod(9, 4) = 1
+	"
+	self proveSafe: '
+⟦val main : BitVec(SizeXX)[v|v === (9///8)] => BitVec(SizeXX)[v|v === (4///8)] => BitVec(SizeXX)[v|v === (1///8)]⟧
+let main = (x, y) => {
+  bvsmod(x, y)
+};
+'
+]
+
+{ #category : #tests }
+SpriteBitVectorTest >> test_Bvsmod_2 [
+	"
+	 Cf. example 2 in Number>>\\
+	 bvsmod(-9, 4) = 3
+	"
+	self proveSafe: '
+⟦val main : BitVec(SizeXX)[v|v === (-9///8)] => BitVec(SizeXX)[v|v === (4///8)] => BitVec(SizeXX)[v|v === (3///8)]⟧
+let main = (x, y) => {
+  bvsmod(x, y)
+};
+'
+]
+
+{ #category : #tests }
+SpriteBitVectorTest >> test_Bvsmod_3 [
+	"
+	 Cf. example 3 in Number>>\\
+	 bvsmod(9, -4) = 3
+	"
+	self proveSafe: '
+⟦val main : BitVec(SizeXX)[v|v === (9///8)] => BitVec(SizeXX)[v|v === (-4///8)] => BitVec(SizeXX)[v|v === (-3///8)]⟧
+let main = (x, y) => {
+  bvsmod(x, y)
+};
+'
+]
+
+{ #category : #tests }
 SpriteBitVectorTest >> test_Create [
 	self proveSafe: '
 ⟦val int8 : BitVec(Size8)[v|v === (127///8)]⟧
 let int8 = toBitVector(127);
+'
+]
+
+{ #category : #tests }
+SpriteBitVectorTest >> test_RotateLeft [
+	"
+		16r12345678 bitRotateLeft: 4  ->
+		16r23456781
+	"
+	self proveSafe: '
+⟦val main : BitVec(Size32)[v|v === (16r12345678///32)] => BitVec(Size32)[v|v === (16r23456781///32)]⟧
+let main = (x) => {
+  rotate_left(4, x)
+};
+'
+]
+
+{ #category : #tests }
+SpriteBitVectorTest >> test_RotateRight [
+	"
+		16r12345678 bitRotateLeft: 4  ->
+		16r812345678
+	"
+	self proveSafe: '
+⟦val main : BitVec(Size32)[v|v === (16r12345678///32)] => BitVec(Size32)[v|v === (16r81234567///32)]⟧
+let main = (x) => {
+  rotate_right(4, x)
+};
+'
+]
+
+{ #category : #tests }
+SpriteBitVectorTest >> test_ShiftLeft_01 [
+	"
+		00000001 bitShiftLeft: 2  ->
+		00000100
+	"
+	self proveSafe: '
+⟦val main : BitVec(Size8) => BitVec(Size8)[v|v === (4///8)]⟧
+let main = (x) => {
+  let one   = toBitVector(1);
+  let shamt = toBitVector(2);
+  bvshl(one, shamt)
+};
+'
+]
+
+{ #category : #tests }
+SpriteBitVectorTest >> test_ShiftLeft_02 [
+	"Z3 bvshl does not extend: whatever hangs and falls, is lost.
+		00000001 bitShiftLeft: 10  ->
+		00000000
+	"
+	self proveSafe: '
+⟦val main : BitVec(Size8) => BitVec(Size8)[v|v === (0///8)]⟧
+let main = (x) => {
+  let one   = toBitVector(1);
+  let shamt = toBitVector(10);
+  bvshl(one, shamt)
+};
 '
 ]

--- a/src/SpriteLang-Tests/SpriteUnknownLengthBitVectorTest.class.st
+++ b/src/SpriteLang-Tests/SpriteUnknownLengthBitVectorTest.class.st
@@ -63,11 +63,26 @@ let main = (x) => {
 ]
 
 { #category : #tests }
-SpriteUnknownLengthBitVectorTest >> test_SignExtend [
+SpriteUnknownLengthBitVectorTest >> test_SignExtend_01 [
 	self proveSafe: '
 ⟦val main : BitVec(Size8)[v|v === (16rAB///8)] => BitVec(Size9)[v|v === (16r1AB///9)]⟧
 let main = (x) => {
   sign_extend(1, x)
+};
+'
+]
+
+{ #category : #tests }
+SpriteUnknownLengthBitVectorTest >> test_SignExtend_02 [
+	self proveSafe: '
+⟦val addOneBit : BitVec(SizeXX)[?] => BitVec(SizeXX)[v|v === (16r1AB///9)]⟧
+let addOneBit = (x) => {
+  sign_extend(1, x)
+};
+
+⟦val main : BitVec(Size8)[v|v === (16rAB///8)] => BitVec(Size9)[v|v === (16r1AB///9)]⟧
+let main = (x) => {
+  addOneBit(x)
 };
 '
 ]

--- a/src/SpriteLang-Tests/SpriteUnknownLengthBitVectorTest.class.st
+++ b/src/SpriteLang-Tests/SpriteUnknownLengthBitVectorTest.class.st
@@ -61,3 +61,23 @@ let main = (x) => {
 };
 '
 ]
+
+{ #category : #tests }
+SpriteUnknownLengthBitVectorTest >> test_SignExtend [
+	self proveSafe: '
+⟦val main : BitVec(Size8)[v|v === (16rAB///8)] => BitVec(Size9)[v|v === (16r1AB///9)]⟧
+let main = (x) => {
+  sign_extend(1, x)
+};
+'
+]
+
+{ #category : #tests }
+SpriteUnknownLengthBitVectorTest >> test_ZeroExtend [
+	self proveSafe: '
+⟦val main : BitVec(Size8)[v|v === (16rAB///8)] => BitVec(Size9)[v|v === (16rAB///9)]⟧
+let main = (x) => {
+  zero_extend(1, x)
+};
+'
+]

--- a/src/Z3-Tests/SimpleBitVectorTest.class.st
+++ b/src/Z3-Tests/SimpleBitVectorTest.class.st
@@ -29,6 +29,51 @@ SimpleBitVectorTest >> testAlreadyBitvector [
 ]
 
 { #category : #tests }
+SimpleBitVectorTest >> testBvneg [
+	"Exhaustively check, by naïvely going through all 8-bit BVs,
+	 that Smalltalk's idea of bvneg (two's complement unary minus)
+	 coincides with Z3's.
+	"
+	0 to: 255 do: [ :i |
+		| posBV negBV |
+		posBV := i /// 8.
+		negBV := i negated /// 8.
+		self
+			assert: posBV negated simplify
+			equals: negBV
+	]
+
+
+]
+
+{ #category : #tests }
+SimpleBitVectorTest >> testBvnegProve [
+	| length i posBV negBV |
+	length := 6.
+	i := 'i' toInt.   "i∈ℤ"
+	posBV := i toBitVector: length.
+	negBV := i negated toBitVector: length.
+	self assert: (posBV negated === negBV) isValid
+]
+
+{ #category : #tests }
+SimpleBitVectorTest >> testBvnot [
+	"Exhaustively check, by naïvely going through all 8-bit BVs, that
+	 Smalltalk's idea of bvnot (bitwise negation) coincides with Z3's.
+	"
+	0 to: 255 do: [ :i |
+		| bv negatedBv |
+		bv := i /// 8.
+		negatedBv := i bitInvert /// 8.
+		self
+			assert: bv bitInvert simplify
+			equals: negatedBv
+	]
+
+
+]
+
+{ #category : #tests }
 SimpleBitVectorTest >> testConcatenation [
 	| a b ab |
 	a := 16rA toBitVector: 4.


### PR DESCRIPTION
Implement missing BV theory symbols (shifts, rotates, compares etc).
Also, implement missing Smalltalk selectors in `Expr` 

This PR extends, subsumes and replaces #587 .