### PR TITLE
Add `Expr >> #==>`

### DIFF
--- a/src/Refinements/Expr.class.st
+++ b/src/Refinements/Expr.class.st
@@ -129,6 +129,13 @@ Expr >> === rhs [
 ]
 
 { #category : #'theory symbols' }
+Expr >> ==> rhs [
+	^ECst
+		e: (PAtom brel: #==> x: self y: rhs)
+		sort: Bool sort
+]
+
+{ #category : #'theory symbols' }
 Expr >> > rhs [
 	^ECst
 		e: (PAtom brel: #> x: self y: rhs)


### PR DESCRIPTION
To play with this, consider BoolGaloisConnectionTest>>testGalois. The `b1 ==> b2` in leqB works because the DummyArg «b1» catches the DNU and creates a FormalSendResult (a pure term). This is the only test in MA that exercises the PureFormula machinery of CardanoTartaglia, and I would prefer to avoid having an exceptional case like this (let alone when we potentially want to get rid of (or fully redo) PureFormula and friends).